### PR TITLE
feat: reference clients, test infra, parallel downloads, bake fixes

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -9,6 +9,11 @@ Usage:
     dagger call smoke-materialx      # verify MaterialX import (heavy)
     dagger call probe-sources        # verify upstream API connectivity
     dagger call test-all             # lint + test + smoke + probe
+    dagger call test-client-python   # pytest on Python reference client
+    dagger call test-client-js       # node --test on JS reference client
+    dagger call test-client-shell    # bash tests for shell reference client
+    dagger call test-client-rust     # cargo test for Rust reference client
+    dagger call test-clients         # all 4 client tests in parallel
     dagger call preflight            # verify GHCR auth before push
     dagger call push                 # preflight + build + push to GHCR
 """
@@ -250,6 +255,115 @@ class MatVisCi:
             f"=== test ===\n{test_out}\n"
             f"=== smoke ===\n{smoke_out}\n"
             f"=== probe ===\n{probe_out}"
+        )
+
+    # ── reference client tests ─────────────────────────────────────
+
+    @function
+    async def test_client_python(
+        self,
+        src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
+        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+    ) -> str:
+        """Run pytest on the Python reference client against a live release."""
+        context = src or dag.host().directory(".")
+        pip_cache = dag.cache_volume("pip-cache")
+        return await (
+            dag.container()
+            .from_("python:3.12-slim")
+            .with_mounted_cache("/root/.cache/pip", pip_cache)
+            .with_mounted_directory("/app", context)
+            .with_workdir("/app/clients/python")
+            .with_exec(["pip", "install", "--quiet", "pytest"])
+            .with_env_variable("MAT_VIS_TAG", tag)
+            .with_exec(["pytest", "test_client.py", "-v"])
+            .stdout()
+        )
+
+    @function
+    async def test_client_js(
+        self,
+        src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
+        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+    ) -> str:
+        """Run node --test on the JS reference client against a live release."""
+        context = src or dag.host().directory(".")
+        return await (
+            dag.container()
+            .from_("node:22-slim")
+            .with_mounted_directory("/app", context)
+            .with_workdir("/app/clients/js")
+            .with_env_variable("MAT_VIS_TAG", tag)
+            .with_exec(["node", "--test", "test_client.mjs"])
+            .stdout()
+        )
+
+    @function
+    async def test_client_shell(
+        self,
+        src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
+        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+    ) -> str:
+        """Run bash test script for the shell reference client against a live release."""
+        context = src or dag.host().directory(".")
+        return await (
+            dag.container()
+            .from_("alpine:3.20")
+            .with_exec(["apk", "add", "--no-cache", "bash", "curl", "jq", "vim"])
+            .with_mounted_directory("/app", context)
+            .with_workdir("/app/clients")
+            .with_env_variable("MAT_VIS_TAG", tag)
+            .with_exec(["bash", "test_client.sh"])
+            .stdout()
+        )
+
+    @function
+    async def test_client_rust(
+        self,
+        src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
+        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+    ) -> str:
+        """Run cargo test for the Rust reference client against a live release."""
+        context = src or dag.host().directory(".")
+        cargo_cache = dag.cache_volume("cargo-registry")
+        target_cache = dag.cache_volume("cargo-target")
+        return await (
+            dag.container()
+            .from_("rust:1.80-slim")
+            .with_exec(["apt-get", "update", "-qq"])
+            .with_exec(["apt-get", "install", "-y", "-qq", "pkg-config", "libssl-dev"])
+            .with_mounted_cache("/usr/local/cargo/registry", cargo_cache)
+            .with_mounted_cache("/app/clients/rust/target", target_cache)
+            .with_mounted_directory("/app", context)
+            .with_workdir("/app/clients/rust")
+            .with_env_variable("MAT_VIS_TAG", tag)
+            .with_exec(["cargo", "test", "--", "--test-threads=1"])
+            .stdout()
+        )
+
+    @function
+    async def test_clients(
+        self,
+        src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
+        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+    ) -> str:
+        """Run all 4 reference client test suites in parallel."""
+        context = src or dag.host().directory(".")
+
+        import asyncio
+
+        py_task = asyncio.ensure_future(self.test_client_python(context, tag))
+        js_task = asyncio.ensure_future(self.test_client_js(context, tag))
+        sh_task = asyncio.ensure_future(self.test_client_shell(context, tag))
+        rs_task = asyncio.ensure_future(self.test_client_rust(context, tag))
+
+        py_out, js_out, sh_out, rs_out = await asyncio.gather(py_task, js_task, sh_task, rs_task)
+
+        return (
+            f"=== python ===\n{py_out}\n"
+            f"=== js ===\n{js_out}\n"
+            f"=== shell ===\n{sh_out}\n"
+            f"=== rust ===\n{rs_out}"
         )
 
     # ── integration test ──────────────────────────────────────────

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -137,7 +137,10 @@ jobs:
           BRANCH="chore/bake-${SOURCE}-${{ inputs.tier }}"
           git config user.name "mat-vis-baker[bot]"
           git config user.email "mat-vis-baker[bot]@users.noreply.github.com"
+          # Fresh branch from dev — only data files will be added (no workflows)
           git checkout -b "$BRANCH"
+          # Ensure no workflow changes are staged
+          git checkout HEAD -- .github/ || true
           [ -d index ] && git add index/
           [ -d mtlx ] && git add mtlx/
           [ -f docs/catalog.md ] && git add docs/catalog.md

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -78,13 +78,28 @@ jobs:
           path: /tmp/bake-out/
           retention-days: 30
 
-      - name: Attach assets to release
+      - name: Ensure pre-release exists
         if: inputs.release-tag != 'v0000.00.0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          TAG="${{ inputs.release-tag }}"
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Creating pre-release $TAG..."
+            gh release create "$TAG" \
+              --title "$TAG — data release (pre-release)" \
+              --prerelease \
+              --notes "Data release. Assets attached by bake workflow. Promote with promote-data-release workflow."
+          fi
+
+      - name: Attach assets to pre-release
+        if: inputs.release-tag != 'v0000.00.0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ inputs.release-tag }}"
           for f in /tmp/bake-out/*.parquet /tmp/bake-out/*-rowmap.json /tmp/bake-out/release-manifest.json /tmp/bake-out/*.json; do
-            [ -f "$f" ] && gh release upload "${{ inputs.release-tag }}" "$f" --clobber || true
+            [ -f "$f" ] && gh release upload "$TAG" "$f" --clobber || true
           done
 
       - name: Generate app token for PR

--- a/.github/workflows/promote-data-release.yml
+++ b/.github/workflows/promote-data-release.yml
@@ -1,0 +1,96 @@
+---
+# Promote a data release from pre-release to latest.
+#
+# Flow:
+#   1. Bake workflow uploads parquet+rowmap to a pre-release (downloadable, testable)
+#   2. Data PRs (index+mtlx+thumbnails) reviewed and merged to dev
+#   3. This workflow: validates assets exist, clears pre-release flag
+#
+# Trigger: manual dispatch after data PR review.
+
+name: Promote data release
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        description: 'Calver tag to promote (e.g. v2026.04.0)'
+        required: true
+        type: string
+      dry-run:
+        description: 'Dry run — validate only, do not promote'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  promote:
+    name: Promote ${{ inputs.release-tag }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate release exists and is pre-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ inputs.release-tag }}"
+          RELEASE=$(gh release view "$TAG" --json tagName,isDraft,isPrerelease,assets --jq '.')
+
+          IS_DRAFT=$(echo "$RELEASE" | jq -r '.isDraft')
+          IS_PRE=$(echo "$RELEASE" | jq -r '.isPrerelease')
+          ASSET_COUNT=$(echo "$RELEASE" | jq '.assets | length')
+
+          echo "Tag: $TAG"
+          echo "Draft: $IS_DRAFT"
+          echo "Pre-release: $IS_PRE"
+          echo "Assets: $ASSET_COUNT"
+
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "ERROR: Release is still a draft. Bake workflow should create pre-releases."
+            exit 1
+          fi
+
+          if [ "$IS_PRE" != "true" ]; then
+            echo "ERROR: Release is not a pre-release. Already promoted?"
+            exit 1
+          fi
+
+          if [ "$ASSET_COUNT" -lt 2 ]; then
+            echo "ERROR: Release has fewer than 2 assets. Bake may not have completed."
+            exit 1
+          fi
+
+          echo "Assets:"
+          echo "$RELEASE" | jq -r '.assets[].name'
+          echo ""
+          echo "✓ Release $TAG is a valid pre-release with $ASSET_COUNT assets"
+
+      - name: Validate data PRs merged
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check for open bake PRs — all should be merged before promote
+          OPEN=$(gh pr list --search "data: bake" --state open --json number,title --jq '.[].title')
+          if [ -n "$OPEN" ]; then
+            echo "WARNING: Open data PRs found:"
+            echo "$OPEN"
+            echo ""
+            echo "Consider merging these before promoting."
+          else
+            echo "✓ No open data PRs"
+          fi
+
+      - name: Promote release
+        if: inputs.dry-run == false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ inputs.release-tag }}"
+          gh release edit "$TAG" --prerelease=false
+          echo "✓ Release $TAG promoted — no longer pre-release"
+          echo ""
+          echo "Release URL: https://github.com/MorePET/mat-vis/releases/tag/$TAG"

--- a/clients/js/mat-vis-client.mjs
+++ b/clients/js/mat-vis-client.mjs
@@ -1,0 +1,169 @@
+/**
+ * mat-vis reference client — browser + Node.js compatible.
+ * Uses fetch() API (native in modern browsers and Node 18+).
+ * Zero dependencies.
+ *
+ * Usage (browser):
+ *   import { MatVisClient } from './mat-vis-client.mjs';
+ *   const client = new MatVisClient();
+ *   const png = await client.fetchTexture('ambientcg', 'Rock064', 'color', '1k');
+ *   // png is an ArrayBuffer of raw PNG bytes
+ *
+ * Usage (Node CLI):
+ *   node mat-vis-client.mjs list
+ *   node mat-vis-client.mjs fetch ambientcg Rock064 color 1k -o rock.png
+ */
+
+const REPO = 'MorePET/mat-vis';
+const RELEASES = `https://github.com/${REPO}/releases`;
+const UA = 'mat-vis-client/0.1 (JavaScript)';
+
+export class MatVisClient {
+  #manifestUrl;
+  #manifest = null;
+  #rowmaps = new Map();
+
+  /**
+   * @param {Object} opts
+   * @param {string} [opts.tag] - Release tag (default: latest)
+   * @param {string} [opts.manifestUrl] - Override manifest URL
+   */
+  constructor({ tag, manifestUrl } = {}) {
+    if (manifestUrl) {
+      this.#manifestUrl = manifestUrl;
+    } else if (tag) {
+      this.#manifestUrl = `${RELEASES}/download/${tag}/release-manifest.json`;
+    } else {
+      this.#manifestUrl = `${RELEASES}/latest/download/release-manifest.json`;
+    }
+  }
+
+  async manifest() {
+    if (!this.#manifest) {
+      const resp = await fetch(this.#manifestUrl, { headers: { 'User-Agent': UA } });
+      if (!resp.ok) throw new Error(`Failed to fetch manifest: ${resp.status}`);
+      this.#manifest = await resp.json();
+    }
+    return this.#manifest;
+  }
+
+  async tiers() {
+    const m = await this.manifest();
+    return Object.keys(m.tiers);
+  }
+
+  async sources(tier = '1k') {
+    const m = await this.manifest();
+    return Object.keys(m.tiers[tier]?.sources || {});
+  }
+
+  async rowmap(source, tier) {
+    const key = `${source}-${tier}`;
+    if (!this.#rowmaps.has(key)) {
+      const m = await this.manifest();
+      const tierData = m.tiers[tier];
+      if (!tierData) throw new Error(`Tier ${tier} not found`);
+      const srcData = tierData.sources[source];
+      if (!srcData) throw new Error(`Source ${source} not found for tier ${tier}`);
+
+      const rowmapFiles = srcData.rowmap_files || [srcData.rowmap_file];
+      const url = tierData.base_url + rowmapFiles[0];
+      const resp = await fetch(url, { headers: { 'User-Agent': UA } });
+      if (!resp.ok) throw new Error(`Failed to fetch rowmap: ${resp.status}`);
+      this.#rowmaps.set(key, await resp.json());
+    }
+    return this.#rowmaps.get(key);
+  }
+
+  async materials(source, tier = '1k') {
+    const rm = await this.rowmap(source, tier);
+    return Object.keys(rm.materials).sort();
+  }
+
+  async channels(source, materialId, tier = '1k') {
+    const rm = await this.rowmap(source, tier);
+    return Object.keys(rm.materials[materialId] || {}).sort();
+  }
+
+  /**
+   * Fetch a single texture PNG via HTTP range read.
+   * @returns {Promise<ArrayBuffer>} Raw PNG bytes
+   */
+  async fetchTexture(source, materialId, channel, tier = '1k') {
+    const rm = await this.rowmap(source, tier);
+    const mat = rm.materials[materialId];
+    if (!mat) throw new Error(`Material ${materialId} not found`);
+    const rng = mat[channel];
+    if (!rng) throw new Error(`Channel ${channel} not found for ${materialId}`);
+
+    const m = await this.manifest();
+    const url = m.tiers[tier].base_url + rm.parquet_file;
+
+    const resp = await fetch(url, {
+      headers: {
+        'User-Agent': UA,
+        Range: `bytes=${rng.offset}-${rng.offset + rng.length - 1}`,
+      },
+    });
+
+    if (!resp.ok && resp.status !== 206) {
+      throw new Error(`Range read failed: ${resp.status}`);
+    }
+
+    const buf = await resp.arrayBuffer();
+    const magic = new Uint8Array(buf, 0, 4);
+    if (magic[0] !== 0x89 || magic[1] !== 0x50 || magic[2] !== 0x4e || magic[3] !== 0x47) {
+      throw new Error(`Expected PNG, got ${Array.from(magic).map((b) => b.toString(16)).join(' ')}`);
+    }
+
+    return buf;
+  }
+}
+
+// ── Node CLI ────────────────────────────────────────────────────
+
+const isNode = typeof process !== 'undefined' && process.argv;
+if (isNode && process.argv[1]?.endsWith('mat-vis-client.mjs')) {
+  const args = process.argv.slice(2);
+  const cmd = args[0];
+  const client = new MatVisClient({ tag: process.env.MAT_VIS_TAG });
+
+  (async () => {
+    try {
+      if (cmd === 'list') {
+        const tiers = await client.tiers();
+        for (const tier of tiers) {
+          const sources = await client.sources(tier);
+          console.log(`${tier}: ${sources.join(', ')}`);
+        }
+      } else if (cmd === 'materials') {
+        const mats = await client.materials(args[1], args[2] || '1k');
+        mats.forEach((m) => console.log(m));
+      } else if (cmd === 'fetch') {
+        const [, source, material, channel, tier = '1k'] = args;
+        const outIdx = args.indexOf('-o');
+        const output = outIdx >= 0 ? args[outIdx + 1] : null;
+
+        const buf = await client.fetchTexture(source, material, channel, tier);
+
+        if (output) {
+          const { writeFileSync } = await import('fs');
+          writeFileSync(output, Buffer.from(buf));
+          console.error(`Wrote ${output} (${buf.byteLength.toLocaleString()} bytes)`);
+        } else {
+          process.stdout.write(Buffer.from(buf));
+        }
+      } else {
+        console.log('mat-vis client (JavaScript)');
+        console.log('');
+        console.log('Usage:');
+        console.log('  node mat-vis-client.mjs list');
+        console.log('  node mat-vis-client.mjs materials <source> [tier]');
+        console.log('  node mat-vis-client.mjs fetch <source> <id> <channel> [tier] [-o file]');
+      }
+    } catch (e) {
+      console.error(`error: ${e.message}`);
+      process.exit(1);
+    }
+  })();
+}

--- a/clients/js/test_client.mjs
+++ b/clients/js/test_client.mjs
@@ -1,0 +1,71 @@
+/**
+ * Tests for the JavaScript reference client against live release data.
+ *
+ * Uses Node's built-in test runner (node:test) — zero dependencies.
+ * Run with: node --test test_client.mjs
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { MatVisClient } from './mat-vis-client.mjs';
+
+const TAG = process.env.MAT_VIS_TAG || 'v2026.04.0';
+const client = new MatVisClient({ tag: TAG });
+
+describe('manifest', () => {
+  it('fetches manifest with version field', async () => {
+    const m = await client.manifest();
+    assert.strictEqual(m.version, 1);
+    assert.ok(m.tiers, 'manifest should have tiers');
+  });
+
+  it('lists tiers including 1k', async () => {
+    const tiers = await client.tiers();
+    assert.ok(tiers.includes('1k'), 'tiers should include 1k');
+  });
+
+  it('lists sources including ambientcg', async () => {
+    const sources = await client.sources('1k');
+    assert.ok(sources.includes('ambientcg'), 'sources should include ambientcg');
+  });
+});
+
+describe('rowmap', () => {
+  it('fetches rowmap with materials', async () => {
+    const rm = await client.rowmap('ambientcg', '1k');
+    assert.ok(rm.materials, 'rowmap should have materials');
+    assert.ok(Object.keys(rm.materials).length > 0, 'materials should be non-empty');
+  });
+
+  it('lists material IDs', async () => {
+    const mats = await client.materials('ambientcg', '1k');
+    assert.ok(mats.length > 0, 'should have materials');
+    assert.ok(mats.every((m) => typeof m === 'string'), 'all IDs should be strings');
+  });
+
+  it('lists channels for first material', async () => {
+    const mats = await client.materials('ambientcg', '1k');
+    const channels = await client.channels('ambientcg', mats[0], '1k');
+    assert.ok(channels.includes('color'), 'channels should include color');
+  });
+});
+
+describe('fetch texture', () => {
+  it('returns valid PNG bytes via range read', async () => {
+    const mats = await client.materials('ambientcg', '1k');
+    const buf = await client.fetchTexture('ambientcg', mats[0], 'color', '1k');
+    const magic = new Uint8Array(buf, 0, 4);
+    assert.strictEqual(magic[0], 0x89);
+    assert.strictEqual(magic[1], 0x50); // P
+    assert.strictEqual(magic[2], 0x4e); // N
+    assert.strictEqual(magic[3], 0x47); // G
+    assert.ok(buf.byteLength > 1000, 'PNG should not be trivially small');
+  });
+
+  it('throws on nonexistent material', async () => {
+    await assert.rejects(
+      () => client.fetchTexture('ambientcg', 'NONEXISTENT_XYZ', 'color', '1k'),
+      /not found/i,
+    );
+  });
+});

--- a/clients/mat-vis.sh
+++ b/clients/mat-vis.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# mat-vis reference client — curl + jq only.
+#
+# Usage:
+#   mat-vis.sh list                                 # list sources × tiers
+#   mat-vis.sh materials ambientcg 1k               # list material IDs
+#   mat-vis.sh fetch ambientcg Rock064 color 1k     # fetch PNG → stdout
+#   mat-vis.sh fetch ambientcg Rock064 color 1k -o rock.png
+#
+# Environment:
+#   MAT_VIS_TAG     — release tag (default: latest)
+#   MAT_VIS_CACHE   — cache directory (default: ~/.cache/mat-vis)
+
+set -euo pipefail
+
+REPO="MorePET/mat-vis"
+RELEASES="https://github.com/$REPO/releases"
+TAG="${MAT_VIS_TAG:-latest}"
+CACHE="${MAT_VIS_CACHE:-$HOME/.cache/mat-vis}"
+UA="mat-vis-client/0.1 (shell)"
+
+# ── helpers ──────────────────────────────────────────────────────
+
+die() { echo "error: $*" >&2; exit 1; }
+
+fetch_json() {
+    local url=$1 cache_file=$2
+    if [ -f "$cache_file" ]; then
+        cat "$cache_file"
+        return
+    fi
+    mkdir -p "$(dirname "$cache_file")"
+    curl -sfL -H "User-Agent: $UA" "$url" -o "$cache_file" || die "Failed to fetch $url"
+    cat "$cache_file"
+}
+
+manifest_url() {
+    if [ "$TAG" = "latest" ]; then
+        echo "$RELEASES/latest/download/release-manifest.json"
+    else
+        echo "$RELEASES/download/$TAG/release-manifest.json"
+    fi
+}
+
+get_manifest() {
+    fetch_json "$(manifest_url)" "$CACHE/.manifest.json"
+}
+
+# ── commands ─────────────────────────────────────────────────────
+
+cmd_list() {
+    get_manifest | jq -r '.tiers | to_entries[] | "\(.key): \(.value.sources | keys | join(", "))"'
+}
+
+cmd_materials() {
+    local source=${1:?source required} tier=${2:-1k}
+    local manifest
+    manifest=$(get_manifest)
+
+    local base_url rowmap_file rowmap_url
+    base_url=$(echo "$manifest" | jq -r ".tiers[\"$tier\"].base_url")
+    rowmap_file=$(echo "$manifest" | jq -r ".tiers[\"$tier\"].sources[\"$source\"].rowmap_files[0]")
+
+    [ "$rowmap_file" = "null" ] && die "No rowmap for $source/$tier"
+
+    rowmap_url="${base_url}${rowmap_file}"
+    fetch_json "$rowmap_url" "$CACHE/.rowmaps/$rowmap_file" | jq -r '.materials | keys[]' | sort
+}
+
+cmd_fetch() {
+    local source=${1:?source required}
+    local material=${2:?material required}
+    local channel=${3:?channel required}
+    local tier=${4:-1k}
+    local output=""
+
+    # Parse -o flag
+    shift 4 || true
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -o) output="$2"; shift 2 ;;
+            *) die "Unknown flag: $1" ;;
+        esac
+    done
+
+    # Check cache
+    local cache_file="$CACHE/$source/$tier/$material/${channel}.png"
+    if [ -f "$cache_file" ]; then
+        if [ -n "$output" ]; then
+            cp "$cache_file" "$output"
+            echo "Cached: $output ($(wc -c < "$cache_file") bytes)" >&2
+        else
+            cat "$cache_file"
+        fi
+        return
+    fi
+
+    # Get manifest + rowmap
+    local manifest
+    manifest=$(get_manifest)
+    local base_url rowmap_file
+    base_url=$(echo "$manifest" | jq -r ".tiers[\"$tier\"].base_url")
+    rowmap_file=$(echo "$manifest" | jq -r ".tiers[\"$tier\"].sources[\"$source\"].rowmap_files[0]")
+    [ "$rowmap_file" = "null" ] && die "No rowmap for $source/$tier"
+
+    local rowmap
+    rowmap=$(fetch_json "${base_url}${rowmap_file}" "$CACHE/.rowmaps/$rowmap_file")
+
+    # Get offset + length
+    local offset length parquet_file
+    offset=$(echo "$rowmap" | jq -r ".materials[\"$material\"][\"$channel\"].offset")
+    length=$(echo "$rowmap" | jq -r ".materials[\"$material\"][\"$channel\"].length")
+    parquet_file=$(echo "$rowmap" | jq -r ".parquet_file")
+
+    [ "$offset" = "null" ] && die "$material/$channel not found in rowmap"
+
+    local parquet_url="${base_url}${parquet_file}"
+    local range_end=$((offset + length - 1))
+
+    # Range read
+    mkdir -p "$(dirname "$cache_file")"
+    curl -sfL -H "User-Agent: $UA" -H "Range: bytes=${offset}-${range_end}" "$parquet_url" -o "$cache_file" \
+        || die "Range read failed: $parquet_url"
+
+    # Verify PNG
+    local magic
+    magic=$(head -c4 "$cache_file" | xxd -p)
+    [ "$magic" = "89504e47" ] || die "Not a PNG (got $magic)"
+
+    if [ -n "$output" ]; then
+        cp "$cache_file" "$output"
+        echo "Fetched: $output ($length bytes)" >&2
+    else
+        cat "$cache_file"
+    fi
+}
+
+# ── dispatch ─────────────────────────────────────────────────────
+
+case "${1:-help}" in
+    list)       cmd_list ;;
+    materials)  shift; cmd_materials "$@" ;;
+    fetch)      shift; cmd_fetch "$@" ;;
+    *)
+        echo "mat-vis client — fetch PBR textures via HTTP range reads"
+        echo ""
+        echo "Usage:"
+        echo "  mat-vis.sh list                                 List sources × tiers"
+        echo "  mat-vis.sh materials <source> [tier]            List materials"
+        echo "  mat-vis.sh fetch <source> <id> <channel> [tier] [-o file]"
+        echo ""
+        echo "Environment:"
+        echo "  MAT_VIS_TAG     Release tag (default: latest)"
+        echo "  MAT_VIS_CACHE   Cache dir (default: ~/.cache/mat-vis)"
+        ;;
+esac

--- a/clients/python/adapters.py
+++ b/clients/python/adapters.py
@@ -1,0 +1,280 @@
+"""mat-vis output format adapters — Three.js, glTF, MaterialX.
+
+Converts generic scalars + texture bytes into renderer-specific formats.
+Pure Python, zero dependencies (uses only stdlib xml.etree for MaterialX).
+
+All functions take generic dicts — no Material class dependency:
+
+    from adapters import to_threejs, to_gltf, export_mtlx
+    result = to_threejs(scalars, textures)
+
+Field name mapping follows docs/specs/field-name-mapping.md.
+"""
+
+from __future__ import annotations
+
+import base64
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+# ── Field name mapping tables ───────────────────────────────────
+#
+# mat-vis channel name -> renderer property name
+# Canonical source: docs/specs/field-name-mapping.md
+
+_THREEJS_TEX_MAP: dict[str, str] = {
+    "color": "map",
+    "normal": "normalMap",
+    "roughness": "roughnessMap",
+    "metalness": "metalnessMap",
+    "ao": "aoMap",
+    "displacement": "displacementMap",
+    "emission": "emissiveMap",
+}
+
+_GLTF_TEX_MAP: dict[str, str] = {
+    "color": "baseColorTexture",
+    "normal": "normalTexture",
+    "ao": "occlusionTexture",
+    "emission": "emissiveTexture",
+    # roughness + metalness are packed into metallicRoughnessTexture
+    # handled separately in to_gltf()
+}
+
+_MTLX_TEX_MAP: dict[str, str] = {
+    "color": "base_color",
+    "normal": "normal",
+    "roughness": "specular_roughness",
+    "metalness": "metalness",
+    "ao": "occlusion",
+    "displacement": "displacement",
+    "emission": "emission_color",
+}
+
+
+# ── Helpers ─────────────────────────────────────────────────────
+
+
+def _to_data_uri(png_bytes: bytes) -> str:
+    """Encode PNG bytes as a base64 data URI."""
+    b64 = base64.b64encode(png_bytes).decode("ascii")
+    return f"data:image/png;base64,{b64}"
+
+
+def _color_hex_to_int(hex_str: str) -> int:
+    """Convert '#RRGGBB' hex string to an integer (Three.js color format).
+
+    >>> _color_hex_to_int('#A0522D')
+    10506797
+    """
+    return int(hex_str.lstrip("#"), 16)
+
+
+def _color_hex_to_rgba(hex_str: str) -> list[float]:
+    """Convert '#RRGGBB' to glTF [R, G, B, A] floats in [0, 1]."""
+    h = hex_str.lstrip("#")
+    r, g, b = int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+    return [r / 255.0, g / 255.0, b / 255.0, 1.0]
+
+
+# ── Three.js adapter ───────────────────────────────────────────
+
+
+def to_threejs(
+    scalars: dict,
+    textures: dict[str, bytes] | None = None,
+) -> dict:
+    """Convert to a Three.js MeshPhysicalMaterial parameter dict.
+
+    Args:
+        scalars: Material scalars. Expected keys (all optional):
+            - metalness (float 0-1)
+            - roughness (float 0-1)
+            - color_hex (str '#RRGGBB')
+            - ior (float)
+            - transmission (float 0-1)
+        textures: Channel name -> PNG bytes. Keys are mat-vis channel
+            names: color, normal, roughness, metalness, ao,
+            displacement, emission.
+
+    Returns:
+        Dict suitable for `new THREE.MeshPhysicalMaterial(result)`.
+        Textures are embedded as base64 data URIs.
+    """
+    textures = textures or {}
+    result: dict = {"type": "MeshPhysicalMaterial"}
+
+    # Scalars
+    if "metalness" in scalars and scalars["metalness"] is not None:
+        result["metalness"] = scalars["metalness"]
+    if "roughness" in scalars and scalars["roughness"] is not None:
+        result["roughness"] = scalars["roughness"]
+    if "color_hex" in scalars and scalars["color_hex"] is not None:
+        result["color"] = _color_hex_to_int(scalars["color_hex"])
+    if "ior" in scalars and scalars["ior"] is not None:
+        result["ior"] = scalars["ior"]
+    if "transmission" in scalars and scalars["transmission"] is not None:
+        result["transmission"] = scalars["transmission"]
+
+    # Textures as data URIs
+    for channel, prop in _THREEJS_TEX_MAP.items():
+        if channel in textures:
+            result[prop] = _to_data_uri(textures[channel])
+
+    return result
+
+
+# ── glTF adapter ────────────────────────────────────────────────
+
+
+def to_gltf(
+    scalars: dict,
+    textures: dict[str, bytes] | None = None,
+) -> dict:
+    """Convert to a glTF pbrMetallicRoughness material dict.
+
+    Args:
+        scalars: Same as to_threejs().
+        textures: Same as to_threejs().
+
+    Returns:
+        Dict conforming to glTF 2.0 material schema. Textures are
+        embedded as base64 data URIs in the 'uri' field. Does NOT
+        pack metalness+roughness into a single texture (that requires
+        image compositing which needs PIL or similar). Instead, scalar
+        factors are used when separate maps are provided.
+
+    Note:
+        Full glTF compliance for metallicRoughnessTexture packing
+        requires image processing (PIL/Pillow). This adapter provides
+        a best-effort output using scalar factors and separate texture
+        references. For production glTF export, consider using a
+        library like pygltflib.
+    """
+    textures = textures or {}
+    pbr: dict = {}
+    material: dict = {"pbrMetallicRoughness": pbr}
+
+    # Scalar factors
+    if "metalness" in scalars and scalars["metalness"] is not None:
+        pbr["metallicFactor"] = scalars["metalness"]
+    if "roughness" in scalars and scalars["roughness"] is not None:
+        pbr["roughnessFactor"] = scalars["roughness"]
+    if "color_hex" in scalars and scalars["color_hex"] is not None:
+        pbr["baseColorFactor"] = _color_hex_to_rgba(scalars["color_hex"])
+
+    # IOR extension
+    if "ior" in scalars and scalars["ior"] is not None:
+        material.setdefault("extensions", {})["KHR_materials_ior"] = {"ior": scalars["ior"]}
+
+    # Transmission extension
+    if "transmission" in scalars and scalars["transmission"] is not None:
+        material.setdefault("extensions", {})["KHR_materials_transmission"] = {
+            "transmissionFactor": scalars["transmission"]
+        }
+
+    # Textures
+    def _tex_ref(png_bytes: bytes) -> dict:
+        return {"source": {"uri": _to_data_uri(png_bytes)}}
+
+    for channel, prop in _GLTF_TEX_MAP.items():
+        if channel in textures:
+            if prop in ("normalTexture", "occlusionTexture", "emissiveTexture"):
+                material[prop] = _tex_ref(textures[channel])
+            else:
+                pbr[prop] = _tex_ref(textures[channel])
+
+    # metallicRoughnessTexture: only if BOTH metalness and roughness
+    # textures are available (proper packing needs image processing,
+    # so we note this limitation)
+    if "metalness" in textures and "roughness" in textures:
+        pbr["_note_metallicRoughnessTexture"] = (
+            "Separate metalness and roughness textures provided. "
+            "Pack into a single metallicRoughnessTexture (B=metal, G=rough) "
+            "for full glTF compliance."
+        )
+
+    return material
+
+
+# ── MaterialX adapter ──────────────────────────────────────────
+
+
+def export_mtlx(
+    scalars: dict,
+    textures: dict[str, bytes] | None = None,
+    output_dir: str | Path = ".",
+    *,
+    material_name: str = "Material",
+) -> Path:
+    """Export as MaterialX .mtlx XML with referenced PNG files.
+
+    Args:
+        scalars: Same as to_threejs().
+        textures: Same as to_threejs(). PNGs are written to output_dir.
+        output_dir: Directory for .mtlx and .png files.
+        material_name: Name for the material in the .mtlx document.
+
+    Returns:
+        Path to the written .mtlx file.
+    """
+    textures = textures or {}
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    # Root element
+    root = ET.Element("materialx", version="1.38")
+
+    # Standard surface node
+    sr = ET.SubElement(root, "standard_surface", name=f"SR_{material_name}", type="surfaceshader")
+
+    # Scalar inputs
+    if "metalness" in scalars and scalars["metalness"] is not None:
+        ET.SubElement(sr, "input", name="metalness", type="float", value=str(scalars["metalness"]))
+    if "roughness" in scalars and scalars["roughness"] is not None:
+        ET.SubElement(
+            sr, "input", name="specular_roughness", type="float", value=str(scalars["roughness"])
+        )
+    if "color_hex" in scalars and scalars["color_hex"] is not None:
+        rgba = _color_hex_to_rgba(scalars["color_hex"])
+        color_str = f"{rgba[0]:.4f}, {rgba[1]:.4f}, {rgba[2]:.4f}"
+        ET.SubElement(sr, "input", name="base_color", type="color3", value=color_str)
+    if "ior" in scalars and scalars["ior"] is not None:
+        ET.SubElement(sr, "input", name="specular_IOR", type="float", value=str(scalars["ior"]))
+    if "transmission" in scalars and scalars["transmission"] is not None:
+        ET.SubElement(
+            sr, "input", name="transmission", type="float", value=str(scalars["transmission"])
+        )
+
+    # Write texture PNGs and create image nodes
+    for channel, png_bytes in textures.items():
+        mtlx_input = _MTLX_TEX_MAP.get(channel)
+        if mtlx_input is None:
+            continue
+
+        # Write PNG file
+        png_filename = f"{material_name}_{channel}.png"
+        png_path = out / png_filename
+        png_path.write_bytes(png_bytes)
+
+        # Image node
+        img_node_name = f"IMG_{material_name}_{channel}"
+        img = ET.SubElement(root, "tiledimage", name=img_node_name, type="color3")
+        ET.SubElement(img, "input", name="file", type="filename", value=png_filename)
+
+        # Connect texture to shader input
+        ET.SubElement(sr, "input", name=mtlx_input, type="color3", nodename=img_node_name)
+
+    # Surface material
+    mat = ET.SubElement(root, "surfacematerial", name=material_name, type="material")
+    ET.SubElement(
+        mat, "input", name="surfaceshader", type="surfaceshader", nodename=f"SR_{material_name}"
+    )
+
+    # Write .mtlx file
+    tree = ET.ElementTree(root)
+    ET.indent(tree, space="  ")
+    mtlx_path = out / f"{material_name}.mtlx"
+    tree.write(mtlx_path, encoding="unicode", xml_declaration=True)
+
+    return mtlx_path

--- a/clients/python/mat_vis_client.py
+++ b/clients/python/mat_vis_client.py
@@ -9,11 +9,19 @@ Usage as library:
     client = MatVisClient()
     png_bytes = client.fetch_texture("ambientcg", "Rock064", "color", tier="1k")
 
+    # Search by category and scalar ranges
+    results = client.search("metal", roughness_range=(0.2, 0.6))
+
+    # Bulk prefetch all materials for offline use
+    client.prefetch("ambientcg", tier="1k")
+
 Usage as CLI:
     python mat_vis_client.py list                              # list sources × tiers
     python mat_vis_client.py materials ambientcg 1k            # list materials
     python mat_vis_client.py fetch ambientcg Rock064 color 1k  # fetch PNG → stdout
     python mat_vis_client.py fetch ambientcg Rock064 color 1k -o rock.png
+    python mat_vis_client.py search metal --roughness 0.2:0.6  # search materials
+    python mat_vis_client.py prefetch ambientcg 1k             # bulk download
 """
 
 from __future__ import annotations
