### PR TITLE
feat: baker pipeline — all 4 sources, integration tested

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -292,6 +292,48 @@ class MatVisCi:
             .stdout()
         )
 
+    # ── bake pipeline ─────────────────────────────────────────────
+
+    @function
+    async def bake_source(
+        self,
+        src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
+        source: Annotated[str, Doc("Source name")] = "ambientcg",
+        tier: Annotated[str, Doc("Resolution tier")] = "1k",
+        release_tag: Annotated[str, Doc("Release tag for rowmap")] = "v0000.00.0",
+    ) -> dagger.Directory:
+        """Run full baker pipeline for one source+tier. Returns directory with artifacts.
+
+        Output directory contains:
+        - mat-vis-<source>-<tier>.parquet
+        - <source>-<tier>-rowmap.json
+        - <source>.json (index)
+        """
+        context = src or dag.host().directory(".")
+        pip_cache = dag.cache_volume("pip-cache")
+
+        ctr = (
+            dag.container()
+            .from_("python:3.12-slim")
+            .with_mounted_cache("/root/.cache/pip", pip_cache)
+            .with_mounted_directory("/app", context)
+            .with_workdir("/app")
+            .with_exec(["pip", "install", "--quiet", "-e", ".[baker]"])
+            .with_exec(
+                [
+                    "mat-vis-baker",
+                    "all",
+                    source,
+                    tier,
+                    "/tmp/out",
+                    "--release-tag",
+                    release_tag,
+                ]
+            )
+        )
+
+        return ctr.directory("/tmp/out")
+
     # ── source probes ─────────────────────────────────────────────
 
     @function

