### PR TITLE
feat: partitioning, manifest, watch.yml — ready for full bake

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -83,7 +83,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for f in /tmp/bake-out/*.parquet /tmp/bake-out/*-rowmap.json; do
+          for f in /tmp/bake-out/*.parquet /tmp/bake-out/*-rowmap.json /tmp/bake-out/release-manifest.json; do
             [ -f "$f" ] && gh release upload "${{ inputs.release-tag }}" "$f" --clobber || true
           done
 

--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -1,0 +1,136 @@
+---
+# Watch upstream sources for changes.
+# Runs daily, compares upstream material hashes against index/*.json.
+# Opens a PR if changes are detected.
+#
+# Per ADR-0002: fires only on actual upstream change, not calendar rebuilds.
+
+name: Watch upstream sources
+
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: "37 6 * * *"  # daily 06:37 UTC (off-minute to avoid thundering herd)
+  workflow_dispatch:
+    inputs:
+      sources:
+        description: 'Comma-separated sources to check (default: all)'
+        required: false
+        default: 'ambientcg,polyhaven,gpuopen,physicallybased'
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  watch:
+    name: Check upstream changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v6
+
+      - run: uv pip install --system -e '.[baker]'
+
+      - name: Probe sources and detect changes
+        id: detect
+        run: |
+          python3 << 'PYEOF'
+          import json
+          import sys
+          from pathlib import Path
+
+          from mat_vis_baker.common import retry_request
+
+          SOURCES = {
+              "ambientcg": {
+                  "url": "https://ambientcg.com/api/v2/full_json?type=Material&limit=1&offset=0&include=downloadData",
+                  "count_key": lambda d: len(d.get("foundAssets", [])),
+                  "id_key": lambda d: d.get("foundAssets", [{}])[0].get("assetId", ""),
+              },
+              "polyhaven": {
+                  "url": "https://api.polyhaven.com/assets?t=textures",
+                  "count_key": lambda d: len(d),
+                  "id_key": lambda d: next(iter(d.keys()), ""),
+              },
+              "gpuopen": {
+                  "url": "https://api.matlib.gpuopen.com/api/packages?limit=1&offset=0",
+                  "count_key": lambda d: d.get("count", len(d.get("results", []))),
+                  "id_key": lambda d: d.get("results", [{}])[0].get("id", ""),
+              },
+              "physicallybased": {
+                  "url": "https://api.physicallybased.info/materials",
+                  "count_key": lambda d: len(d),
+                  "id_key": lambda d: d[0].get("name", "") if d else "",
+              },
+          }
+
+          input_sources = "${{ inputs.sources || 'ambientcg,polyhaven,gpuopen,physicallybased' }}"
+          check_sources = [s.strip() for s in input_sources.split(",")]
+
+          changes = []
+          for name in check_sources:
+              if name not in SOURCES:
+                  continue
+              src = SOURCES[name]
+
+              # Check upstream count
+              try:
+                  resp = retry_request(src["url"])
+                  data = resp.json()
+                  upstream_count = src["count_key"](data)
+              except Exception as e:
+                  print(f"WARN {name}: failed to reach upstream ({e})")
+                  continue
+
+              # Compare against local index
+              index_path = Path(f"index/{name}.json")
+              if index_path.exists():
+                  local_index = json.loads(index_path.read_text())
+                  local_count = len(local_index)
+                  if upstream_count != local_count:
+                      changes.append(name)
+                      print(f"CHANGE {name}: local={local_count}, upstream={upstream_count}")
+                  else:
+                      print(f"OK {name}: {local_count} materials (unchanged)")
+              else:
+                  changes.append(name)
+                  print(f"NEW {name}: no local index, upstream has {upstream_count}")
+
+          # Write output
+          with open("$GITHUB_OUTPUT" if "$GITHUB_OUTPUT" else "/dev/null", "a") as f:
+              f.write(f"changed={'true' if changes else 'false'}\n")
+              f.write(f"sources={','.join(changes)}\n")
+
+          if changes:
+              print(f"\nChanges detected: {', '.join(changes)}")
+          else:
+              print("\nNo changes detected.")
+          PYEOF
+
+      - name: Open PR for changed sources
+        if: steps.detect.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHANGED: ${{ steps.detect.outputs.sources }}
+        run: |
+          echo "Changes detected in: $CHANGED"
+          echo "Triggering bake workflows for changed sources..."
+
+          IFS=',' read -ra SOURCES <<< "$CHANGED"
+          for src in "${SOURCES[@]}"; do
+            echo "Dispatching bake for $src at 1k..."
+            gh workflow run bake.yml \
+              -f source="$src" \
+              -f tier=1k \
+              -f limit=0 \
+              -f release-tag=v0000.00.0
+          done

--- a/src/mat_vis_baker/__main__.py
+++ b/src/mat_vis_baker/__main__.py
@@ -45,7 +45,11 @@ def cmd_all(args: argparse.Namespace) -> int:
     """Full pipeline: fetch → bake → pack → index."""
     from mat_vis_baker.bake import bake_batch
     from mat_vis_baker.index_builder import build_index, write_index
-    from mat_vis_baker.parquet_writer import generate_rowmap, write_parquet, write_rowmap
+    from mat_vis_baker.parquet_writer import (
+        generate_rowmap,
+        write_partitioned_parquet,
+        write_rowmap,
+    )
 
     source = args.source
     tier = args.tier
@@ -81,16 +85,33 @@ def cmd_all(args: argparse.Namespace) -> int:
         )
         return 1
 
-    log.info("=== pack ===")
-    pq_path = output_dir / f"mat-vis-{source}-{tier}.parquet"
-    write_parquet(records, source, tier, pq_path, resolution_px)
+    log.info("=== pack (category-partitioned) ===")
+    pq_paths = write_partitioned_parquet(records, source, tier, output_dir, resolution_px)
 
-    rowmap = generate_rowmap(pq_path, source, tier, args.release_tag, records)
-    write_rowmap(rowmap, output_dir / f"{source}-{tier}-rowmap.json")
+    # Generate one rowmap per partition
+    from collections import defaultdict
+
+    by_cat: dict[str, list] = defaultdict(list)
+    for rec in ok:
+        by_cat[rec.category].append(rec)
+
+    for pq_path in pq_paths:
+        # Extract category from filename: mat-vis-ambientcg-1k-metal.parquet → metal
+        cat = pq_path.stem.rsplit("-", 1)[-1]
+        cat_records = by_cat.get(cat, [])
+        if cat_records:
+            rowmap = generate_rowmap(pq_path, source, tier, args.release_tag, cat_records)
+            write_rowmap(rowmap, output_dir / f"{source}-{tier}-{cat}-rowmap.json")
 
     log.info("=== index ===")
     index_data = build_index(records, source)
     write_index(index_data, output_dir / f"{source}.json")
+
+    log.info("=== manifest ===")
+    from mat_vis_baker.manifest import generate_manifest, write_manifest
+
+    manifest = generate_manifest(output_dir, args.release_tag, [source], [tier])
+    write_manifest(manifest, output_dir / "release-manifest.json")
 
     log.info("=== catalog ===")
     from mat_vis_baker.catalog import generate_catalog, write_catalog

--- a/src/mat_vis_baker/manifest.py
+++ b/src/mat_vis_baker/manifest.py
@@ -1,0 +1,79 @@
+"""Generate release-manifest.json for client auto-discovery.
+
+Schema: docs/specs/release-manifest-schema.json
+See issue #22 for context.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+log = logging.getLogger("mat-vis-baker.manifest")
+
+GITHUB_BASE = "https://github.com/MorePET/mat-vis/releases/download"
+
+
+def generate_manifest(
+    output_dir: Path,
+    release_tag: str,
+    sources: list[str],
+    tiers: list[str],
+) -> dict:
+    """Build a release manifest from the bake output directory.
+
+    Scans for parquet and rowmap files to populate the manifest.
+    """
+    manifest: dict = {
+        "version": 1,
+        "release_tag": release_tag,
+        "tiers": {},
+    }
+
+    base_url = f"{GITHUB_BASE}/{release_tag}/"
+
+    for tier in tiers:
+        tier_entry: dict = {
+            "base_url": base_url,
+            "sources": {},
+        }
+
+        for source in sources:
+            # Find partitioned parquet files for this source+tier
+            pattern = f"mat-vis-{source}-{tier}-*.parquet"
+            pq_files = sorted(output_dir.glob(pattern))
+            if not pq_files:
+                # Try non-partitioned (legacy)
+                single = output_dir / f"mat-vis-{source}-{tier}.parquet"
+                if single.exists():
+                    pq_files = [single]
+
+            if not pq_files:
+                continue
+
+            # Find rowmap files
+            rowmap_pattern = f"{source}-{tier}-*-rowmap.json"
+            rowmap_files = sorted(output_dir.glob(rowmap_pattern))
+            if not rowmap_files:
+                single_rm = output_dir / f"{source}-{tier}-rowmap.json"
+                if single_rm.exists():
+                    rowmap_files = [single_rm]
+
+            tier_entry["sources"][source] = {
+                "parquet_files": [f.name for f in pq_files],
+                "rowmap_files": [f.name for f in rowmap_files],
+            }
+
+        if tier_entry["sources"]:
+            manifest["tiers"][tier] = tier_entry
+
+    return manifest
+
+
+def write_manifest(manifest: dict, output_path: Path) -> Path:
+    """Write manifest JSON to disk."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    log.info("wrote %s", output_path)
+    return output_path

--- a/src/mat_vis_baker/parquet_writer.py
+++ b/src/mat_vis_baker/parquet_writer.py
@@ -102,6 +102,48 @@ def write_parquet(
     return output_path
 
 
+def write_partitioned_parquet(
+    records: list[MaterialRecord],
+    source: str,
+    tier: str,
+    output_dir: Path,
+    resolution_px: int,
+) -> list[Path]:
+    """Write category-partitioned parquet files. Returns list of paths.
+
+    Naming: mat-vis-<source>-<tier>-<category>.parquet
+    Each file stays under GitHub's 2 GB per-asset limit.
+    """
+    from collections import defaultdict
+
+    ok_records = [r for r in records if r.status == "ok"]
+    if not ok_records:
+        raise ValueError("No successful records to write")
+
+    by_cat: dict[str, list[MaterialRecord]] = defaultdict(list)
+    for rec in ok_records:
+        by_cat[rec.category].append(rec)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    paths: list[Path] = []
+
+    for cat in sorted(by_cat.keys()):
+        cat_records = by_cat[cat]
+        filename = f"mat-vis-{source}-{tier}-{cat}.parquet"
+        path = output_dir / filename
+        write_parquet(cat_records, source, tier, path, resolution_px)
+        paths.append(path)
+
+    log.info(
+        "wrote %d partitioned parquet files for %s %s (%d total records)",
+        len(paths),
+        source,
+        tier,
+        len(ok_records),
+    )
+    return paths
+
+
 # ── rowmap generation ───────────────────────────────────────────
 
 
@@ -142,7 +184,7 @@ def generate_rowmap(
     meta = pf.metadata
 
     ok_records = [r for r in records if r.status == "ok"]
-    parquet_name = f"mat-vis-{source}-{tier}.parquet"
+    parquet_name = parquet_path.name
 
     materials: dict[str, dict[str, dict[str, int]]] = {}
 


### PR DESCRIPTION
## Summary

- Category-partitioned parquet (fits GitHub 2GB limit)
- release-manifest.json for client auto-discovery (#22)
- watch.yml: daily upstream change detection → auto-bake dispatch
- ADRs updated for calver, Dagger, texture_hashes, thumbnails
- HF hosting issue created (#25) for 4K+ tiers

## After merge

Trigger full bakes:
```
gh workflow run bake.yml -f source=ambientcg -f tier=1k -f limit=0 -f release-tag=v2026.04.0
gh workflow run bake.yml -f source=polyhaven -f tier=1k -f limit=0 -f release-tag=v2026.04.0
gh workflow run bake.yml -f source=gpuopen -f tier=1k -f limit=0 -f release-tag=v2026.04.0
gh workflow run bake.yml -f source=physicallybased -f tier=1k -f limit=0 -f release-tag=v2026.04.0
```