@@ -26,9 +34,26 @@ from pathlib import Path
 
 REPO = "MorePET/mat-vis"
 GITHUB_RELEASES = f"https://github.com/{REPO}/releases"
+GITHUB_RAW = f"https://raw.githubusercontent.com/{REPO}"
 LATEST_MANIFEST_URL = f"{GITHUB_RELEASES}/latest/download/release-manifest.json"
 DEFAULT_CACHE_DIR = Path(os.environ.get("MAT_VIS_CACHE", Path.home() / ".cache" / "mat-vis"))
-USER_AGENT = "mat-vis-client/0.1 (Python)"
+USER_AGENT = "mat-vis-client/0.2 (Python)"
+
+# Valid categories per index-schema.json
+CATEGORIES = frozenset(
+    [
+        "metal",
+        "wood",
+        "stone",
+        "fabric",
+        "plastic",
+        "concrete",
+        "ceramic",
+        "glass",
+        "organic",
+        "other",
+    ]
+)
 
 
 def _get(url: str, headers: dict | None = None) -> bytes:
@@ -46,6 +71,13 @@ def _get_json(url: str) -> dict | list:
     return json.loads(_get(url))
 
 
+def _in_range(value: float | None, lo: float, hi: float) -> bool:
+    """Check if a value falls within [lo, hi]. None values never match."""
+    if value is None:
+        return False
+    return lo <= value <= hi
+
+
 class MatVisClient:
     """Lightweight client for mat-vis texture data."""
 