--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -92,6 +92,50 @@ if ok < len(SOURCES):
     sys.exit(1)
 '''
 
+VERIFY_SCRIPT = '''\
+"""Verify integration test output: parquet + rowmap + range-read."""
+
+import json
+import sys
+from pathlib import Path
+
+out_dir = Path(sys.argv[1])
+
+# Check files exist
+pq_files = list(out_dir.glob("*.parquet"))
+assert pq_files, f"No parquet files in {out_dir}"
+pq_path = pq_files[0]
+
+rowmap_files = list(out_dir.glob("*-rowmap.json"))
+assert rowmap_files, f"No rowmap files in {out_dir}"
+
+index_files = list(out_dir.glob("*.json"))
+assert any("rowmap" not in f.name for f in index_files), "No index JSON"
+
+# Load rowmap and verify range reads
+rowmap = json.loads(rowmap_files[0].read_text())
+file_bytes = pq_path.read_bytes()
+
+materials = rowmap["materials"]
+assert len(materials) > 0, "Rowmap has no materials"
+
+verified = 0
+for mid, channels in materials.items():
+    for ch, rng in channels.items():
+        offset = rng["offset"]
+        length = rng["length"]
+        chunk = file_bytes[offset : offset + length]
+        assert chunk[:4] == b"\\x89PNG", f"{mid}/{ch}: not PNG at offset {offset}"
+        assert len(chunk) == length, f"{mid}/{ch}: length mismatch"
+        verified += 1
+
+print(f"  OK parquet: {pq_path.name} ({len(file_bytes)} bytes)")
+print(f"  OK rowmap: {len(materials)} materials")
+print(f"  OK range-read: {verified} channels verified (all PNG)")
+print(f"  OK index: {len(index_files)} JSON files")
+print(f"\\nintegration test passed")
+'''
+
 
 @object_type
 class MatVisCi:
@@ -193,6 +237,40 @@ class MatVisCi:
             f"=== test ===\n{test_out}\n"
             f"=== smoke ===\n{smoke_out}\n"
             f"=== probe ===\n{probe_out}"
+        )
+
+    # ── integration test ──────────────────────────────────────────
+
+    @function
+    async def integration_test(
+        self,
+        src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
+    ) -> str:
+        """End-to-end: fetch 2 ambientcg materials → bake → pack → rowmap → range-read verify."""
+        context = src or dag.host().directory(".")
+        ctr = self.build(context)
+        return await (
+            ctr.with_mounted_directory("/app", context)
+            .with_workdir("/app")
+            .with_exec(["pip", "install", "--quiet", "-e", ".[baker]"])
+            .with_exec(
+                [
+                    "mat-vis-baker",
+                    "all",
+                    "ambientcg",
+                    "1k",
+                    "/tmp/integration",
+                    "--limit",
+                    "2",
+                ]
+            )
+            .with_new_file(
+                "/tmp/verify.py",
+                contents=VERIFY_SCRIPT,
+                permissions=0o755,
+            )
+            .with_exec(["python", "/tmp/verify.py", "/tmp/integration"])
+            .stdout()
         )
 
     # ── source probes ─────────────────────────────────────────────

--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -246,11 +246,17 @@ class MatVisCi:
         self,
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
     ) -> str:
-        """End-to-end: fetch 2 ambientcg materials → bake → pack → rowmap → range-read verify."""
+        """End-to-end: fetch 2 ambientcg materials → bake → pack → rowmap → range-read verify.
+
+        Runs native (no platform override) — tests pipeline logic, not the amd64 image.
+        """
         context = src or dag.host().directory(".")
-        ctr = self.build(context)
+        pip_cache = dag.cache_volume("pip-cache")
         return await (
-            ctr.with_mounted_directory("/app", context)
+            dag.container()
+            .from_("python:3.12-slim")
+            .with_mounted_cache("/root/.cache/pip", pip_cache)
+            .with_mounted_directory("/app", context)
             .with_workdir("/app")
             .with_exec(["pip", "install", "--quiet", "-e", ".[baker]"])
             .with_exec(

--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -120,14 +120,27 @@ materials = rowmap["materials"]
 assert len(materials) > 0, "Rowmap has no materials"
 
 verified = 0
+errors = []
 for mid, channels in materials.items():
     for ch, rng in channels.items():
         offset = rng["offset"]
         length = rng["length"]
         chunk = file_bytes[offset : offset + length]
-        assert chunk[:4] == b"\\x89PNG", f"{mid}/{ch}: not PNG at offset {offset}"
-        assert len(chunk) == length, f"{mid}/{ch}: length mismatch"
+        if chunk[:4] != b"\\x89PNG":
+            errors.append(f"{mid}/{ch}: not PNG at offset {offset} (got {chunk[:4]!r})")
+            continue
+        if len(chunk) != length:
+            errors.append(
+                f"{mid}/{ch}: length mismatch at offset {offset}"
+                f" (expected {length}, got {len(chunk)}, file_size={len(file_bytes)})"
+            )
+            continue
         verified += 1
+
+if errors:
+    for e in errors:
+        print(f"  FAIL {e}")
+    sys.exit(1)
 
 print(f"  OK parquet: {pq_path.name} ({len(file_bytes)} bytes)")
 print(f"  OK rowmap: {len(materials)} materials")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,21 @@ jobs:
           module: .dagger
           args: test-all --src=.
 
+  integration:
+    name: Integration test (real upstream data)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dagger/dagger-for-github@v8.4.1
+        with:
+          verb: call
+          module: .dagger
+          args: integration-test --src=.
+
   push:
     name: Push baker image to GHCR
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: ci
+    needs: [ci, integration]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,4 @@
+# Typos configuration — domain-specific words that are correct.
+[default.extend-words]
+# PBR standard term for metallic property (0-1 scalar)
+metalness = "metalness"

--- a/src/mat_vis_baker/__main__.py
+++ b/src/mat_vis_baker/__main__.py
@@ -59,6 +59,14 @@ def cmd_all(args: argparse.Namespace) -> int:
     else:
         records = fetch(tier, output_dir / "textures", limit=args.limit)
 
+    if source == "physicallybased":
+        # Scalar only — no bake, no parquet, just index
+        log.info("=== index (scalar only) ===")
+        index_data = build_index(records, source)
+        write_index(index_data, output_dir / f"{source}.json")
+        log.info("=== done: %d records ===", len(records))
+        return 0
+
     log.info("=== bake ===")
     records = bake_batch(records, output_dir / "baked", tier)
 

--- a/src/mat_vis_baker/__main__.py
+++ b/src/mat_vis_baker/__main__.py
@@ -26,7 +26,18 @@ def _get_fetcher(source: str):
         from mat_vis_baker.sources.ambientcg import fetch
 
         return fetch
-    # TODO: polyhaven, gpuopen, physicallybased
+    if source == "polyhaven":
+        from mat_vis_baker.sources.polyhaven import fetch
+
+        return fetch
+    if source == "gpuopen":
+        from mat_vis_baker.sources.gpuopen import fetch
+
+        return fetch
+    if source == "physicallybased":
+        from mat_vis_baker.sources.physicallybased import fetch
+
+        return fetch
     raise NotImplementedError(f"Source {source!r} not yet implemented")
 
 
@@ -43,7 +54,10 @@ def cmd_all(args: argparse.Namespace) -> int:
 
     log.info("=== fetch %s %s ===", source, tier)
     fetch = _get_fetcher(source)
-    records = fetch(tier, output_dir / "textures", limit=args.limit)
+    if source == "physicallybased":
+        records = fetch()  # scalar only, no tier/output_dir
+    else:
+        records = fetch(tier, output_dir / "textures", limit=args.limit)
 
     log.info("=== bake ===")
     records = bake_batch(records, output_dir / "baked", tier)

--- a/src/mat_vis_baker/__main__.py
+++ b/src/mat_vis_baker/__main__.py
@@ -1,22 +1,114 @@
 """CLI entry point for the mat-vis baker.
 
 Usage:
-    mat-vis-baker fetch <source> <tier> <output_dir>
-    mat-vis-baker bake <mtlx_dir> <output_dir>
-    mat-vis-baker pack <baked_dir> <output.parquet>
-    mat-vis-baker index <source> <output.json>
-    mat-vis-baker all <source> <tier> <output_dir>
+    mat-vis-baker all <source> <tier> <output_dir> [--limit N] [--release-tag TAG]
+    mat-vis-baker fetch <source> <tier> <output_dir> [--limit N]
 
 Called directly in release.yml. Not a user-facing tool.
 """
+
+from __future__ import annotations
+
+import argparse
+import logging
 import sys
+from pathlib import Path
+
+from mat_vis_baker.common import TIER_TO_PX, VALID_TIERS
+
+log = logging.getLogger("mat-vis-baker")
+
+SOURCES = ["ambientcg", "polyhaven", "gpuopen", "physicallybased"]
 
 
-def main():
-    print("mat-vis-baker: not yet implemented", file=sys.stderr)
-    print(f"args: {sys.argv[1:]}", file=sys.stderr)
-    sys.exit(1)
+def _get_fetcher(source: str):
+    if source == "ambientcg":
+        from mat_vis_baker.sources.ambientcg import fetch
+
+        return fetch
+    # TODO: polyhaven, gpuopen, physicallybased
+    raise NotImplementedError(f"Source {source!r} not yet implemented")
+
+
+def cmd_all(args: argparse.Namespace) -> int:
+    """Full pipeline: fetch → bake → pack → index."""
+    from mat_vis_baker.bake import bake_batch
+    from mat_vis_baker.index_builder import build_index, write_index
+    from mat_vis_baker.parquet_writer import generate_rowmap, write_parquet, write_rowmap
+
+    source = args.source
+    tier = args.tier
+    output_dir = Path(args.output_dir)
+    resolution_px = TIER_TO_PX[tier]
+
+    log.info("=== fetch %s %s ===", source, tier)
+    fetch = _get_fetcher(source)
+    records = fetch(tier, output_dir / "textures", limit=args.limit)
+
+    log.info("=== bake ===")
+    records = bake_batch(records, output_dir / "baked", tier)
+
+    ok = [r for r in records if r.status == "ok"]
+    total = len(records)
+    if total > 0 and len(ok) / total < 0.95:
+        log.error(
+            "success rate %.1f%% < 95%% threshold (%d/%d)", len(ok) / total * 100, len(ok), total
+        )
+        return 1
+
+    log.info("=== pack ===")
+    pq_path = output_dir / f"mat-vis-{source}-{tier}.parquet"
+    write_parquet(records, source, tier, pq_path, resolution_px)
+
+    rowmap = generate_rowmap(pq_path, source, tier, args.release_tag, records)
+    write_rowmap(rowmap, output_dir / f"{source}-{tier}-rowmap.json")
+
+    log.info("=== index ===")
+    index_data = build_index(records, source)
+    write_index(index_data, output_dir / f"{source}.json")
+
+    log.info("=== done: %d ok, %d failed ===", len(ok), total - len(ok))
+    return 0
+
+
+def cmd_fetch(args: argparse.Namespace) -> int:
+    """Fetch only — download textures from upstream."""
+    fetch = _get_fetcher(args.source)
+    records = fetch(args.tier, Path(args.output_dir), limit=args.limit)
+    ok = sum(1 for r in records if r.status == "ok")
+    log.info("fetch done: %d ok, %d failed", ok, len(records) - ok)
+    return 0
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
+
+    parser = argparse.ArgumentParser(prog="mat-vis-baker")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_all = sub.add_parser("all", help="Full pipeline: fetch → bake → pack → index")
+    p_all.add_argument("source", choices=SOURCES)
+    p_all.add_argument("tier", choices=VALID_TIERS)
+    p_all.add_argument("output_dir")
+    p_all.add_argument("--limit", type=int, default=None)
+    p_all.add_argument("--release-tag", default="v0000.00.0")
+
+    p_fetch = sub.add_parser("fetch", help="Fetch textures from upstream")
+    p_fetch.add_argument("source", choices=SOURCES)
+    p_fetch.add_argument("tier", choices=VALID_TIERS)
+    p_fetch.add_argument("output_dir")
+    p_fetch.add_argument("--limit", type=int, default=None)
+
+    args = parser.parse_args()
+
+    if args.command == "all":
+        return cmd_all(args)
+    if args.command == "fetch":
+        return cmd_fetch(args)
+
+    parser.print_help()
+    return 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/src/mat_vis_baker/bake.py
+++ b/src/mat_vis_baker/bake.py
@@ -1,1 +1,115 @@
-"""Bake .mtlx → flat PNGs. Pure Python for flat graphs, materialx fallback for layered."""
+"""Bake engine — validate flat ONGs, bake layered mtlx via MaterialX.
+
+Most sources (ambientcg, polyhaven) ship pre-baked flat ONGs.
+The bake stage validates them. gpuopen layered graphs require
+MaterialX baking (optional dependency).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from PIL import Image
+
+from mat_vis_baker.common import TIER_TO_PX, MaterialRecord
+
+log = logging.getLogger("mat-vis-baker.bake")
+
+
+def _validate_png(path: Path, expected_px: int | None = None) -> bool:
+    """Open with Pillow, verify valid PNG. Optionally check dimensions."""
+    try:
+        with Image.open(path) as img:
+            if img.format != "PNG":
+                log.warning("%s: not PNG (got %s)", path, img.format)
+                return False
+            if expected_px and (img.width != expected_px or img.height != expected_px):
+                log.warning(
+                    "%s: expected %dx%d, got %dx%d",
+                    path,
+                    expected_px,
+                    expected_px,
+                    img.width,
+                    img.height,
+                )
+                # non-square or wrong size is a warning, not a failure
+            return True
+    except Exception:
+        log.exception("%s: invalid image", path)
+        return False
+
+
+def _bake_mtlx(mtlx_path: Path, output_dir: Path, resolution_px: int) -> dict[str, Path]:
+    """Bake a layered MaterialX graph to flat ONGs.
+
+    Requires the [materialx] optional dependency.
+    """
+    try:
+        import MaterialX as mx  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "MaterialX is required for baking layered gpuopen graphs. "
+            "Install with: pip install mat-vis[materialx]"
+        ) from exc
+
+    # TODO: implement full MaterialX TextureBaker flow
+    # For now, raise so gpuopen layered materials are skipped cleanly
+    raise NotImplementedError(f"MaterialX baking not yet implemented: {mtlx_path}")
+
+
+def bake_material(
+    record: MaterialRecord, output_dir: Path, tier: str | None = None
+) -> MaterialRecord:
+    """Validate or bake a single material's textures."""
+    if record.status == "failed":
+        return record
+
+    expected_px = TIER_TO_PX.get(tier) if tier else None
+
+    if record.needs_mtlx_bake:
+        mtlx_path = record.texture_paths.get("_mtlx")
+        if not mtlx_path:
+            log.error("%s: needs mtlx bake but no mtlx path", record.id)
+            record.status = "failed"
+            return record
+        try:
+            baked = _bake_mtlx(mtlx_path, output_dir / record.id, expected_px or 1024)
+            record.texture_paths.update(baked)
+            record.maps = sorted(baked.keys())
+        except (ImportError, NotImplementedError):
+            log.exception("%s: mtlx bake failed", record.id)
+            record.status = "failed"
+        return record
+
+    # flat ONGs — validate each
+    valid_maps: dict[str, Path] = {}
+    for channel, path in record.texture_paths.items():
+        if _validate_png(path, expected_px):
+            valid_maps[channel] = path
+        else:
+            log.warning("%s/%s: invalid PNG, dropping channel", record.id, channel)
+
+    if not valid_maps:
+        log.error("%s: no valid textures after validation", record.id)
+        record.status = "failed"
+    else:
+        record.texture_paths = valid_maps
+        record.maps = sorted(valid_maps.keys())
+
+    return record
+
+
+def bake_batch(
+    records: list[MaterialRecord], output_dir: Path, tier: str | None = None
+) -> list[MaterialRecord]:
+    """Validate/bake all records, catching per-material errors."""
+    for rec in records:
+        try:
+            bake_material(rec, output_dir, tier)
+        except Exception:
+            log.exception("%s: unexpected bake error", rec.id)
+            rec.status = "failed"
+    ok = sum(1 for r in records if r.status == "ok")
+    log.info("bake: %d ok, %d failed / %d total", ok, len(records) - ok, len(records))
+    return records

--- a/src/mat_vis_baker/common.py
+++ b/src/mat_vis_baker/common.py
@@ -1,0 +1,299 @@
+"""Shared types, constants, and utilities for the mat-vis baker."""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import requests
+
+log = logging.getLogger("mat-vis-baker")
+
+# ── canonical enums (source of truth: docs/specs/*.json) ────────
+
+CANONICAL_CATEGORIES = frozenset(
+    {
+        "metal",
+        "wood",
+        "stone",
+        "fabric",
+        "plastic",
+        "concrete",
+        "ceramic",
+        "glass",
+        "organic",
+        "other",
+    }
+)
+
+CANONICAL_CHANNELS = ["color", "normal", "roughness", "metalness", "ao", "displacement", "emission"]
+
+VALID_TIERS = ["1k", "2k", "4k", "8k"]
+
+TIER_TO_PX = {"1k": 1024, "2k": 2048, "4k": 4096, "8k": 8192}
+
+BAKER_VERSION = "0.1.0"
+
+USER_AGENT = f"mat-vis-baker/{BAKER_VERSION}"
+
+# ── category normalization ──────────────────────────────────────
+
+_CATEGORY_MAP: dict[str, str] = {}
+for _cat, _keywords in {
+    "metal": [
+        "metal",
+        "steel",
+        "iron",
+        "aluminum",
+        "aluminium",
+        "copper",
+        "brass",
+        "bronze",
+        "chrome",
+        "gold",
+        "silver",
+        "rust",
+        "rusty",
+        "corroded",
+        "titanium",
+        "zinc",
+        "lead",
+        "tin",
+    ],
+    "wood": [
+        "wood",
+        "plywood",
+        "bark",
+        "timber",
+        "lumber",
+        "oak",
+        "pine",
+        "birch",
+        "walnut",
+        "mahogany",
+        "bamboo",
+        "cork",
+        "parquet",
+    ],
+    "stone": [
+        "stone",
+        "rock",
+        "marble",
+        "granite",
+        "slate",
+        "sandstone",
+        "limestone",
+        "cobblestone",
+        "pebble",
+        "gravel",
+        "cliff",
+        "lava",
+        "basalt",
+        "quartzite",
+    ],
+    "fabric": [
+        "fabric",
+        "cloth",
+        "textile",
+        "leather",
+        "denim",
+        "silk",
+        "wool",
+        "cotton",
+        "linen",
+        "carpet",
+        "rug",
+        "knit",
+        "woven",
+        "burlap",
+        "canvas",
+    ],
+    "plastic": [
+        "plastic",
+        "rubber",
+        "foam",
+        "nylon",
+        "vinyl",
+        "acrylic",
+        "pvc",
+        "resin",
+        "silicone",
+        "synthetic",
+    ],
+    "concrete": [
+        "concrete",
+        "cement",
+        "asphalt",
+        "stucco",
+        "plaster",
+        "mortar",
+        "pavement",
+        "sidewalk",
+    ],
+    "ceramic": ["ceramic", "porcelain", "tile", "terracotta", "clay", "brick", "pottery"],
+    "glass": ["glass", "mirror", "crystal", "window", "translucent", "transparent"],
+    "organic": [
+        "organic",
+        "soil",
+        "dirt",
+        "mud",
+        "sand",
+        "snow",
+        "ice",
+        "grass",
+        "moss",
+        "leaf",
+        "leaves",
+        "bark",
+        "ground",
+        "terrain",
+        "earth",
+        "peat",
+        "hay",
+        "straw",
+        "coral",
+        "bone",
+        "shell",
+        "food",
+    ],
+}.items():
+    for kw in _keywords:
+        _CATEGORY_MAP[kw] = _cat
+
+
+def normalize_category(raw: str) -> str:
+    """Map a freeform upstream category to one of the 10 canonical categories."""
+    if not raw:
+        return "other"
+    # ambientcg uses hierarchical like "Metal/Steel" — take first segment
+    first = raw.split("/")[0].strip().lower()
+    if first in _CATEGORY_MAP:
+        return _CATEGORY_MAP[first]
+    # try individual words
+    for word in first.split():
+        if word in _CATEGORY_MAP:
+            return _CATEGORY_MAP[word]
+    return "other"
+
+
+# ── channel normalization (per-source) ──────────────────────────
+
+_CHANNEL_MAPS: dict[str, dict[str, str]] = {
+    "ambientcg": {
+        "color": "color",
+        "normalgl": "normal",
+        "normaldx": "normal",
+        "normal": "normal",
+        "roughness": "roughness",
+        "metalness": "metalness",
+        "metallic": "metalness",
+        "ambientocclusion": "ao",
+        "displacement": "displacement",
+        "emission": "emission",
+        "opacity": None,  # skip
+    },
+    "polyhaven": {
+        "diffuse": "color",
+        "diff": "color",
+        "col": "color",
+        "nor_gl": "normal",
+        "norgl": "normal",
+        "nor_dx": "normal",
+        "nordx": "normal",
+        "rough": "roughness",
+        "metal": "metalness",
+        "ao": "ao",
+        "disp": "displacement",
+        "displacement": "displacement",
+        "emission": "emission",
+        "arm": None,  # packed ARM, skip
+    },
+    "gpuopen": {
+        "basecolor": "color",
+        "base_color": "color",
+        "color": "color",
+        "normal": "normal",
+        "roughness": "roughness",
+        "metallic": "metalness",
+        "metalness": "metalness",
+        "ambientocclusion": "ao",
+        "ao": "ao",
+        "displacement": "displacement",
+        "height": "displacement",
+        "emissive": "emission",
+        "emission": "emission",
+    },
+}
+
+
+def normalize_channel(source: str, raw_name: str) -> str | None:
+    """Map a source-specific channel name to canonical. Returns None to skip."""
+    cmap = _CHANNEL_MAPS.get(source, {})
+    return cmap.get(raw_name.lower().replace(" ", "").replace("_", ""))
+
+
+# ── data types ──────────────────────────────────────────────────
+
+
+@dataclass
+class MaterialRecord:
+    """Intermediate record passed between pipeline stages."""
+
+    id: str
+    source: str
+    name: str
+    category: str
+    tags: list[str] = field(default_factory=list)
+    source_url: str = ""
+    source_license: str = "CC0-1.0"
+    source_mtlx_url: str | None = None
+    color_hex: str | None = None
+    roughness: float | None = None
+    metalness: float | None = None
+    ior: float | None = None
+    last_updated: str = ""
+    available_tiers: list[str] = field(default_factory=list)
+    maps: list[str] = field(default_factory=list)
+    texture_paths: dict[str, Path] = field(default_factory=dict)
+    status: str = "ok"
+    needs_mtlx_bake: bool = False
+
+
+# ── HTTP retry ──────────────────────────────────────────────────
+
+
+def retry_request(
+    url: str,
+    *,
+    max_retries: int = 3,
+    backoff_base: float = 1.0,
+    session: requests.Session | None = None,
+    timeout: float = 60,
+) -> requests.Response:
+    """GET with exponential backoff on 429/5xx."""
+    s = session or requests.Session()
+    s.headers.setdefault("User-Agent", USER_AGENT)
+
+    last_exc: Exception | None = None
+    for attempt in range(max_retries):
+        try:
+            resp = s.get(url, timeout=timeout)
+            if resp.status_code == 200:
+                return resp
+            if resp.status_code in (429, 500, 502, 503, 504):
+                wait = backoff_base * (2**attempt)
+                log.warning("HTTP %d from %s, retry in %.1fs", resp.status_code, url, wait)
+                time.sleep(wait)
+                continue
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            last_exc = exc
+            wait = backoff_base * (2**attempt)
+            log.warning("%s from %s, retry in %.1fs", exc, url, wait)
+            time.sleep(wait)
+
+    if last_exc:
+        raise last_exc
+    raise requests.HTTPError(f"Failed after {max_retries} retries: {url}")

--- a/src/mat_vis_baker/index_builder.py
+++ b/src/mat_vis_baker/index_builder.py
@@ -1,1 +1,54 @@
-"""Build/update index/*.json from upstream source metadata."""
+"""Build index/<source>.json from MaterialRecords."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from mat_vis_baker.common import MaterialRecord
+
+log = logging.getLogger("mat-vis-baker.index")
+
+
+def build_index(records: list[MaterialRecord], source: str) -> list[dict]:
+    """Convert MaterialRecords to index JSON entries (both ok and failed)."""
+    entries = []
+    for rec in records:
+        entry: dict = {
+            "id": rec.id,
+            "source": source,
+            "name": rec.name,
+            "category": rec.category,
+            "tags": rec.tags,
+            "source_url": rec.source_url,
+            "source_license": rec.source_license,
+            "available_tiers": rec.available_tiers,
+            "maps": rec.maps,
+            "last_updated": rec.last_updated,
+        }
+        if rec.color_hex is not None:
+            entry["color_hex"] = rec.color_hex
+        if rec.roughness is not None:
+            entry["roughness"] = rec.roughness
+        if rec.metalness is not None:
+            entry["metalness"] = rec.metalness
+        if rec.ior is not None:
+            entry["ior"] = rec.ior
+        if rec.source_mtlx_url is not None:
+            entry["source_mtlx_url"] = rec.source_mtlx_url
+        if rec.status == "failed":
+            entry["status"] = "failed"
+
+        entries.append(entry)
+
+    entries.sort(key=lambda e: e["id"])
+    return entries
+
+
+def write_index(index_data: list[dict], output_path: Path) -> Path:
+    """Write index JSON to disk."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(index_data, indent=2, ensure_ascii=False) + "\n")
+    log.info("wrote %s (%d entries)", output_path, len(index_data))
+    return output_path

--- a/src/mat_vis_baker/parquet_writer.py
+++ b/src/mat_vis_baker/parquet_writer.py
@@ -105,10 +105,23 @@ def write_parquet(
 # ── rowmap generation ───────────────────────────────────────────
 
 
-def _find_png_offset(data: bytes, start: int) -> int | None:
-    """Find the first PNG magic bytes at or after `start`."""
-    idx = data.find(PNG_MAGIC, start)
-    return idx if idx >= 0 else None
+_MAX_PAGE_HEADER_SIZE = 100  # Thrift page header is typically 13-50 bytes
+
+
+def _find_png_in_page(data: bytes, page_offset: int, png_length: int) -> int | None:
+    """Find PNG magic within the first bytes after a data page offset.
+
+    Only scans a small window after the page offset to avoid false positives
+    from PNG magic bytes inside other columns' binary data.
+    """
+    search_end = min(page_offset + _MAX_PAGE_HEADER_SIZE, len(data))
+    idx = data.find(PNG_MAGIC, page_offset, search_end)
+    if idx is None or idx < 0:
+        return None
+    # Verify we have enough bytes for the full PNG
+    if idx + png_length > len(data):
+        return None
+    return idx
 
 
 def generate_rowmap(
@@ -120,9 +133,9 @@ def generate_rowmap(
 ) -> dict:
     """Generate a rowmap JSON from a Parquet file.
 
-    Uses the PNG magic byte scan approach: for each binary column in each
-    row group, find the PNG start after the data page offset and use the
-    known PNG byte length from the records.
+    For each binary column, scans a small window after the data page offset
+    for the PNG magic bytes. The window is limited to avoid false positives
+    from PNG magic appearing inside other columns' compressed data.
     """
     pf = pq.ParquetFile(parquet_path)
     file_bytes = parquet_path.read_bytes()
@@ -150,10 +163,14 @@ def generate_rowmap(
                 continue
 
             page_offset = col_meta.data_page_offset
-            png_start = _find_png_offset(file_bytes, page_offset)
+            png_start = _find_png_in_page(file_bytes, page_offset, len(png_bytes))
             if png_start is None:
                 log.warning(
-                    "%s/%s: PNG magic not found after offset %d", rec.id, col_name, page_offset
+                    "%s/%s: PNG magic not found within %d bytes of page offset %d",
+                    rec.id,
+                    col_name,
+                    _MAX_PAGE_HEADER_SIZE,
+                    page_offset,
                 )
                 continue
 

--- a/src/mat_vis_baker/parquet_writer.py
+++ b/src/mat_vis_baker/parquet_writer.py
@@ -1,1 +1,190 @@
-"""Build Parquet files + rowmap JSONs from baked PNGs."""
+"""Pack baked ONGs into Parquet + generate rowmap JSON for HTTP range reads.
+
+Binary (PNG) columns are UNCOMPRESSED so that byte-range reads return raw
+PNG payload without any decompression. Scalar columns use ZSTD.
+
+Row group size = 1 (one material per row group) for per-material offset discovery.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from mat_vis_baker.common import BAKER_VERSION, CANONICAL_CHANNELS, MaterialRecord
+
+log = logging.getLogger("mat-vis-baker.parquet")
+
+PNG_MAGIC = b"\x89PNG"
+
+CHANNEL_COLS = frozenset(CANONICAL_CHANNELS)
+
+_SCHEMA = pa.schema(
+    [
+        pa.field("id", pa.string(), nullable=False),
+        pa.field("source", pa.string(), nullable=False),
+        pa.field("category", pa.string(), nullable=False),
+        pa.field("resolution_px", pa.int32(), nullable=False),
+        pa.field("color", pa.binary()),
+        pa.field("normal", pa.binary()),
+        pa.field("roughness", pa.binary()),
+        pa.field("metalness", pa.binary()),
+        pa.field("ao", pa.binary()),
+        pa.field("displacement", pa.binary()),
+        pa.field("emission", pa.binary()),
+        pa.field("source_url", pa.string(), nullable=False),
+        pa.field("source_license", pa.string(), nullable=False),
+        pa.field("baker_version", pa.string(), nullable=False),
+        pa.field("baked_at", pa.string(), nullable=False),
+    ]
+)
+
+
+def _read_png_bytes(path: Path | None) -> bytes | None:
+    if path is None or not path.exists():
+        return None
+    return path.read_bytes()
+
+
+def write_parquet(
+    records: list[MaterialRecord],
+    source: str,
+    tier: str,
+    output_path: Path,
+    resolution_px: int,
+) -> Path:
+    """Write a Parquet file from MaterialRecords. Returns output path."""
+    ok_records = [r for r in records if r.status == "ok"]
+    if not ok_records:
+        raise ValueError("No successful records to write")
+
+    now = datetime.now(timezone.utc).isoformat()
+
+    rows: dict[str, list] = {f.name: [] for f in _SCHEMA}
+    for rec in ok_records:
+        rows["id"].append(rec.id)
+        rows["source"].append(source)
+        rows["category"].append(rec.category)
+        rows["resolution_px"].append(resolution_px)
+        for ch in CANONICAL_CHANNELS:
+            rows[ch].append(_read_png_bytes(rec.texture_paths.get(ch)))
+        rows["source_url"].append(rec.source_url)
+        rows["source_license"].append(rec.source_license)
+        rows["baker_version"].append(BAKER_VERSION)
+        rows["baked_at"].append(now)
+
+    table = pa.table(rows, schema=_SCHEMA)
+
+    compression = {col: "NONE" if col in CHANNEL_COLS else "ZSTD" for col in table.column_names}
+    use_dictionary = {col: col not in CHANNEL_COLS for col in table.column_names}
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    pq.write_table(
+        table,
+        output_path,
+        compression=compression,
+        use_dictionary=use_dictionary,
+        row_group_size=1,
+        write_statistics=True,
+    )
+
+    log.info(
+        "wrote %s (%d rows, %.1f MB)",
+        output_path,
+        len(ok_records),
+        output_path.stat().st_size / 1e6,
+    )
+    return output_path
+
+
+# ── rowmap generation ───────────────────────────────────────────
+
+
+def _find_png_offset(data: bytes, start: int) -> int | None:
+    """Find the first PNG magic bytes at or after `start`."""
+    idx = data.find(PNG_MAGIC, start)
+    return idx if idx >= 0 else None
+
+
+def generate_rowmap(
+    parquet_path: Path,
+    source: str,
+    tier: str,
+    release_tag: str,
+    records: list[MaterialRecord],
+) -> dict:
+    """Generate a rowmap JSON from a Parquet file.
+
+    Uses the PNG magic byte scan approach: for each binary column in each
+    row group, find the PNG start after the data page offset and use the
+    known PNG byte length from the records.
+    """
+    pf = pq.ParquetFile(parquet_path)
+    file_bytes = parquet_path.read_bytes()
+    meta = pf.metadata
+
+    ok_records = [r for r in records if r.status == "ok"]
+    parquet_name = f"mat-vis-{source}-{tier}.parquet"
+
+    materials: dict[str, dict[str, dict[str, int]]] = {}
+
+    for rg_idx in range(meta.num_row_groups):
+        rg = meta.row_group(rg_idx)
+        rec = ok_records[rg_idx]
+        channels: dict[str, dict[str, int]] = {}
+
+        for col_idx in range(rg.num_columns):
+            col_meta = rg.column(col_idx)
+            col_name = col_meta.path_in_schema
+
+            if col_name not in CHANNEL_COLS:
+                continue
+
+            png_bytes = _read_png_bytes(rec.texture_paths.get(col_name))
+            if png_bytes is None:
+                continue
+
+            page_offset = col_meta.data_page_offset
+            png_start = _find_png_offset(file_bytes, page_offset)
+            if png_start is None:
+                log.warning(
+                    "%s/%s: PNG magic not found after offset %d", rec.id, col_name, page_offset
+                )
+                continue
+
+            channels[col_name] = {
+                "offset": png_start,
+                "length": len(png_bytes),
+            }
+
+        if channels:
+            materials[rec.id] = channels
+
+    rowmap = {
+        "version": 1,
+        "release_tag": release_tag,
+        "source": source,
+        "tier": tier,
+        "parquet_file": parquet_name,
+        "materials": materials,
+    }
+
+    log.info(
+        "rowmap: %d materials, %d total channels",
+        len(materials),
+        sum(len(v) for v in materials.values()),
+    )
+    return rowmap
+
+
+def write_rowmap(rowmap: dict, output_path: Path) -> Path:
+    """Write rowmap JSON to disk."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(rowmap, indent=2) + "\n")
+    log.info("wrote %s", output_path)
+    return output_path

--- a/src/mat_vis_baker/sources/ambientcg.py
+++ b/src/mat_vis_baker/sources/ambientcg.py
@@ -120,6 +120,11 @@ def _extract_maps_from_zip(zip_bytes: bytes, material_id: str, output_dir: Path)
 # ── main fetch ──────────────────────────────────────────────────
 
 
+def _filter_with_downloads(entries: list[dict], tier: str) -> list[dict]:
+    """Filter to entries that have a download URL for the given tier."""
+    return [e for e in entries if _extract_download_url(e, tier) is not None]
+
+
 def fetch(
     tier: str,
     output_dir: Path,
@@ -130,6 +135,10 @@ def fetch(
     """Fetch ambientcg materials for a given tier."""
     s = session or requests.Session()
     entries = discover(session=s)
+
+    # Filter to entries with downloads for this tier, then apply limit
+    entries = _filter_with_downloads(entries, tier)
+    log.info("%d materials have downloads for tier %s", len(entries), tier)
     if limit:
         entries = entries[:limit]
 
@@ -143,16 +152,6 @@ def fetch(
         name = entry.get("displayName", mid)
         try:
             dl_url = _extract_download_url(entry, tier)
-            if not dl_url:
-                log.warning("%s: no download for tier %s", mid, tier)
-                failed += 1
-                records.append(
-                    MaterialRecord(
-                        id=mid, source="ambientcg", name=name, category="other", status="failed"
-                    )
-                )
-                continue
-
             resp = retry_request(dl_url, session=s)
             textures = _extract_maps_from_zip(resp.content, mid, output_dir)
 

--- a/src/mat_vis_baker/sources/ambientcg.py
+++ b/src/mat_vis_baker/sources/ambientcg.py
@@ -38,7 +38,7 @@ def discover(*, session: requests.Session | None = None) -> list[dict]:
     offset = 0
 
     while True:
-        url = f"{API_BASE}?type=Material&limit={PAGE_SIZE}&offset={offset}"
+        url = f"{API_BASE}?type=Material&limit={PAGE_SIZE}&offset={offset}&include=downloadData"
         resp = retry_request(url, session=s)
         data = resp.json()
         assets = data.get("foundAssets", [])
@@ -56,35 +56,33 @@ def discover(*, session: requests.Session | None = None) -> list[dict]:
 
 # ── download + extract ──────────────────────────────────────────
 
-_TIER_KEYS = {"1k": "1k-png", "2k": "2k-png", "4k": "4k-png", "8k": "8k-png"}
+_TIER_ATTRS = {"1k": "1K-PNG", "2k": "2K-PNG", "4k": "4K-PNG", "8k": "8K-PNG"}
 
 
 def _extract_download_url(entry: dict, tier: str) -> str | None:
-    """Get the ZIP download URL for a given tier from an API entry."""
+    """Get the ZIP download URL for a given tier from an API entry.
+
+    Downloads live under downloadFolders.default.downloadFiletypeCategories.zip.downloads[]
+    with the tier encoded in the `attribute` field (e.g. "1K-PNG").
+    """
     folders = entry.get("downloadFolders")
     if not folders:
         return None
 
-    tier_key = _TIER_KEYS.get(tier)
-    if not tier_key:
-        return None
-
-    # try exact key, then case-insensitive
-    folder = folders.get(tier_key)
-    if not folder:
-        for k, v in folders.items():
-            if k.lower() == tier_key.lower():
-                folder = v
-                break
-    if not folder:
+    target_attr = _TIER_ATTRS.get(tier)
+    if not target_attr:
         return None
 
     try:
-        cats = folder["downloadFiletypeCategories"]
-        zips = cats["zip"]["downloads"]
-        return zips[0]["fullDownloadPath"]
-    except (KeyError, IndexError):
+        downloads = folders["default"]["downloadFiletypeCategories"]["zip"]["downloads"]
+    except (KeyError, TypeError):
         return None
+
+    for dl in downloads:
+        if dl.get("attribute", "").upper() == target_attr:
+            return dl.get("fullDownloadPath")
+
+    return None
 
 
 _CHANNEL_RE = re.compile(r"_([A-Za-z]+)\.(png|jpg)$", re.IGNORECASE)

--- a/src/mat_vis_baker/sources/ambientcg.py
+++ b/src/mat_vis_baker/sources/ambientcg.py
@@ -1,1 +1,200 @@
-"""Fetcher for ambientcg.com. See docs/specs/source-apis.md."""
+"""AmbientCG source fetcher.
+
+API: https://ambientcg.com/api/v2/full_json?type=Material&limit=100&offset=0
+License: CC0-1.0 (all materials)
+Format: ZIP per resolution containing flat ONGs — no mtlx baking needed.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import re
+import zipfile
+from pathlib import Path
+
+import requests
+
+from mat_vis_baker.common import (
+    MaterialRecord,
+    normalize_category,
+    normalize_channel,
+    retry_request,
+)
+
+log = logging.getLogger("mat-vis-baker.ambientcg")
+
+API_BASE = "https://ambientcg.com/api/v2/full_json"
+PAGE_SIZE = 100
+
+
+# ── discovery ───────────────────────────────────────────────────
+
+
+def discover(*, session: requests.Session | None = None) -> list[dict]:
+    """Paginate the ambientcg API and return all material entries."""
+    s = session or requests.Session()
+    all_assets: list[dict] = []
+    offset = 0
+
+    while True:
+        url = f"{API_BASE}?type=Material&limit={PAGE_SIZE}&offset={offset}"
+        resp = retry_request(url, session=s)
+        data = resp.json()
+        assets = data.get("foundAssets", [])
+        if not assets:
+            break
+        all_assets.extend(assets)
+        log.info("discovered %d materials (offset=%d)", len(all_assets), offset)
+        if len(assets) < PAGE_SIZE:
+            break
+        offset += PAGE_SIZE
+
+    log.info("total: %d materials", len(all_assets))
+    return all_assets
+
+
+# ── download + extract ──────────────────────────────────────────
+
+_TIER_KEYS = {"1k": "1k-png", "2k": "2k-png", "4k": "4k-png", "8k": "8k-png"}
+
+
+def _extract_download_url(entry: dict, tier: str) -> str | None:
+    """Get the ZIP download URL for a given tier from an API entry."""
+    folders = entry.get("downloadFolders")
+    if not folders:
+        return None
+
+    tier_key = _TIER_KEYS.get(tier)
+    if not tier_key:
+        return None
+
+    # try exact key, then case-insensitive
+    folder = folders.get(tier_key)
+    if not folder:
+        for k, v in folders.items():
+            if k.lower() == tier_key.lower():
+                folder = v
+                break
+    if not folder:
+        return None
+
+    try:
+        cats = folder["downloadFiletypeCategories"]
+        zips = cats["zip"]["downloads"]
+        return zips[0]["fullDownloadPath"]
+    except (KeyError, IndexError):
+        return None
+
+
+_CHANNEL_RE = re.compile(r"_([A-Za-z]+)\.(png|jpg)$", re.IGNORECASE)
+
+
+def _extract_maps_from_zip(zip_bytes: bytes, material_id: str, output_dir: Path) -> dict[str, Path]:
+    """Extract PNG textures from a ZIP, normalize channel names."""
+    mat_dir = output_dir / material_id
+    mat_dir.mkdir(parents=True, exist_ok=True)
+    result: dict[str, Path] = {}
+
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+        for name in zf.namelist():
+            if name.endswith("/"):
+                continue
+            m = _CHANNEL_RE.search(name)
+            if not m:
+                continue
+            raw_channel = m.group(1)
+            channel = normalize_channel("ambientcg", raw_channel)
+            if channel is None:
+                continue
+            if channel in result:
+                continue
+
+            out_path = mat_dir / f"{channel}.png"
+            out_path.write_bytes(zf.read(name))
+            result[channel] = out_path
+
+    return result
+
+
+# ── main fetch ──────────────────────────────────────────────────
+
+
+def fetch(
+    tier: str,
+    output_dir: Path,
+    *,
+    limit: int | None = None,
+    session: requests.Session | None = None,
+) -> list[MaterialRecord]:
+    """Fetch ambientcg materials for a given tier."""
+    s = session or requests.Session()
+    entries = discover(session=s)
+    if limit:
+        entries = entries[:limit]
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    records: list[MaterialRecord] = []
+    ok = 0
+    failed = 0
+
+    for entry in entries:
+        mid = entry.get("assetId", "")
+        name = entry.get("displayName", mid)
+        try:
+            dl_url = _extract_download_url(entry, tier)
+            if not dl_url:
+                log.warning("%s: no download for tier %s", mid, tier)
+                failed += 1
+                records.append(
+                    MaterialRecord(
+                        id=mid, source="ambientcg", name=name, category="other", status="failed"
+                    )
+                )
+                continue
+
+            resp = retry_request(dl_url, session=s)
+            textures = _extract_maps_from_zip(resp.content, mid, output_dir)
+
+            if not textures:
+                log.warning("%s: no textures in ZIP", mid)
+                failed += 1
+                records.append(
+                    MaterialRecord(
+                        id=mid, source="ambientcg", name=name, category="other", status="failed"
+                    )
+                )
+                continue
+
+            cat = normalize_category(entry.get("displayCategory", entry.get("category", "")))
+            tags = entry.get("tags", [])
+            release_date = (entry.get("releaseDate") or "")[:10]
+
+            rec = MaterialRecord(
+                id=mid,
+                source="ambientcg",
+                name=name,
+                category=cat,
+                tags=tags,
+                source_url=f"https://ambientcg.com/a/{mid}",
+                source_license="CC0-1.0",
+                last_updated=release_date,
+                available_tiers=[tier],
+                maps=sorted(textures.keys()),
+                texture_paths=textures,
+            )
+            records.append(rec)
+            ok += 1
+            log.info("%s: ok (%d textures)", mid, len(textures))
+
+        except Exception:
+            log.exception("%s: fetch failed", mid)
+            failed += 1
+            records.append(
+                MaterialRecord(
+                    id=mid, source="ambientcg", name=name, category="other", status="failed"
+                )
+            )
+
+    log.info("ambientcg: %d ok, %d failed / %d total", ok, failed, len(entries))
+    return records

--- a/src/mat_vis_baker/sources/gpuopen.py
+++ b/src/mat_vis_baker/sources/gpuopen.py
@@ -1,1 +1,203 @@
-"""Fetcher for matlib.gpuopen.com"""
+"""GPUOpen MaterialX Library fetcher.
+
+API: https://api.matlib.gpuopen.com/api/packages?limit=100&offset=0
+License: TBV (per material)
+Format: ZIP with .mtlx + textures. Some materials have layered graphs.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import re
+import zipfile
+from pathlib import Path
+
+import requests
+
+from mat_vis_baker.common import (
+    MaterialRecord,
+    normalize_category,
+    normalize_channel,
+    retry_request,
+)
+
+log = logging.getLogger("mat-vis-baker.gpuopen")
+
+API_BASE = "https://api.matlib.gpuopen.com/api"
+PAGE_SIZE = 100
+
+
+# ── discovery ───────────────────────────────────────────────────
+
+
+def discover(*, session: requests.Session | None = None) -> list[dict]:
+    """Paginate the gpuopen packages API."""
+    s = session or requests.Session()
+    all_packages: list[dict] = []
+    offset = 0
+
+    while True:
+        url = f"{API_BASE}/packages?limit={PAGE_SIZE}&offset={offset}"
+        resp = retry_request(url, session=s)
+        data = resp.json()
+        results = data.get("results", [])
+        if not results:
+            break
+        all_packages.extend(results)
+        log.info("discovered %d packages (offset=%d)", len(all_packages), offset)
+        if len(results) < PAGE_SIZE:
+            break
+        offset += PAGE_SIZE
+
+    log.info("total: %d packages", len(all_packages))
+    return all_packages
+
+
+def _fetch_package_detail(package_id: str, *, session: requests.Session | None = None) -> dict:
+    """Get detailed package info including download URL."""
+    s = session or requests.Session()
+    resp = retry_request(f"{API_BASE}/packages/{package_id}", session=s)
+    return resp.json()
+
+
+# ── download + extract ──────────────────────────────────────────
+
+_IMG_RE = re.compile(r"\.(png|jpg|jpeg|tif|tiff|exr)$", re.IGNORECASE)
+
+
+def _extract_from_zip(
+    zip_bytes: bytes,
+    material_id: str,
+    output_dir: Path,
+) -> tuple[Path | None, dict[str, Path]]:
+    """Extract .mtlx and texture files from a ZIP. Returns (mtlx_path, {channel: path})."""
+    mat_dir = output_dir / material_id
+    mat_dir.mkdir(parents=True, exist_ok=True)
+    mtlx_path: Path | None = None
+    textures: dict[str, Path] = {}
+
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+        for name in zf.namelist():
+            if name.endswith("/"):
+                continue
+            basename = name.rsplit("/", 1)[-1].lower()
+
+            if basename.endswith(".mtlx"):
+                mtlx_path = mat_dir / "material.mtlx"
+                mtlx_path.write_bytes(zf.read(name))
+                continue
+
+            if _IMG_RE.search(basename):
+                # Try to extract channel from filename
+                stem = basename.rsplit(".", 1)[0]
+                # Common patterns: basecolor.png, *_basecolor.png, *_normal.png
+                parts = re.split(r"[_\-]", stem)
+                channel = None
+                for part in reversed(parts):
+                    channel = normalize_channel("gpuopen", part)
+                    if channel:
+                        break
+                if channel and channel not in textures:
+                    ext = basename.rsplit(".", 1)[-1]
+                    out_path = mat_dir / f"{channel}.{ext}"
+                    out_path.write_bytes(zf.read(name))
+                    textures[channel] = out_path
+
+    return mtlx_path, textures
+
+
+# ── main fetch ──────────────────────────────────────────────────
+
+
+def fetch(
+    tier: str,
+    output_dir: Path,
+    *,
+    limit: int | None = None,
+    session: requests.Session | None = None,
+) -> list[MaterialRecord]:
+    """Fetch gpuopen materials. Layered mtlx graphs are flagged for baking."""
+    s = session or requests.Session()
+    packages = discover(session=s)
+    if limit:
+        packages = packages[:limit]
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    records: list[MaterialRecord] = []
+    ok = 0
+    failed = 0
+
+    for pkg in packages:
+        mid = pkg.get("id", "")
+        name = pkg.get("title", mid)
+        try:
+            detail = _fetch_package_detail(mid, session=s)
+            dl_url = detail.get("downloadUrl") or detail.get("download_url")
+            if not dl_url:
+                log.warning("%s: no download URL", mid)
+                failed += 1
+                records.append(
+                    MaterialRecord(
+                        id=mid, source="gpuopen", name=name, category="other", status="failed"
+                    )
+                )
+                continue
+
+            resp = retry_request(dl_url, session=s)
+            mtlx_path, textures = _extract_from_zip(resp.content, mid, output_dir)
+
+            # If no flat textures but we have mtlx, flag for baking
+            needs_bake = bool(mtlx_path) and not textures
+
+            if not textures and not mtlx_path:
+                log.warning("%s: no textures or mtlx in ZIP", mid)
+                failed += 1
+                records.append(
+                    MaterialRecord(
+                        id=mid, source="gpuopen", name=name, category="other", status="failed"
+                    )
+                )
+                continue
+
+            cat = normalize_category(pkg.get("category", ""))
+            tags = pkg.get("tags", [])
+            if isinstance(tags, str):
+                tags = [t.strip() for t in tags.split(",") if t.strip()]
+
+            texture_paths = dict(textures)
+            if mtlx_path:
+                texture_paths["_mtlx"] = mtlx_path
+
+            rec = MaterialRecord(
+                id=mid,
+                source="gpuopen",
+                name=name,
+                category=cat,
+                tags=tags,
+                source_url=f"https://matlib.gpuopen.com/main/materials/all?material={mid}",
+                source_license="TBV",
+                last_updated="",
+                available_tiers=[tier] if textures else [],
+                maps=sorted(textures.keys()),
+                texture_paths=texture_paths,
+                needs_mtlx_bake=needs_bake,
+            )
+            records.append(rec)
+            if needs_bake:
+                log.info("%s: mtlx only (needs bake)", mid)
+            else:
+                ok += 1
+                log.info("%s: ok (%d textures)", mid, len(textures))
+
+        except Exception:
+            log.exception("%s: fetch failed", mid)
+            failed += 1
+            records.append(
+                MaterialRecord(
+                    id=mid, source="gpuopen", name=name, category="other", status="failed"
+                )
+            )
+
+    log.info("gpuopen: %d ok, %d failed / %d total", ok, failed, len(packages))
+    return records

--- a/src/mat_vis_baker/sources/physicallybased.py
+++ b/src/mat_vis_baker/sources/physicallybased.py
@@ -1,1 +1,66 @@
-"""Fetcher for physicallybased.info (scalar-only)"""
+"""Physicallybased.info fetcher — scalar properties only, no textures.
+
+API: https://api.physicallybased.info/materials
+License: CC0-1.0
+Format: JSON array of scalar material properties (IOR, color, roughness, etc.)
+No textures, no parquet — index JSON only.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import requests
+
+from mat_vis_baker.common import (
+    MaterialRecord,
+    normalize_category,
+    retry_request,
+)
+
+log = logging.getLogger("mat-vis-baker.physicallybased")
+
+API_URL = "https://api.physicallybased.info/materials"
+
+
+def _rgb_to_hex(rgb: list[float] | None) -> str | None:
+    """Convert [r, g, b] floats (0-1) to #RRGGBB hex."""
+    if not rgb or len(rgb) < 3:
+        return None
+    r, g, b = rgb[:3]
+    return "#{:02X}{:02X}{:02X}".format(
+        int(round(r * 255)), int(round(g * 255)), int(round(b * 255))
+    )
+
+
+def fetch(*, session: requests.Session | None = None) -> list[MaterialRecord]:
+    """Fetch all physicallybased materials (scalar only, no tier needed)."""
+    s = session or requests.Session()
+    resp = retry_request(API_URL, session=s)
+    materials = resp.json()
+    log.info("fetched %d materials", len(materials))
+
+    records: list[MaterialRecord] = []
+    for mat in materials:
+        name = mat.get("name", "")
+        cat = normalize_category(mat.get("category", ""))
+        color_hex = _rgb_to_hex(mat.get("color"))
+
+        rec = MaterialRecord(
+            id=name.lower().replace(" ", "_"),
+            source="physicallybased",
+            name=name,
+            category=cat,
+            source_url="https://physicallybased.info",
+            source_license="CC0-1.0",
+            color_hex=color_hex,
+            roughness=mat.get("roughness"),
+            metalness=mat.get("metalness"),
+            ior=mat.get("ior"),
+            available_tiers=[],
+            maps=[],
+        )
+        records.append(rec)
+
+    log.info("physicallybased: %d records", len(records))
+    return records

--- a/src/mat_vis_baker/sources/polyhaven.py
+++ b/src/mat_vis_baker/sources/polyhaven.py
@@ -1,1 +1,166 @@
-"""Fetcher for polyhaven.com"""
+"""Polyhaven source fetcher.
+
+API: https://api.polyhaven.com/assets?t=textures
+License: CC0-1.0 (all assets)
+Format: Individual PNG downloads per map per resolution (no ZIP).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import requests
+
+from mat_vis_baker.common import (
+    MaterialRecord,
+    normalize_category,
+    normalize_channel,
+    retry_request,
+)
+
+log = logging.getLogger("mat-vis-baker.polyhaven")
+
+API_BASE = "https://api.polyhaven.com"
+
+_TIER_KEYS = {"1k": "1k", "2k": "2k", "4k": "4k", "8k": "8k"}
+
+
+# ── discovery ───────────────────────────────────────────────────
+
+
+def discover(*, session: requests.Session | None = None) -> dict:
+    """Fetch all texture assets in a single call. Returns dict keyed by slug."""
+    s = session or requests.Session()
+    resp = retry_request(f"{API_BASE}/assets?t=textures", session=s)
+    data = resp.json()
+    log.info("discovered %d texture assets", len(data))
+    return data
+
+
+def _fetch_files(slug: str, *, session: requests.Session | None = None) -> dict:
+    """Get per-resolution file map for a single asset."""
+    s = session or requests.Session()
+    resp = retry_request(f"{API_BASE}/files/{slug}", session=s)
+    return resp.json()
+
+
+# ── download ────────────────────────────────────────────────────
+
+
+def _download_maps(
+    file_info: dict,
+    tier: str,
+    output_dir: Path,
+    material_id: str,
+    *,
+    session: requests.Session | None = None,
+) -> dict[str, Path]:
+    """Download PNG maps for a given tier. Returns {channel: path}."""
+    s = session or requests.Session()
+    tier_key = _TIER_KEYS.get(tier)
+    if not tier_key or tier_key not in file_info:
+        return {}
+
+    tier_data = file_info[tier_key]
+    mat_dir = output_dir / material_id
+    mat_dir.mkdir(parents=True, exist_ok=True)
+    result: dict[str, Path] = {}
+
+    for map_key, formats in tier_data.items():
+        channel = normalize_channel("polyhaven", map_key)
+        if channel is None:
+            continue
+        if channel in result:
+            continue
+
+        # Prefer PNG, fall back to JPG
+        fmt_data = formats.get("png") or formats.get("jpg")
+        if not fmt_data or "url" not in fmt_data:
+            continue
+
+        url = fmt_data["url"]
+        try:
+            resp = retry_request(url, session=s)
+            out_path = mat_dir / f"{channel}.png"
+            out_path.write_bytes(resp.content)
+            result[channel] = out_path
+        except Exception:
+            log.warning("%s/%s: download failed from %s", material_id, channel, url)
+
+    return result
+
+
+# ── main fetch ──────────────────────────────────────────────────
+
+
+def fetch(
+    tier: str,
+    output_dir: Path,
+    *,
+    limit: int | None = None,
+    session: requests.Session | None = None,
+) -> list[MaterialRecord]:
+    """Fetch polyhaven materials for a given tier."""
+    s = session or requests.Session()
+    assets = discover(session=s)
+
+    slugs = list(assets.keys())
+    if limit:
+        slugs = slugs[:limit]
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    records: list[MaterialRecord] = []
+    ok = 0
+    failed = 0
+
+    for slug in slugs:
+        meta = assets[slug]
+        name = meta.get("name", slug)
+        try:
+            file_info = _fetch_files(slug, session=s)
+            textures = _download_maps(file_info, tier, output_dir, slug, session=s)
+
+            if not textures:
+                log.warning("%s: no textures for tier %s", slug, tier)
+                failed += 1
+                records.append(
+                    MaterialRecord(
+                        id=slug, source="polyhaven", name=name, category="other", status="failed"
+                    )
+                )
+                continue
+
+            cats = meta.get("categories", {})
+            cat_str = next(iter(cats.keys()), "") if cats else ""
+            cat = normalize_category(cat_str)
+            tags = meta.get("tags", [])
+
+            rec = MaterialRecord(
+                id=slug,
+                source="polyhaven",
+                name=name,
+                category=cat,
+                tags=tags,
+                source_url=f"https://polyhaven.com/a/{slug}",
+                source_license="CC0-1.0",
+                last_updated="",
+                available_tiers=[tier],
+                maps=sorted(textures.keys()),
+                texture_paths=textures,
+            )
+            records.append(rec)
+            ok += 1
+            log.info("%s: ok (%d textures)", slug, len(textures))
+
+        except Exception:
+            log.exception("%s: fetch failed", slug)
+            failed += 1
+            records.append(
+                MaterialRecord(
+                    id=slug, source="polyhaven", name=name, category="other", status="failed"
+                )
+            )
+
+    log.info("polyhaven: %d ok, %d failed / %d total", ok, failed, len(slugs))
+    return records

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,78 @@
 """Shared fixtures. See docs/specs/ for schema definitions."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from mat_vis_baker.common import MaterialRecord
+
+
+@pytest.fixture
+def tiny_png_bytes() -> bytes:
+    """A minimal valid 4x4 red PNG."""
+    img = Image.new("RGB", (4, 4), color=(255, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture
+def sample_record(tmp_path: Path, tiny_png_bytes: bytes) -> MaterialRecord:
+    """A single MaterialRecord with tiny ONGs on disk."""
+    mat_dir = tmp_path / "TestMat001"
+    mat_dir.mkdir()
+    paths = {}
+    for ch in ["color", "normal", "roughness"]:
+        p = mat_dir / f"{ch}.png"
+        p.write_bytes(tiny_png_bytes)
+        paths[ch] = p
+
+    return MaterialRecord(
+        id="TestMat001",
+        source="ambientcg",
+        name="Test Material",
+        category="metal",
+        tags=["test"],
+        source_url="https://example.com/a/TestMat001",
+        source_license="CC0-1.0",
+        last_updated="2026-04-16",
+        available_tiers=["1k"],
+        maps=sorted(paths.keys()),
+        texture_paths=paths,
+    )
+
+
+@pytest.fixture
+def sample_records(tmp_path: Path, tiny_png_bytes: bytes) -> list[MaterialRecord]:
+    """Three MaterialRecords with tiny ONGs."""
+    records = []
+    for i in range(3):
+        mid = f"TestMat{i:03d}"
+        mat_dir = tmp_path / mid
+        mat_dir.mkdir()
+        paths = {}
+        for ch in ["color", "normal", "roughness"]:
+            p = mat_dir / f"{ch}.png"
+            p.write_bytes(tiny_png_bytes)
+            paths[ch] = p
+
+        records.append(
+            MaterialRecord(
+                id=mid,
+                source="ambientcg",
+                name=f"Test Material {i}",
+                category="metal",
+                tags=["test"],
+                source_url=f"https://example.com/a/{mid}",
+                source_license="CC0-1.0",
+                last_updated="2026-04-16",
+                available_tiers=["1k"],
+                maps=sorted(paths.keys()),
+                texture_paths=paths,
+            )
+        )
+    return records

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,49 @@
+"""Tests for mat_vis_baker.common."""
+
+from mat_vis_baker.common import normalize_category, normalize_channel
+
+
+class TestNormalizeCategory:
+    def test_known_metal(self):
+        assert normalize_category("Metal/Steel") == "metal"
+
+    def test_known_wood(self):
+        assert normalize_category("Wood") == "wood"
+
+    def test_hierarchical_first_segment(self):
+        assert normalize_category("Stone/Marble/White") == "stone"
+
+    def test_unknown_falls_to_other(self):
+        assert normalize_category("FooBarBaz") == "other"
+
+    def test_empty_string(self):
+        assert normalize_category("") == "other"
+
+    def test_case_insensitive(self):
+        assert normalize_category("CONCRETE") == "concrete"
+
+    def test_organic_soil(self):
+        assert normalize_category("Soil") == "organic"
+
+
+class TestNormalizeChannel:
+    def test_ambientcg_color(self):
+        assert normalize_channel("ambientcg", "Color") == "color"
+
+    def test_ambientcg_normalgl(self):
+        assert normalize_channel("ambientcg", "NormalGL") == "normal"
+
+    def test_ambientcg_ao(self):
+        assert normalize_channel("ambientcg", "AmbientOcclusion") == "ao"
+
+    def test_polyhaven_diffuse(self):
+        assert normalize_channel("polyhaven", "diffuse") == "color"
+
+    def test_polyhaven_nor_gl(self):
+        assert normalize_channel("polyhaven", "nor_gl") == "normal"
+
+    def test_unknown_returns_none(self):
+        assert normalize_channel("ambientcg", "SomeWeirdMap") is None
+
+    def test_unknown_source(self):
+        assert normalize_channel("unknown_source", "color") is None

--- a/tests/test_parquet_writer.py
+++ b/tests/test_parquet_writer.py
@@ -1,0 +1,93 @@
+"""Tests for mat_vis_baker.parquet_writer — the critical correctness tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+from mat_vis_baker.common import CANONICAL_CHANNELS, MaterialRecord
+from mat_vis_baker.parquet_writer import generate_rowmap, write_parquet
+
+
+class TestWriteParquet:
+    def test_schema_columns(self, tmp_path: Path, sample_records: list[MaterialRecord]):
+        out = tmp_path / "test.parquet"
+        write_parquet(sample_records, "ambientcg", "1k", out, 1024)
+        pf = pq.ParquetFile(out)
+        cols = pf.schema_arrow.names
+        assert "id" in cols
+        assert "source" in cols
+        assert "color" in cols
+        assert "normal" in cols
+
+    def test_binary_columns_uncompressed(
+        self, tmp_path: Path, sample_records: list[MaterialRecord]
+    ):
+        out = tmp_path / "test.parquet"
+        write_parquet(sample_records, "ambientcg", "1k", out, 1024)
+        pf = pq.ParquetFile(out)
+        meta = pf.metadata
+        rg = meta.row_group(0)
+        for col_idx in range(rg.num_columns):
+            col = rg.column(col_idx)
+            if col.path_in_schema in CANONICAL_CHANNELS:
+                assert col.compression == "UNCOMPRESSED", (
+                    f"{col.path_in_schema} should be UNCOMPRESSED"
+                )
+
+    def test_one_row_per_row_group(self, tmp_path: Path, sample_records: list[MaterialRecord]):
+        out = tmp_path / "test.parquet"
+        write_parquet(sample_records, "ambientcg", "1k", out, 1024)
+        pf = pq.ParquetFile(out)
+        assert pf.metadata.num_row_groups == len(sample_records)
+
+    def test_row_count(self, tmp_path: Path, sample_records: list[MaterialRecord]):
+        out = tmp_path / "test.parquet"
+        write_parquet(sample_records, "ambientcg", "1k", out, 1024)
+        pf = pq.ParquetFile(out)
+        assert pf.metadata.num_rows == len(sample_records)
+
+
+class TestRowmap:
+    def test_rowmap_offsets_yield_valid_png(
+        self, tmp_path: Path, sample_records: list[MaterialRecord], tiny_png_bytes: bytes
+    ):
+        """The critical test: read bytes at rowmap offsets → valid PNG."""
+        out = tmp_path / "test.parquet"
+        write_parquet(sample_records, "ambientcg", "1k", out, 1024)
+        rowmap = generate_rowmap(out, "ambientcg", "1k", "v0000.00.0", sample_records)
+
+        file_bytes = out.read_bytes()
+
+        for mid, channels in rowmap["materials"].items():
+            for ch, rng in channels.items():
+                offset = rng["offset"]
+                length = rng["length"]
+                extracted = file_bytes[offset : offset + length]
+                assert extracted[:4] == b"\x89PNG", (
+                    f"{mid}/{ch}: bytes at offset don't start with PNG magic"
+                )
+                assert len(extracted) == length
+                assert extracted == tiny_png_bytes, (
+                    f"{mid}/{ch}: extracted bytes differ from original"
+                )
+
+    def test_rowmap_structure(self, tmp_path: Path, sample_records: list[MaterialRecord]):
+        out = tmp_path / "test.parquet"
+        write_parquet(sample_records, "ambientcg", "1k", out, 1024)
+        rowmap = generate_rowmap(out, "ambientcg", "1k", "v0000.00.0", sample_records)
+
+        assert rowmap["version"] == 1
+        assert rowmap["source"] == "ambientcg"
+        assert rowmap["tier"] == "1k"
+        assert "materials" in rowmap
+        assert len(rowmap["materials"]) == len(sample_records)
+
+    def test_all_channels_present(self, tmp_path: Path, sample_records: list[MaterialRecord]):
+        out = tmp_path / "test.parquet"
+        write_parquet(sample_records, "ambientcg", "1k", out, 1024)
+        rowmap = generate_rowmap(out, "ambientcg", "1k", "v0000.00.0", sample_records)
+
+        for mid, channels in rowmap["materials"].items():
+            assert set(channels.keys()) == {"color", "normal", "roughness"}


### PR DESCRIPTION
## Summary

Full baker pipeline implementation:
- 4 source fetchers (ambientcg, polyhaven, gpuopen, physicallybased)
- Bake engine (PNG validation, mtlx stub for gpuopen)
- Parquet writer (UNCOMPRESSED binary, ZSTD scalars, rowmap via bounded PNG magic scan)
- Index builder + CLI with 95% success threshold
- 22 unit tests + integration test (real upstream data, range-read verified)
- Dagger bake-source function for CI-driven builds

## Test plan

- [x] 22 unit tests pass (normalization, parquet schema, rowmap offsets)
- [x] Integration test passes (2 real ambientcg materials → parquet → rowmap → range-read)
- [x] All 4 API probes pass
- [x] CI green (both jobs)