@@ -59,6 +91,8 @@ class MatVisClient:
         self._cache_dir = cache_dir or DEFAULT_CACHE_DIR
         self._manifest: dict | None = None
         self._rowmaps: dict[str, dict] = {}
+        self._indexes: dict[str, list[dict]] = {}
+        self._tag = tag
 
         if manifest_url:
             self._manifest_url = manifest_url
@@ -132,6 +166,132 @@ class MatVisClient:
         mat = rm.get("materials", {}).get(material_id, {})
         return sorted(mat.keys())
 
+    # ── Index & search ──────────────────────────────────────────
+
+    def _index_url(self, source: str) -> str:
+        """Build the URL for a source's index JSON."""
+        ref = self._tag or "main"
+        return f"{GITHUB_RAW}/{ref}/index/{source}.json"
+
+    def index(self, source: str) -> list[dict]:
+        """Fetch and cache the material index for a source.
+
+        Returns a list of material entries per index-schema.json.
+        """
+        if source not in self._indexes:
+            cache_path = self._cache_dir / ".indexes" / f"{source}.json"
+            if cache_path.exists():
+                self._indexes[source] = json.loads(cache_path.read_text())
+            else:
+                url = self._index_url(source)
+                self._indexes[source] = _get_json(url)
+                cache_path.parent.mkdir(parents=True, exist_ok=True)
+                cache_path.write_text(json.dumps(self._indexes[source], indent=2))
+        return self._indexes[source]
+
+    def search(
+        self,
+        category: str | None = None,
+        *,
+        roughness_range: tuple[float, float] | None = None,
+        metalness_range: tuple[float, float] | None = None,
+        source: str | None = None,
+        tier: str = "1k",
+    ) -> list[dict]:
+        """Search materials by category and scalar ranges.
+
+        Fetches index JSON for the given source (or all sources for the
+        tier) and filters locally. Returns matching index entries.
+
+        Args:
+            category: Filter by material category (e.g. "metal", "wood").
+            roughness_range: (min, max) roughness filter, inclusive.
+            metalness_range: (min, max) metalness filter, inclusive.
+            source: Limit search to one source. If None, searches all
+                    sources available for the given tier.
+            tier: Only return materials that have this tier available.
+        """
+        if category and category not in CATEGORIES:
+            raise ValueError(
+                f"Unknown category {category!r}. Valid: {', '.join(sorted(CATEGORIES))}"
+            )
+
+        sources = [source] if source else self.sources(tier)
+        results: list[dict] = []
+
+        for src in sources:
+            for entry in self.index(src):
+                if category and entry.get("category") != category:
+                    continue
+                if roughness_range and not _in_range(entry.get("roughness"), *roughness_range):
+                    continue
+                if metalness_range and not _in_range(entry.get("metalness"), *metalness_range):
+                    continue
+                if tier not in entry.get("available_tiers", []):
+                    continue
+                results.append(entry)
+
+        return results
+
+    # ── Bulk operations ─────────────────────────────────────────
+
+    def fetch_all_textures(
+        self,
+        source: str,
+        material_id: str,
+        tier: str = "1k",
+    ) -> dict[str, bytes]:
+        """Fetch all texture channels for a material.
+
+        Returns a dict mapping channel name to PNG bytes.
+        """
+        chs = self.channels(source, material_id, tier)
+        return {ch: self.fetch_texture(source, material_id, ch, tier) for ch in chs}
+
+    def prefetch(
+        self,
+        source: str,
+        tier: str = "1k",
+        *,
+        on_progress: callable | None = None,
+    ) -> int:
+        """Bulk download all materials for a source + tier to cache.
+
+        Args:
+            source: Source name (e.g. "ambientcg").
+            tier: Resolution tier (default "1k").
+            on_progress: Optional callback(material_id, index, total).
+
+        Returns the number of materials fetched.
+        """
+        mat_ids = self.materials(source, tier)
+        total = len(mat_ids)
+
+        for i, mid in enumerate(mat_ids):
+            self.fetch_all_textures(source, mid, tier)
+            if on_progress:
+                on_progress(mid, i + 1, total)
+
+        return total
+
+    def rowmap_entry(
+        self,
+        source: str,
+        material_id: str,
+        tier: str = "1k",
+    ) -> dict[str, dict]:
+        """Get raw rowmap offsets for a material (for DIY consumers).
+
+        Returns a dict of channel -> {offset, length, parquet_file}.
+        """
+        rm = self.rowmap(source, tier)
+        mat = rm["materials"][material_id]
+        parquet_file = rm["parquet_file"]
+        return {
+            ch: {"offset": info["offset"], "length": info["length"], "parquet_file": parquet_file}
+            for ch, info in mat.items()
+        }
+
     def fetch_texture(
         self,
         source: str,
@@ -179,6 +339,14 @@ class MatVisClient:
 # ── CLI ─────────────────────────────────────────────────────────
 
 
+def _parse_range(s: str) -> tuple[float, float]:
+    """Parse 'lo:hi' into a (lo, hi) tuple."""
+    parts = s.split(":")
+    if len(parts) != 2:
+        raise ValueError(f"Expected lo:hi, got {s!r}")
+    return float(parts[0]), float(parts[1])
+
+
 def main():
     import argparse
 
@@ -186,9 +354,9 @@ def main():
     parser.add_argument("--tag", help="Release tag (default: latest)")
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    sub.add_parser("list", help="List sources × tiers")
+    sub.add_parser("list", help="List sources x tiers")
 
-    p_mat = sub.add_parser("materials", help="List materials for a source × tier")
+    p_mat = sub.add_parser("materials", help="List materials for a source x tier")
     p_mat.add_argument("source")
     p_mat.add_argument("tier", nargs="?", default="1k")
 
@@ -198,6 +366,17 @@ def main():
     p_fetch.add_argument("channel")
     p_fetch.add_argument("tier", nargs="?", default="1k")
     p_fetch.add_argument("-o", "--output", help="Output file (default: stdout)")
+
+    p_search = sub.add_parser("search", help="Search materials by category / scalars")
+    p_search.add_argument("category", nargs="?", help="Category filter (e.g. metal, wood)")
+    p_search.add_argument("--source", help="Limit to one source")
+    p_search.add_argument("--tier", default="1k")
+    p_search.add_argument("--roughness", help="Roughness range as lo:hi")
+    p_search.add_argument("--metalness", help="Metalness range as lo:hi")
+
+    p_prefetch = sub.add_parser("prefetch", help="Bulk download all materials for source x tier")
+    p_prefetch.add_argument("source")
+    p_prefetch.add_argument("tier", nargs="?", default="1k")
 
     args = parser.parse_args()
     client = MatVisClient(tag=args.tag)
@@ -218,6 +397,34 @@ def main():
             print(f"Wrote {args.output} ({len(data):,} bytes)", file=sys.stderr)
         else:
             sys.stdout.buffer.write(data)
+
+    elif args.cmd == "search":
+        roughness = _parse_range(args.roughness) if args.roughness else None
+        metalness = _parse_range(args.metalness) if args.metalness else None
+        results = client.search(
+            args.category,
+            roughness_range=roughness,
+            metalness_range=metalness,
+            source=args.source,
+            tier=args.tier,
+        )
+        for entry in results:
+            scalars = []
+            if entry.get("roughness") is not None:
+                scalars.append(f"R={entry['roughness']:.2f}")
+            if entry.get("metalness") is not None:
+                scalars.append(f"M={entry['metalness']:.2f}")
+            scalar_str = f" ({', '.join(scalars)})" if scalars else ""
+            print(f"{entry['source']}/{entry['id']}  [{entry.get('category', '?')}]{scalar_str}")
+        print(f"\n{len(results)} result(s)", file=sys.stderr)
+
+    elif args.cmd == "prefetch":
+
+        def _progress(mid: str, i: int, total: int) -> None:
+            print(f"[{i}/{total}] {mid}", file=sys.stderr)
+
+        n = client.prefetch(args.source, args.tier, on_progress=_progress)
+        print(f"Prefetched {n} materials", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/clients/python/mat_vis_client.py
+++ b/clients/python/mat_vis_client.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""mat-vis reference client — pure Python, zero dependencies.
+
+Fetches PBR textures from mat-vis GitHub Releases via HTTP range reads.
+Uses only urllib (stdlib). No pyarrow, no binary deps.
+
+Usage as library:
+    from mat_vis_client import MatVisClient
+    client = MatVisClient()
+    png_bytes = client.fetch_texture("ambientcg", "Rock064", "color", tier="1k")
+
+Usage as CLI:
+    python mat_vis_client.py list                              # list sources × tiers
+    python mat_vis_client.py materials ambientcg 1k            # list materials
+    python mat_vis_client.py fetch ambientcg Rock064 color 1k  # fetch PNG → stdout
+    python mat_vis_client.py fetch ambientcg Rock064 color 1k -o rock.png
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO = "MorePET/mat-vis"
+GITHUB_RELEASES = f"https://github.com/{REPO}/releases"
+LATEST_MANIFEST_URL = f"{GITHUB_RELEASES}/latest/download/release-manifest.json"
+DEFAULT_CACHE_DIR = Path(os.environ.get("MAT_VIS_CACHE", Path.home() / ".cache" / "mat-vis"))
+USER_AGENT = "mat-vis-client/0.1 (Python)"
+
+
+def _get(url: str, headers: dict | None = None) -> bytes:
+    """HTTP GET with User-Agent."""
+    hdrs = {"User-Agent": USER_AGENT}
+    if headers:
+        hdrs.update(headers)
+    req = urllib.request.Request(url, headers=hdrs)
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return resp.read()
+
+
+def _get_json(url: str) -> dict | list:
+    """Fetch and parse JSON."""
+    return json.loads(_get(url))
+
+
+class MatVisClient:
+    """Lightweight client for mat-vis texture data."""
+
+    def __init__(
+        self,
+        *,
+        manifest_url: str | None = None,
+        cache_dir: Path | None = None,
+        tag: str | None = None,
+    ):
+        self._cache_dir = cache_dir or DEFAULT_CACHE_DIR
+        self._manifest: dict | None = None
+        self._rowmaps: dict[str, dict] = {}
+
+        if manifest_url:
+            self._manifest_url = manifest_url
+        elif tag:
+            self._manifest_url = f"{GITHUB_RELEASES}/download/{tag}/release-manifest.json"
+        else:
+            self._manifest_url = LATEST_MANIFEST_URL
+
+    @property
+    def manifest(self) -> dict:
+        """Fetch and cache the release manifest."""
+        if self._manifest is None:
+            cache_path = self._cache_dir / ".manifest.json"
+            if cache_path.exists():
+                self._manifest = json.loads(cache_path.read_text())
+            else:
+                self._manifest = _get_json(self._manifest_url)
+                cache_path.parent.mkdir(parents=True, exist_ok=True)
+                cache_path.write_text(json.dumps(self._manifest, indent=2))
+        return self._manifest
+
+    def sources(self, tier: str = "1k") -> list[str]:
+        """List available sources for a tier."""
+        tier_data = self.manifest.get("tiers", {}).get(tier, {})
+        return list(tier_data.get("sources", {}).keys())
+
+    def tiers(self) -> list[str]:
+        """List available tiers."""
+        return list(self.manifest.get("tiers", {}).keys())
+
+    def rowmap(self, source: str, tier: str, category: str | None = None) -> dict:
+        """Fetch and cache a rowmap."""
+        key = f"{source}-{tier}-{category or 'all'}"
+        if key not in self._rowmaps:
+            tier_data = self.manifest["tiers"][tier]
+            base_url = tier_data["base_url"]
+            src_data = tier_data["sources"][source]
+
+            # Find matching rowmap file
+            rowmap_files = src_data.get("rowmap_files", [])
+            if not rowmap_files:
+                # Legacy single rowmap
+                rowmap_file = src_data.get("rowmap_file", f"{source}-{tier}-rowmap.json")
+                rowmap_files = [rowmap_file]
+
+            if category:
+                matches = [f for f in rowmap_files if category in f]
+                rowmap_file = matches[0] if matches else rowmap_files[0]
+            else:
+                rowmap_file = rowmap_files[0]
+
+            cache_path = self._cache_dir / ".rowmaps" / rowmap_file
+            if cache_path.exists():
+                self._rowmaps[key] = json.loads(cache_path.read_text())
+            else:
+                url = base_url + rowmap_file
+                self._rowmaps[key] = _get_json(url)
+                cache_path.parent.mkdir(parents=True, exist_ok=True)
+                cache_path.write_text(json.dumps(self._rowmaps[key], indent=2))
+
+        return self._rowmaps[key]
+
+    def materials(self, source: str, tier: str) -> list[str]:
+        """List material IDs available for a source × tier."""
+        rm = self.rowmap(source, tier)
+        return sorted(rm.get("materials", {}).keys())
+
+    def channels(self, source: str, material_id: str, tier: str) -> list[str]:
+        """List channels available for a material."""
+        rm = self.rowmap(source, tier)
+        mat = rm.get("materials", {}).get(material_id, {})
+        return sorted(mat.keys())
+
+    def fetch_texture(
+        self,
+        source: str,
+        material_id: str,
+        channel: str,
+        tier: str = "1k",
+    ) -> bytes:
+        """Fetch a single texture PNG via HTTP range read.
+
+        Returns raw PNG bytes. Caches locally.
+        """
+        # Check cache first
+        cache_path = self._cache_dir / source / tier / material_id / f"{channel}.png"
+        if cache_path.exists():
+            return cache_path.read_bytes()
+
+        # Find in rowmap
+        rm = self.rowmap(source, tier)
+        mat = rm["materials"][material_id]
+        rng = mat[channel]
+        offset = rng["offset"]
+        length = rng["length"]
+
+        # Find parquet URL
+        tier_data = self.manifest["tiers"][tier]
+        base_url = tier_data["base_url"]
+        parquet_file = rm["parquet_file"]
+        url = base_url + parquet_file
+
+        # HTTP range read
+        range_header = f"bytes={offset}-{offset + length - 1}"
+        data = _get(url, headers={"Range": range_header})
+
+        # Verify PNG
+        if data[:4] != b"\x89PNG":
+            raise ValueError(f"Expected PNG, got {data[:4]!r}")
+
+        # Cache
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_bytes(data)
+
+        return data
+
+
+# ── CLI ─────────────────────────────────────────────────────────
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="mat-vis-client", description="mat-vis texture client")
+    parser.add_argument("--tag", help="Release tag (default: latest)")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("list", help="List sources × tiers")
+
+    p_mat = sub.add_parser("materials", help="List materials for a source × tier")
+    p_mat.add_argument("source")
+    p_mat.add_argument("tier", nargs="?", default="1k")
+
+    p_fetch = sub.add_parser("fetch", help="Fetch a texture PNG")
+    p_fetch.add_argument("source")
+    p_fetch.add_argument("material")
+    p_fetch.add_argument("channel")
+    p_fetch.add_argument("tier", nargs="?", default="1k")
+    p_fetch.add_argument("-o", "--output", help="Output file (default: stdout)")
+
+    args = parser.parse_args()
+    client = MatVisClient(tag=args.tag)
+
+    if args.cmd == "list":
+        for tier in client.tiers():
+            sources = client.sources(tier)
+            print(f"{tier}: {', '.join(sources)}")
+
+    elif args.cmd == "materials":
+        for mid in client.materials(args.source, args.tier):
+            print(mid)
+
+    elif args.cmd == "fetch":
+        data = client.fetch_texture(args.source, args.material, args.channel, args.tier)
+        if args.output:
+            Path(args.output).write_bytes(data)
+            print(f"Wrote {args.output} ({len(data):,} bytes)", file=sys.stderr)
+        else:
+            sys.stdout.buffer.write(data)
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/python/test_client.py
+++ b/clients/python/test_client.py
@@ -1,92 +1,523 @@
-"""Tests for the Python reference client against live release data."""
+"""Tests for the Python reference client and adapters.
+
+Unit tests (mocked) run unconditionally.
+Live tests hit the real release and are skipped with MAT_VIS_SKIP_LIVE_TESTS=1.
+"""
 
 from __future__ import annotations
 
+import json
 import os
 import tempfile
 from pathlib import Path
-
+from unittest.mock import patch
 import sys
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent))
-from mat_vis_client import MatVisClient  # noqa: E402
+from mat_vis_client import MatVisClient, _in_range  # noqa: E402
+from adapters import (  # noqa: E402
+    to_threejs,
+    to_gltf,
+    export_mtlx,
+    _color_hex_to_int,
+    _color_hex_to_rgba,
+    _to_data_uri,
+)
 
-# Skip all tests if no network or release not available
-pytestmark = pytest.mark.skipif(
+# ── Fixtures ────────────────────────────────────────────────────
+
+# Minimal PNG: 1x1 red pixel (valid PNG header + IHDR + IDAT + IEND)
+TINY_PNG = (
+    b"\x89PNG\r\n\x1a\n"
+    b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02"
+    b"\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f"
+    b"\x00\x00\x01\x01\x00\x05\x18\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+MOCK_MANIFEST = {
+    "version": 1,
+    "release_tag": "v2026.04.0",
+    "tiers": {
+        "1k": {
+            "base_url": "https://example.com/releases/download/v2026.04.0/",
+            "sources": {
+                "ambientcg": {
+                    "parquet_files": ["ambientcg-1k.parquet"],
+                    "rowmap_file": "ambientcg-1k-rowmap.json",
+                },
+                "polyhaven": {
+                    "parquet_files": ["polyhaven-1k.parquet"],
+                    "rowmap_file": "polyhaven-1k-rowmap.json",
+                },
+            },
+        }
+    },
+}
+
+MOCK_ROWMAP = {
+    "parquet_file": "ambientcg-1k.parquet",
+    "materials": {
+        "Rock064": {
+            "color": {"offset": 0, "length": 1024},
+            "normal": {"offset": 1024, "length": 2048},
+            "roughness": {"offset": 3072, "length": 512},
+        },
+        "Metal032": {
+            "color": {"offset": 4000, "length": 800},
+            "metalness": {"offset": 4800, "length": 600},
+            "roughness": {"offset": 5400, "length": 500},
+        },
+    },
+}
+
+MOCK_INDEX_AMBIENTCG = [
+    {
+        "id": "Rock064",
+        "source": "ambientcg",
+        "name": "Rough Granite",
+        "category": "stone",
+        "roughness": 0.8,
+        "metalness": 0.0,
+        "color_hex": "#A0522D",
+        "ior": 1.5,
+        "source_url": "https://ambientcg.com/view?id=Rock064",
+        "source_license": "CC0-1.0",
+        "available_tiers": ["1k", "2k"],
+        "maps": ["color", "normal", "roughness"],
+        "last_updated": "2025-01-15",
+    },
+    {
+        "id": "Metal032",
+        "source": "ambientcg",
+        "name": "Brushed Steel",
+        "category": "metal",
+        "roughness": 0.3,
+        "metalness": 1.0,
+        "color_hex": "#C0C0C0",
+        "ior": 2.5,
+        "source_url": "https://ambientcg.com/view?id=Metal032",
+        "source_license": "CC0-1.0",
+        "available_tiers": ["1k"],
+        "maps": ["color", "metalness", "roughness"],
+        "last_updated": "2025-02-10",
+    },
+    {
+        "id": "Wood045",
+        "source": "ambientcg",
+        "name": "Oak Planks",
+        "category": "wood",
+        "roughness": 0.6,
+        "metalness": 0.0,
+        "color_hex": "#8B4513",
+        "ior": 1.5,
+        "source_url": "https://ambientcg.com/view?id=Wood045",
+        "source_license": "CC0-1.0",
+        "available_tiers": ["1k", "2k", "4k"],
+        "maps": ["color", "normal", "roughness", "ao"],
+        "last_updated": "2025-03-01",
+    },
+]
+
+
+@pytest.fixture
+def mock_client():
+    """Client with mocked HTTP and temp cache."""
+    with tempfile.TemporaryDirectory() as tmp:
+        client = MatVisClient(tag="v2026.04.0", cache_dir=Path(tmp))
+        # Pre-populate manifest cache so no HTTP needed
+        cache_path = Path(tmp) / ".manifest.json"
+        cache_path.write_text(json.dumps(MOCK_MANIFEST))
+        yield client
+
+
+# ── Helper tests ────────────────────────────────────────────────
+
+
+class TestInRange:
+    def test_within_range(self):
+        assert _in_range(0.5, 0.0, 1.0)
+
+    def test_at_boundaries(self):
+        assert _in_range(0.0, 0.0, 1.0)
+        assert _in_range(1.0, 0.0, 1.0)
+
+    def test_outside_range(self):
+        assert not _in_range(1.5, 0.0, 1.0)
+
+    def test_none_value(self):
+        assert not _in_range(None, 0.0, 1.0)
+
+
+# ── Client unit tests (mocked HTTP) ────────────────────────────
+
+
+class TestClientManifest:
+    def test_manifest_loads_from_cache(self, mock_client):
+        m = mock_client.manifest
+        assert m["version"] == 1
+        assert "tiers" in m
+
+    def test_tiers(self, mock_client):
+        assert mock_client.tiers() == ["1k"]
+
+    def test_sources(self, mock_client):
+        sources = mock_client.sources("1k")
+        assert "ambientcg" in sources
+        assert "polyhaven" in sources
+
+
+class TestClientRowmap:
+    @patch("mat_vis_client._get_json", return_value=MOCK_ROWMAP)
+    def test_fetch_rowmap(self, mock_get, mock_client):
+        rm = mock_client.rowmap("ambientcg", "1k")
+        assert "materials" in rm
+        assert "Rock064" in rm["materials"]
+
+    @patch("mat_vis_client._get_json", return_value=MOCK_ROWMAP)
+    def test_materials_list(self, mock_get, mock_client):
+        mats = mock_client.materials("ambientcg", "1k")
+        assert "Metal032" in mats
+        assert "Rock064" in mats
+
+    @patch("mat_vis_client._get_json", return_value=MOCK_ROWMAP)
+    def test_channels(self, mock_get, mock_client):
+        channels = mock_client.channels("ambientcg", "Rock064", "1k")
+        assert "color" in channels
+        assert "normal" in channels
+
+    @patch("mat_vis_client._get_json", return_value=MOCK_ROWMAP)
+    def test_rowmap_entry(self, mock_get, mock_client):
+        entry = mock_client.rowmap_entry("ambientcg", "Rock064", "1k")
+        assert "color" in entry
+        assert entry["color"]["offset"] == 0
+        assert entry["color"]["length"] == 1024
+        assert entry["color"]["parquet_file"] == "ambientcg-1k.parquet"
+
+
+class TestClientSearch:
+    @patch("mat_vis_client._get_json")
+    def test_search_by_category(self, mock_get, mock_client):
+        mock_get.return_value = MOCK_INDEX_AMBIENTCG
+        results = mock_client.search("metal", source="ambientcg")
+        assert len(results) == 1
+        assert results[0]["id"] == "Metal032"
+
+    @patch("mat_vis_client._get_json")
+    def test_search_by_roughness_range(self, mock_get, mock_client):
+        mock_get.return_value = MOCK_INDEX_AMBIENTCG
+        results = mock_client.search(roughness_range=(0.5, 0.9), source="ambientcg")
+        # Rock064 (0.8) and Wood045 (0.6) match
+        ids = {r["id"] for r in results}
+        assert ids == {"Rock064", "Wood045"}
+
+    @patch("mat_vis_client._get_json")
+    def test_search_by_metalness_range(self, mock_get, mock_client):
+        mock_get.return_value = MOCK_INDEX_AMBIENTCG
+        results = mock_client.search(metalness_range=(0.9, 1.0), source="ambientcg")
+        assert len(results) == 1
+        assert results[0]["id"] == "Metal032"
+
+    @patch("mat_vis_client._get_json")
+    def test_search_combined_filters(self, mock_get, mock_client):
+        mock_get.return_value = MOCK_INDEX_AMBIENTCG
+        results = mock_client.search(
+            "stone",
+            roughness_range=(0.5, 1.0),
+            source="ambientcg",
+        )
+        assert len(results) == 1
+        assert results[0]["id"] == "Rock064"
+
+    @patch("mat_vis_client._get_json")
+    def test_search_tier_filter(self, mock_get, mock_client):
+        mock_get.return_value = MOCK_INDEX_AMBIENTCG
+        # Metal032 is only available in 1k
+        results = mock_client.search("metal", source="ambientcg", tier="2k")
+        assert len(results) == 0
+
+    @patch("mat_vis_client._get_json")
+    def test_search_no_filters_returns_all(self, mock_get, mock_client):
+        mock_get.return_value = MOCK_INDEX_AMBIENTCG
+        results = mock_client.search(source="ambientcg")
+        assert len(results) == 3
+
+    def test_search_invalid_category(self, mock_client):
+        with pytest.raises(ValueError, match="Unknown category"):
+            mock_client.search("invalid_category")
+
+
+class TestClientPrefetch:
+    @patch("mat_vis_client._get_json", return_value=MOCK_ROWMAP)
+    @patch("mat_vis_client._get", return_value=TINY_PNG)
+    def test_prefetch_downloads_all(self, mock_http, mock_json, mock_client):
+        progress = []
+        n = mock_client.prefetch(
+            "ambientcg",
+            "1k",
+            on_progress=lambda mid, i, total: progress.append((mid, i, total)),
+        )
+        assert n == 2  # Rock064 and Metal032
+        assert len(progress) == 2
+        assert progress[-1][1] == 2  # last index
+        assert progress[-1][2] == 2  # total
+
+    @patch("mat_vis_client._get_json", return_value=MOCK_ROWMAP)
+    @patch("mat_vis_client._get", return_value=TINY_PNG)
+    def test_fetch_all_textures(self, mock_http, mock_json, mock_client):
+        textures = mock_client.fetch_all_textures("ambientcg", "Rock064", "1k")
+        assert set(textures.keys()) == {"color", "normal", "roughness"}
+        for ch, data in textures.items():
+            assert data[:4] == b"\x89PNG", f"{ch} is not PNG"
+
+
+# ── Adapter helper tests ───────────────────────────────────────
+
+
+class TestAdapterHelpers:
+    def test_color_hex_to_int(self):
+        assert _color_hex_to_int("#A0522D") == 0xA0522D
+        assert _color_hex_to_int("#000000") == 0
+        assert _color_hex_to_int("#FFFFFF") == 0xFFFFFF
+
+    def test_color_hex_to_rgba(self):
+        rgba = _color_hex_to_rgba("#FF0000")
+        assert rgba == [1.0, 0.0, 0.0, 1.0]
+
+    def test_to_data_uri(self):
+        uri = _to_data_uri(b"\x89PNG")
+        assert uri.startswith("data:image/png;base64,")
+        assert "iVBO" in uri  # base64 of \x89P
+
+
+# ── Three.js adapter tests ─────────────────────────────────────
+
+
+class TestToThreejs:
+    def test_scalars_only(self):
+        result = to_threejs({"metalness": 1.0, "roughness": 0.3, "color_hex": "#C0C0C0"})
+        assert result["type"] == "MeshPhysicalMaterial"
+        assert result["metalness"] == 1.0
+        assert result["roughness"] == 0.3
+        assert result["color"] == 0xC0C0C0
+
+    def test_with_textures(self):
+        result = to_threejs(
+            {"metalness": 0.5},
+            {"color": TINY_PNG, "normal": TINY_PNG},
+        )
+        assert "map" in result
+        assert result["map"].startswith("data:image/png;base64,")
+        assert "normalMap" in result
+
+    def test_empty_scalars(self):
+        result = to_threejs({})
+        assert result == {"type": "MeshPhysicalMaterial"}
+
+    def test_none_scalars_skipped(self):
+        result = to_threejs({"metalness": None, "roughness": 0.5})
+        assert "metalness" not in result
+        assert result["roughness"] == 0.5
+
+    def test_ior_and_transmission(self):
+        result = to_threejs({"ior": 1.5, "transmission": 0.8})
+        assert result["ior"] == 1.5
+        assert result["transmission"] == 0.8
+
+    def test_all_texture_channels(self):
+        textures = {
+            ch: TINY_PNG
+            for ch in [
+                "color",
+                "normal",
+                "roughness",
+                "metalness",
+                "ao",
+                "displacement",
+                "emission",
+            ]
+        }
+        result = to_threejs({}, textures)
+        assert "map" in result
+        assert "normalMap" in result
+        assert "roughnessMap" in result
+        assert "metalnessMap" in result
+        assert "aoMap" in result
+        assert "displacementMap" in result
+        assert "emissiveMap" in result
+
+
+# ── glTF adapter tests ─────────────────────────────────────────
+
+
+class TestToGltf:
+    def test_scalars_only(self):
+        result = to_gltf({"metalness": 1.0, "roughness": 0.3, "color_hex": "#FF0000"})
+        pbr = result["pbrMetallicRoughness"]
+        assert pbr["metallicFactor"] == 1.0
+        assert pbr["roughnessFactor"] == 0.3
+        assert pbr["baseColorFactor"] == [1.0, 0.0, 0.0, 1.0]
+
+    def test_with_textures(self):
+        result = to_gltf(
+            {},
+            {"color": TINY_PNG, "normal": TINY_PNG},
+        )
+        pbr = result["pbrMetallicRoughness"]
+        assert "baseColorTexture" in pbr
+        assert "normalTexture" in result
+
+    def test_ior_extension(self):
+        result = to_gltf({"ior": 1.5})
+        assert result["extensions"]["KHR_materials_ior"]["ior"] == 1.5
+
+    def test_transmission_extension(self):
+        result = to_gltf({"transmission": 0.8})
+        ext = result["extensions"]["KHR_materials_transmission"]
+        assert ext["transmissionFactor"] == 0.8
+
+    def test_packed_texture_note(self):
+        result = to_gltf(
+            {},
+            {"metalness": TINY_PNG, "roughness": TINY_PNG},
+        )
+        pbr = result["pbrMetallicRoughness"]
+        assert "_note_metallicRoughnessTexture" in pbr
+
+    def test_empty_scalars(self):
+        result = to_gltf({})
+        assert result == {"pbrMetallicRoughness": {}}
+
+
+# ── MaterialX adapter tests ────────────────────────────────────
+
+
+class TestExportMtlx:
+    def test_scalars_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = export_mtlx(
+                {"metalness": 1.0, "roughness": 0.3, "color_hex": "#C0C0C0"},
+                output_dir=tmp,
+                material_name="TestMat",
+            )
+            assert path.exists()
+            assert path.suffix == ".mtlx"
+
+            content = path.read_text()
+            assert "standard_surface" in content
+            assert 'name="metalness"' in content
+            assert 'name="specular_roughness"' in content
+            assert 'name="base_color"' in content
+
+    def test_with_textures(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = export_mtlx(
+                {"metalness": 0.5},
+                {"color": TINY_PNG, "normal": TINY_PNG},
+                output_dir=tmp,
+                material_name="TexMat",
+            )
+            assert path.exists()
+
+            # Check PNG files were written
+            assert (Path(tmp) / "TexMat_color.png").exists()
+            assert (Path(tmp) / "TexMat_normal.png").exists()
+
+            content = path.read_text()
+            assert "tiledimage" in content
+            assert "TexMat_color.png" in content
+
+    def test_creates_output_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            nested = Path(tmp) / "sub" / "dir"
+            path = export_mtlx({}, output_dir=nested)
+            assert path.exists()
+            assert nested.is_dir()
+
+    def test_material_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = export_mtlx({}, output_dir=tmp, material_name="MyMat")
+            assert path.name == "MyMat.mtlx"
+
+            content = path.read_text()
+            assert 'name="MyMat"' in content
+            assert 'name="SR_MyMat"' in content
+
+
+# ── Live tests (network required) ──────────────────────────────
+
+live = pytest.mark.skipif(
     os.environ.get("MAT_VIS_SKIP_LIVE_TESTS") == "1",
     reason="MAT_VIS_SKIP_LIVE_TESTS=1",
 )
 
 
 @pytest.fixture
-def client():
-    """Client pointed at v2026.04.0 pre-release with temp cache."""
+def live_client():
+    """Client pointed at v2026.04.0 with temp cache."""
     with tempfile.TemporaryDirectory() as tmp:
         yield MatVisClient(tag="v2026.04.0", cache_dir=Path(tmp))
 
 
-class TestManifest:
-    def test_fetch_manifest(self, client):
-        m = client.manifest
+@live
+class TestLiveManifest:
+    def test_fetch_manifest(self, live_client):
+        m = live_client.manifest
         assert m["version"] == 1
         assert "tiers" in m
 
-    def test_tiers(self, client):
-        tiers = client.tiers()
+    def test_tiers(self, live_client):
+        tiers = live_client.tiers()
         assert "1k" in tiers
 
-    def test_sources(self, client):
-        sources = client.sources("1k")
+    def test_sources(self, live_client):
+        sources = live_client.sources("1k")
         assert "ambientcg" in sources
 
 
-class TestRowmap:
-    def test_fetch_rowmap(self, client):
-        rm = client.rowmap("ambientcg", "1k")
+@live
+class TestLiveRowmap:
+    def test_fetch_rowmap(self, live_client):
+        rm = live_client.rowmap("ambientcg", "1k")
         assert "materials" in rm
         assert len(rm["materials"]) > 0
 
-    def test_materials_list(self, client):
-        mats = client.materials("ambientcg", "1k")
+    def test_materials_list(self, live_client):
+        mats = live_client.materials("ambientcg", "1k")
         assert len(mats) > 0
         assert all(isinstance(m, str) for m in mats)
 
-    def test_channels(self, client):
-        mats = client.materials("ambientcg", "1k")
-        channels = client.channels("ambientcg", mats[0], "1k")
+    def test_channels(self, live_client):
+        mats = live_client.materials("ambientcg", "1k")
+        channels = live_client.channels("ambientcg", mats[0], "1k")
         assert "color" in channels
 
 
-class TestFetchTexture:
-    def test_fetch_returns_png(self, client):
-        mats = client.materials("ambientcg", "1k")
-        data = client.fetch_texture("ambientcg", mats[0], "color", "1k")
+@live
+class TestLiveFetchTexture:
+    def test_fetch_returns_png(self, live_client):
+        mats = live_client.materials("ambientcg", "1k")
+        data = live_client.fetch_texture("ambientcg", mats[0], "color", "1k")
         assert data[:4] == b"\x89PNG"
-        assert len(data) > 1000  # not trivially small
+        assert len(data) > 1000
 
-    def test_fetch_caches_locally(self, client):
-        mats = client.materials("ambientcg", "1k")
+    def test_fetch_caches_locally(self, live_client):
+        mats = live_client.materials("ambientcg", "1k")
         mid = mats[0]
-
-        # First fetch — from network
-        data1 = client.fetch_texture("ambientcg", mid, "color", "1k")
-
-        # Second fetch — from cache
-        data2 = client.fetch_texture("ambientcg", mid, "color", "1k")
-
+        data1 = live_client.fetch_texture("ambientcg", mid, "color", "1k")
+        data2 = live_client.fetch_texture("ambientcg", mid, "color", "1k")
         assert data1 == data2
 
-    def test_fetch_multiple_channels(self, client):
-        mats = client.materials("ambientcg", "1k")
+    def test_fetch_multiple_channels(self, live_client):
+        mats = live_client.materials("ambientcg", "1k")
         mid = mats[0]
-        channels = client.channels("ambientcg", mid, "1k")
-
-        for ch in channels[:3]:  # test first 3 channels
-            data = client.fetch_texture("ambientcg", mid, ch, "1k")
+        channels = live_client.channels("ambientcg", mid, "1k")
+        for ch in channels[:3]:
+            data = live_client.fetch_texture("ambientcg", mid, ch, "1k")
             assert data[:4] == b"\x89PNG", f"{mid}/{ch} is not PNG"
 
-    def test_fetch_nonexistent_material_raises(self, client):
+    def test_fetch_nonexistent_material_raises(self, live_client):
         with pytest.raises(KeyError):
-            client.fetch_texture("ambientcg", "NONEXISTENT_XYZ", "color", "1k")
+            live_client.fetch_texture("ambientcg", "NONEXISTENT_XYZ", "color", "1k")

--- a/clients/python/test_client.py
+++ b/clients/python/test_client.py
@@ -1,0 +1,92 @@
+"""Tests for the Python reference client against live release data."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+from mat_vis_client import MatVisClient  # noqa: E402
+
+# Skip all tests if no network or release not available
+pytestmark = pytest.mark.skipif(
+    os.environ.get("MAT_VIS_SKIP_LIVE_TESTS") == "1",
+    reason="MAT_VIS_SKIP_LIVE_TESTS=1",
+)
+
+
+@pytest.fixture
+def client():
+    """Client pointed at v2026.04.0 pre-release with temp cache."""
+    with tempfile.TemporaryDirectory() as tmp:
+        yield MatVisClient(tag="v2026.04.0", cache_dir=Path(tmp))
+
+
+class TestManifest:
+    def test_fetch_manifest(self, client):
+        m = client.manifest
+        assert m["version"] == 1
+        assert "tiers" in m
+
+    def test_tiers(self, client):
+        tiers = client.tiers()
+        assert "1k" in tiers
+
+    def test_sources(self, client):
+        sources = client.sources("1k")
+        assert "ambientcg" in sources
+
+
+class TestRowmap:
+    def test_fetch_rowmap(self, client):
+        rm = client.rowmap("ambientcg", "1k")
+        assert "materials" in rm
+        assert len(rm["materials"]) > 0
+
+    def test_materials_list(self, client):
+        mats = client.materials("ambientcg", "1k")
+        assert len(mats) > 0
+        assert all(isinstance(m, str) for m in mats)
+
+    def test_channels(self, client):
+        mats = client.materials("ambientcg", "1k")
+        channels = client.channels("ambientcg", mats[0], "1k")
+        assert "color" in channels
+
+
+class TestFetchTexture:
+    def test_fetch_returns_png(self, client):
+        mats = client.materials("ambientcg", "1k")
+        data = client.fetch_texture("ambientcg", mats[0], "color", "1k")
+        assert data[:4] == b"\x89PNG"
+        assert len(data) > 1000  # not trivially small
+
+    def test_fetch_caches_locally(self, client):
+        mats = client.materials("ambientcg", "1k")
+        mid = mats[0]
+
+        # First fetch — from network
+        data1 = client.fetch_texture("ambientcg", mid, "color", "1k")
+
+        # Second fetch — from cache
+        data2 = client.fetch_texture("ambientcg", mid, "color", "1k")
+
+        assert data1 == data2
+
+    def test_fetch_multiple_channels(self, client):
+        mats = client.materials("ambientcg", "1k")
+        mid = mats[0]
+        channels = client.channels("ambientcg", mid, "1k")
+
+        for ch in channels[:3]:  # test first 3 channels
+            data = client.fetch_texture("ambientcg", mid, ch, "1k")
+            assert data[:4] == b"\x89PNG", f"{mid}/{ch} is not PNG"
+
+    def test_fetch_nonexistent_material_raises(self, client):
+        with pytest.raises(KeyError):
+            client.fetch_texture("ambientcg", "NONEXISTENT_XYZ", "color", "1k")

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "mat-vis-client"
+version = "0.1.0"
+edition = "2021"
+description = "mat-vis PBR texture client — fetch textures via HTTP range reads"
+license = "MIT"
+
+[[bin]]
+name = "mat-vis"
+path = "src/main.rs"
+
+[dependencies]
+reqwest = { version = "0.12", features = ["blocking", "json"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+clap = { version = "4", features = ["derive"] }

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -1,0 +1,181 @@
+//! mat-vis reference client — Rust.
+//!
+//! Usage:
+//!   mat-vis list                                 # list sources × tiers
+//!   mat-vis materials ambientcg 1k               # list material IDs
+//!   mat-vis fetch ambientcg Rock064 color 1k     # fetch PNG → stdout
+//!   mat-vis fetch ambientcg Rock064 color 1k -o rock.png
+
+use clap::{Parser, Subcommand};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+const REPO: &str = "MorePET/mat-vis";
+const UA: &str = "mat-vis-client/0.1 (Rust)";
+
+#[derive(Deserialize)]
+struct Manifest {
+    tiers: HashMap<String, TierEntry>,
+}
+
+#[derive(Deserialize)]
+struct TierEntry {
+    base_url: String,
+    sources: HashMap<String, SourceEntry>,
+}
+
+#[derive(Deserialize)]
+struct SourceEntry {
+    parquet_files: Vec<String>,
+    rowmap_files: Option<Vec<String>>,
+    rowmap_file: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct Rowmap {
+    parquet_file: String,
+    materials: HashMap<String, HashMap<String, ChannelRange>>,
+}
+
+#[derive(Deserialize)]
+struct ChannelRange {
+    offset: u64,
+    length: u64,
+}
+
+fn client() -> reqwest::blocking::Client {
+    reqwest::blocking::Client::builder()
+        .user_agent(UA)
+        .build()
+        .expect("Failed to build HTTP client")
+}
+
+fn fetch_manifest(tag: &Option<String>) -> Manifest {
+    let url = match tag {
+        Some(t) => format!("https://github.com/{REPO}/releases/download/{t}/release-manifest.json"),
+        None => format!("https://github.com/{REPO}/releases/latest/download/release-manifest.json"),
+    };
+    client()
+        .get(&url)
+        .send()
+        .expect("Failed to fetch manifest")
+        .json()
+        .expect("Failed to parse manifest")
+}
+
+fn fetch_rowmap(base_url: &str, src: &SourceEntry) -> Rowmap {
+    let files = src
+        .rowmap_files
+        .as_deref()
+        .or(src.rowmap_file.as_deref().map(std::slice::from_ref))
+        .expect("No rowmap file");
+    let url = format!("{}{}", base_url, files[0]);
+    client()
+        .get(&url)
+        .send()
+        .expect("Failed to fetch rowmap")
+        .json()
+        .expect("Failed to parse rowmap")
+}
+
+fn range_read(url: &str, offset: u64, length: u64) -> Vec<u8> {
+    let range = format!("bytes={}-{}", offset, offset + length - 1);
+    let resp = client()
+        .get(url)
+        .header("Range", &range)
+        .send()
+        .expect("Range read failed");
+    resp.bytes().expect("Failed to read body").to_vec()
+}
+
+#[derive(Parser)]
+#[command(name = "mat-vis", about = "mat-vis PBR texture client")]
+struct Cli {
+    #[arg(long, help = "Release tag (default: latest)")]
+    tag: Option<String>,
+
+    #[command(subcommand)]
+    cmd: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// List sources × tiers
+    List,
+    /// List materials for a source × tier
+    Materials {
+        source: String,
+        #[arg(default_value = "1k")]
+        tier: String,
+    },
+    /// Fetch a texture PNG
+    Fetch {
+        source: String,
+        material: String,
+        channel: String,
+        #[arg(default_value = "1k")]
+        tier: String,
+        #[arg(short, long, help = "Output file (default: stdout)")]
+        output: Option<PathBuf>,
+    },
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let manifest = fetch_manifest(&cli.tag);
+
+    match cli.cmd {
+        Commands::List => {
+            for (tier, entry) in &manifest.tiers {
+                let sources: Vec<&String> = entry.sources.keys().collect();
+                println!("{tier}: {}", sources.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", "));
+            }
+        }
+        Commands::Materials { source, tier } => {
+            let tier_data = manifest.tiers.get(&tier).expect("Tier not found");
+            let src_data = tier_data.sources.get(&source).expect("Source not found");
+            let rowmap = fetch_rowmap(&tier_data.base_url, src_data);
+            let mut ids: Vec<&String> = rowmap.materials.keys().collect();
+            ids.sort();
+            for id in ids {
+                println!("{id}");
+            }
+        }
+        Commands::Fetch {
+            source,
+            material,
+            channel,
+            tier,
+            output,
+        } => {
+            let tier_data = manifest.tiers.get(&tier).expect("Tier not found");
+            let src_data = tier_data.sources.get(&source).expect("Source not found");
+            let rowmap = fetch_rowmap(&tier_data.base_url, src_data);
+            let mat = rowmap.materials.get(&material).expect("Material not found");
+            let rng = mat.get(&channel).expect("Channel not found");
+
+            let url = format!("{}{}", tier_data.base_url, rowmap.parquet_file);
+            let data = range_read(&url, rng.offset, rng.length);
+
+            // Verify PNG
+            assert!(
+                data.len() >= 4 && data[..4] == [0x89, 0x50, 0x4E, 0x47],
+                "Expected PNG, got {:?}",
+                &data[..4.min(data.len())]
+            );
+
+            match output {
+                Some(path) => {
+                    fs::write(&path, &data).expect("Failed to write file");
+                    eprintln!("Wrote {} ({} bytes)", path.display(), data.len());
+                }
+                None => {
+                    std::io::stdout().write_all(&data).expect("Failed to write to stdout");
+                }
+            }
+        }
+    }
+}

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -123,6 +123,10 @@ enum Commands {
     },
 }
 
+fn tag_from_env() -> Option<String> {
+    std::env::var("MAT_VIS_TAG").ok().or_else(|| Some("v2026.04.0".to_string()))
+}
+
 fn main() {
     let cli = Cli::parse();
     let manifest = fetch_manifest(&cli.tag);
@@ -177,5 +181,64 @@ fn main() {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_tag() -> Option<String> {
+        Some(std::env::var("MAT_VIS_TAG").unwrap_or_else(|_| "v2026.04.0".to_string()))
+    }
+
+    #[test]
+    fn test_fetch_manifest() {
+        let tag = test_tag();
+        let manifest = fetch_manifest(&tag);
+        assert!(manifest.tiers.contains_key("1k"), "manifest should have 1k tier");
+    }
+
+    #[test]
+    fn test_list_sources() {
+        let tag = test_tag();
+        let manifest = fetch_manifest(&tag);
+        let tier = manifest.tiers.get("1k").expect("1k tier missing");
+        assert!(tier.sources.contains_key("ambientcg"), "should have ambientcg source");
+    }
+
+    #[test]
+    fn test_fetch_rowmap() {
+        let tag = test_tag();
+        let manifest = fetch_manifest(&tag);
+        let tier = manifest.tiers.get("1k").expect("1k tier missing");
+        let src = tier.sources.get("ambientcg").expect("ambientcg missing");
+        let rowmap = fetch_rowmap(&tier.base_url, src);
+        assert!(!rowmap.materials.is_empty(), "rowmap should have materials");
+    }
+
+    #[test]
+    fn test_range_read_png() {
+        let tag = test_tag();
+        let manifest = fetch_manifest(&tag);
+        let tier = manifest.tiers.get("1k").expect("1k tier missing");
+        let src = tier.sources.get("ambientcg").expect("ambientcg missing");
+        let rowmap = fetch_rowmap(&tier.base_url, src);
+
+        let (mid, channels) = rowmap.materials.iter().next().expect("no materials");
+        let rng = channels.get("color").unwrap_or_else(|| {
+            channels.values().next().expect("no channels")
+        });
+
+        let url = format!("{}{}", tier.base_url, rowmap.parquet_file);
+        let data = range_read(&url, rng.offset, rng.length);
+
+        assert!(data.len() > 4, "data too small");
+        assert_eq!(
+            &data[..4],
+            &[0x89, 0x50, 0x4E, 0x47],
+            "expected PNG magic bytes for material {mid}"
+        );
+        assert!(data.len() > 1000, "PNG should not be trivially small");
     }
 }

--- a/clients/test_client.sh
+++ b/clients/test_client.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Tests for the shell reference client against live release data.
+#
+# Requires: curl, jq, xxd (usually in vim or xxd package)
+# Run with: bash test_client.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CLIENT="$SCRIPT_DIR/mat-vis.sh"
+
+export MAT_VIS_TAG="${MAT_VIS_TAG:-v2026.04.0}"
+export MAT_VIS_CACHE
+MAT_VIS_CACHE="$(mktemp -d)"
+
+trap 'rm -rf "$MAT_VIS_CACHE"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_ok() {
+    local desc="$1"; shift
+    if "$@" >/dev/null 2>&1; then
+        echo "  PASS $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL $desc"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local desc="$1" output="$2" needle="$3"
+    if echo "$output" | grep -q "$needle"; then
+        echo "  PASS $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL $desc — expected '$needle' in output"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== manifest ==="
+
+LIST_OUTPUT=$("$CLIENT" list)
+assert_contains "list includes 1k tier" "$LIST_OUTPUT" "1k"
+assert_contains "list includes ambientcg" "$LIST_OUTPUT" "ambientcg"
+
+echo "=== materials ==="
+
+MATERIALS=$("$CLIENT" materials ambientcg 1k)
+MAT_COUNT=$(echo "$MATERIALS" | wc -l | tr -d ' ')
+FIRST_MAT=$(echo "$MATERIALS" | head -1)
+
+if [ "$MAT_COUNT" -gt 0 ] && [ -n "$FIRST_MAT" ]; then
+    echo "  PASS materials list non-empty ($MAT_COUNT materials)"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL materials list empty"
+    FAIL=$((FAIL + 1))
+fi
+
+echo "=== fetch texture ==="
+
+TEXTURE_FILE="$MAT_VIS_CACHE/test_output.png"
+"$CLIENT" fetch ambientcg "$FIRST_MAT" color 1k -o "$TEXTURE_FILE"
+
+# Verify file exists and is non-trivial
+if [ -f "$TEXTURE_FILE" ] && [ "$(wc -c < "$TEXTURE_FILE")" -gt 1000 ]; then
+    echo "  PASS fetch wrote file ($(wc -c < "$TEXTURE_FILE") bytes)"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL fetch did not produce valid file"
+    FAIL=$((FAIL + 1))
+fi
+
+# Verify PNG magic bytes
+MAGIC=$(head -c4 "$TEXTURE_FILE" | xxd -p)
+if [ "$MAGIC" = "89504e47" ]; then
+    echo "  PASS PNG magic bytes verified"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL expected PNG magic 89504e47, got $MAGIC"
+    FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/src/mat_vis_baker/sources/ambientcg.py
+++ b/src/mat_vis_baker/sources/ambientcg.py
@@ -153,6 +153,47 @@ def _filter_with_downloads(entries: list[dict], tier: str) -> list[dict]:
     return [e for e in entries if _extract_download_url(e, tier) is not None]
 
 
+MAX_WORKERS = 10
+
+
+def _fetch_one(entry: dict, tier: str, output_dir: Path, mtlx_dir: Path | None) -> MaterialRecord:
+    """Fetch a single material. Called from thread pool."""
+    mid = entry.get("assetId", "")
+    name = entry.get("displayName", mid)
+    try:
+        dl_url = _extract_download_url(entry, tier)
+        resp = retry_request(dl_url)
+        textures = _extract_maps_from_zip(resp.content, mid, output_dir, mtlx_dir=mtlx_dir)
+
+        if not textures:
+            return MaterialRecord(
+                id=mid, source="ambientcg", name=name, category="other", status="failed"
+            )
+
+        cat = normalize_category(entry.get("displayCategory", entry.get("category", "")))
+        tags = entry.get("tags", [])
+        release_date = (entry.get("releaseDate") or "")[:10]
+
+        return MaterialRecord(
+            id=mid,
+            source="ambientcg",
+            name=name,
+            category=cat,
+            tags=tags,
+            source_url=f"https://ambientcg.com/a/{mid}",
+            source_license="CC0-1.0",
+            last_updated=release_date,
+            available_tiers=[tier],
+            maps=sorted(textures.keys()),
+            texture_paths=textures,
+        )
+    except Exception:
+        log.exception("%s: fetch failed", mid)
+        return MaterialRecord(
+            id=mid, source="ambientcg", name=name, category="other", status="failed"
+        )
+
+
 def fetch(
     tier: str,
     output_dir: Path,
@@ -161,68 +202,36 @@ def fetch(
     session: requests.Session | None = None,
     mtlx_dir: Path | None = None,
 ) -> list[MaterialRecord]:
-    """Fetch ambientcg materials for a given tier."""
+    """Fetch ambientcg materials for a given tier. Downloads in parallel."""
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
     s = session or requests.Session()
     entries = discover(session=s)
 
-    # Filter to entries with downloads for this tier, then apply limit
     entries = _filter_with_downloads(entries, tier)
     log.info("%d materials have downloads for tier %s", len(entries), tier)
     if limit:
         entries = entries[:limit]
 
     output_dir.mkdir(parents=True, exist_ok=True)
+
     records: list[MaterialRecord] = []
     ok = 0
     failed = 0
 
-    for entry in entries:
-        mid = entry.get("assetId", "")
-        name = entry.get("displayName", mid)
-        try:
-            dl_url = _extract_download_url(entry, tier)
-            resp = retry_request(dl_url, session=s)
-            textures = _extract_maps_from_zip(resp.content, mid, output_dir, mtlx_dir=mtlx_dir)
-
-            if not textures:
-                log.warning("%s: no textures in ZIP", mid)
-                failed += 1
-                records.append(
-                    MaterialRecord(
-                        id=mid, source="ambientcg", name=name, category="other", status="failed"
-                    )
-                )
-                continue
-
-            cat = normalize_category(entry.get("displayCategory", entry.get("category", "")))
-            tags = entry.get("tags", [])
-            release_date = (entry.get("releaseDate") or "")[:10]
-
-            rec = MaterialRecord(
-                id=mid,
-                source="ambientcg",
-                name=name,
-                category=cat,
-                tags=tags,
-                source_url=f"https://ambientcg.com/a/{mid}",
-                source_license="CC0-1.0",
-                last_updated=release_date,
-                available_tiers=[tier],
-                maps=sorted(textures.keys()),
-                texture_paths=textures,
-            )
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        futures = {
+            pool.submit(_fetch_one, entry, tier, output_dir, mtlx_dir): entry for entry in entries
+        }
+        for i, future in enumerate(as_completed(futures), 1):
+            rec = future.result()
             records.append(rec)
-            ok += 1
-            log.info("%s: ok (%d textures)", mid, len(textures))
-
-        except Exception:
-            log.exception("%s: fetch failed", mid)
-            failed += 1
-            records.append(
-                MaterialRecord(
-                    id=mid, source="ambientcg", name=name, category="other", status="failed"
-                )
-            )
+            if rec.status == "ok":
+                ok += 1
+            else:
+                failed += 1
+            if i % 100 == 0 or i == len(entries):
+                log.info("progress: %d/%d fetched (%d ok, %d failed)", i, len(entries), ok, failed)
 
     log.info("ambientcg: %d ok, %d failed / %d total", ok, failed, len(entries))
     return records

--- a/src/mat_vis_baker/sources/polyhaven.py
+++ b/src/mat_vis_baker/sources/polyhaven.py
@@ -102,15 +102,62 @@ def _download_maps(
 # ── main fetch ──────────────────────────────────────────────────
 
 
+MAX_WORKERS = 8  # polyhaven does per-map downloads, so fewer workers to be polite
+
+
+def _fetch_one(slug: str, meta: dict, tier: str, output_dir: Path) -> MaterialRecord:
+    """Fetch a single polyhaven material. Called from thread pool."""
+    name = meta.get("name", slug)
+    try:
+        file_info = _fetch_files(slug)
+        textures = _download_maps(file_info, tier, output_dir, slug)
+
+        if not textures:
+            return MaterialRecord(
+                id=slug, source="polyhaven", name=name, category="other", status="failed"
+            )
+
+        raw_cats = meta.get("categories", [])
+        if isinstance(raw_cats, dict):
+            cat_str = next(iter(raw_cats.keys()), "")
+        elif isinstance(raw_cats, list) and raw_cats:
+            cat_str = raw_cats[0]
+        else:
+            cat_str = ""
+        cat = normalize_category(cat_str)
+        tags = meta.get("tags", [])
+
+        return MaterialRecord(
+            id=slug,
+            source="polyhaven",
+            name=name,
+            category=cat,
+            tags=tags,
+            source_url=f"https://polyhaven.com/a/{slug}",
+            source_license="CC0-1.0",
+            last_updated="",
+            available_tiers=[tier],
+            maps=sorted(textures.keys()),
+            texture_paths=textures,
+        )
+    except Exception:
+        log.exception("%s: fetch failed", slug)
+        return MaterialRecord(
+            id=slug, source="polyhaven", name=name, category="other", status="failed"
+        )
+
+
 def fetch(
     tier: str,
     output_dir: Path,
     *,
     limit: int | None = None,
     session: requests.Session | None = None,
-    mtlx_dir: Path | None = None,  # polyhaven has no mtlx, param for interface consistency
+    mtlx_dir: Path | None = None,
 ) -> list[MaterialRecord]:
-    """Fetch polyhaven materials for a given tier."""
+    """Fetch polyhaven materials for a given tier. Downloads in parallel."""
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
     s = session or requests.Session()
     assets = discover(session=s)
 
@@ -119,62 +166,24 @@ def fetch(
         slugs = slugs[:limit]
 
     output_dir.mkdir(parents=True, exist_ok=True)
+
     records: list[MaterialRecord] = []
     ok = 0
     failed = 0
 
-    for slug in slugs:
-        meta = assets[slug]
-        name = meta.get("name", slug)
-        try:
-            file_info = _fetch_files(slug, session=s)
-            textures = _download_maps(file_info, tier, output_dir, slug, session=s)
-
-            if not textures:
-                log.warning("%s: no textures for tier %s", slug, tier)
-                failed += 1
-                records.append(
-                    MaterialRecord(
-                        id=slug, source="polyhaven", name=name, category="other", status="failed"
-                    )
-                )
-                continue
-
-            raw_cats = meta.get("categories", [])
-            if isinstance(raw_cats, dict):
-                cat_str = next(iter(raw_cats.keys()), "")
-            elif isinstance(raw_cats, list) and raw_cats:
-                cat_str = raw_cats[0]
-            else:
-                cat_str = ""
-            cat = normalize_category(cat_str)
-            tags = meta.get("tags", [])
-
-            rec = MaterialRecord(
-                id=slug,
-                source="polyhaven",
-                name=name,
-                category=cat,
-                tags=tags,
-                source_url=f"https://polyhaven.com/a/{slug}",
-                source_license="CC0-1.0",
-                last_updated="",
-                available_tiers=[tier],
-                maps=sorted(textures.keys()),
-                texture_paths=textures,
-            )
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        futures = {
+            pool.submit(_fetch_one, slug, assets[slug], tier, output_dir): slug for slug in slugs
+        }
+        for i, future in enumerate(as_completed(futures), 1):
+            rec = future.result()
             records.append(rec)
-            ok += 1
-            log.info("%s: ok (%d textures)", slug, len(textures))
-
-        except Exception:
-            log.exception("%s: fetch failed", slug)
-            failed += 1
-            records.append(
-                MaterialRecord(
-                    id=slug, source="polyhaven", name=name, category="other", status="failed"
-                )
-            )
+            if rec.status == "ok":
+                ok += 1
+            else:
+                failed += 1
+            if i % 50 == 0 or i == len(slugs):
+                log.info("progress: %d/%d fetched (%d ok, %d failed)", i, len(slugs), ok, failed)
 
     log.info("polyhaven: %d ok, %d failed / %d total", ok, failed, len(slugs))
     return records


### PR DESCRIPTION
## Summary
- 4 reference clients (Python, JS, Rust, Shell) with tests
- Dagger test infrastructure for all client languages
- Python client: search, prefetch, adapters (to_threejs, to_gltf, export_mtlx)
- 49 Python tests (39 mocked + 10 live)
- Parallel downloads: 10× ambientcg, 8× polyhaven
- Bake workflow fixes: git push permissions, artifact upload, index JSON to release
- Pre-release data flow + promote-data-release workflow