### PR TITLE
fix: partitioned rowmap merging, dynamic size splitting, client tests CI

### DIFF
--- a/clients/python/mat_vis_client.py
+++ b/clients/python/mat_vis_client.py
@@ -124,34 +124,47 @@ class MatVisClient:
         return list(self.manifest.get("tiers", {}).keys())
 
     def rowmap(self, source: str, tier: str, category: str | None = None) -> dict:
-        """Fetch and cache a rowmap."""
+        """Fetch and cache rowmaps. Merges partitioned rowmaps into one."""
         key = f"{source}-{tier}-{category or 'all'}"
         if key not in self._rowmaps:
             tier_data = self.manifest["tiers"][tier]
             base_url = tier_data["base_url"]
             src_data = tier_data["sources"][source]
 
-            # Find matching rowmap file
             rowmap_files = src_data.get("rowmap_files", [])
             if not rowmap_files:
-                # Legacy single rowmap
                 rowmap_file = src_data.get("rowmap_file", f"{source}-{tier}-rowmap.json")
                 rowmap_files = [rowmap_file]
 
             if category:
-                matches = [f for f in rowmap_files if category in f]
-                rowmap_file = matches[0] if matches else rowmap_files[0]
-            else:
-                rowmap_file = rowmap_files[0]
+                rowmap_files = [f for f in rowmap_files if category in f] or rowmap_files[:1]
 
-            cache_path = self._cache_dir / ".rowmaps" / rowmap_file
-            if cache_path.exists():
-                self._rowmaps[key] = json.loads(cache_path.read_text())
-            else:
-                url = base_url + rowmap_file
-                self._rowmaps[key] = _get_json(url)
-                cache_path.parent.mkdir(parents=True, exist_ok=True)
-                cache_path.write_text(json.dumps(self._rowmaps[key], indent=2))
+            # Fetch all partition rowmaps and merge materials
+            merged: dict = {"materials": {}}
+            for rmf in rowmap_files:
+                cache_path = self._cache_dir / ".rowmaps" / rmf
+                if cache_path.exists():
+                    rm = json.loads(cache_path.read_text())
+                else:
+                    url = base_url + rmf
+                    rm = _get_json(url)
+                    cache_path.parent.mkdir(parents=True, exist_ok=True)
+                    cache_path.write_text(json.dumps(rm, indent=2))
+
+                # Each partitioned rowmap has its own parquet_file
+                pq_file = rm.get("parquet_file", "")
+                for mid, channels in rm.get("materials", {}).items():
+                    # Tag each channel with its parquet file for range reads
+                    for ch_data in channels.values():
+                        ch_data["parquet_file"] = pq_file
+                    merged["materials"][mid] = channels
+
+                # Keep metadata from last rowmap (they're all the same except materials)
+                for k in ("version", "release_tag", "source", "tier"):
+                    if k in rm:
+                        merged[k] = rm[k]
+
+            self._rowmaps[key] = merged
 
         return self._rowmaps[key]
 
@@ -315,10 +328,10 @@ class MatVisClient:
         offset = rng["offset"]
         length = rng["length"]
 
-        # Find parquet URL
+        # Find parquet URL (per-partition from merged rowmap)
         tier_data = self.manifest["tiers"][tier]
         base_url = tier_data["base_url"]
-        parquet_file = rm["parquet_file"]
+        parquet_file = rng.get("parquet_file") or rm.get("parquet_file", "")
         url = base_url + parquet_file
 
         # HTTP range read

--- a/src/mat_vis_baker/parquet_writer.py
+++ b/src/mat_vis_baker/parquet_writer.py
@@ -102,6 +102,19 @@ def write_parquet(
     return output_path
 
 
+MAX_PARTITION_BYTES = 1_800_000_000  # 1.8 GB — stay under GitHub's 2 GB limit
+
+
+def _estimate_partition_size(records: list[MaterialRecord]) -> int:
+    """Estimate parquet size from texture file sizes."""
+    total = 0
+    for rec in records:
+        for ch, path in rec.texture_paths.items():
+            if not ch.startswith("_") and path.exists():
+                total += path.stat().st_size
+    return total
+
+
 def write_partitioned_parquet(
     records: list[MaterialRecord],
     source: str,
@@ -109,10 +122,10 @@ def write_partitioned_parquet(
     output_dir: Path,
     resolution_px: int,
 ) -> list[Path]:
-    """Write category-partitioned parquet files. Returns list of paths.
+    """Write size-aware partitioned parquet files. Returns list of paths.
 
-    Naming: mat-vis-<source>-<tier>-<category>.parquet
-    Each file stays under GitHub's 2 GB per-asset limit.
+    First partitions by category. If a category exceeds MAX_PARTITION_BYTES,
+    splits further into numbered chunks (alphabetical by material ID).
     """
     from collections import defaultdict
 
@@ -128,11 +141,33 @@ def write_partitioned_parquet(
     paths: list[Path] = []
 
     for cat in sorted(by_cat.keys()):
-        cat_records = by_cat[cat]
-        filename = f"mat-vis-{source}-{tier}-{cat}.parquet"
-        path = output_dir / filename
-        write_parquet(cat_records, source, tier, path, resolution_px)
-        paths.append(path)
+        cat_records = sorted(by_cat[cat], key=lambda r: r.id)
+        est_size = _estimate_partition_size(cat_records)
+
+        if est_size <= MAX_PARTITION_BYTES:
+            # Single partition
+            filename = f"mat-vis-{source}-{tier}-{cat}.parquet"
+            path = output_dir / filename
+            write_parquet(cat_records, source, tier, path, resolution_px)
+            paths.append(path)
+        else:
+            # Split into chunks that fit under the limit
+            n_chunks = (est_size // MAX_PARTITION_BYTES) + 1
+            chunk_size = max(1, len(cat_records) // n_chunks)
+            log.info(
+                "%s: %.1f GB estimated, splitting into %d chunks of ~%d materials",
+                cat,
+                est_size / 1e9,
+                n_chunks,
+                chunk_size,
+            )
+            for i in range(0, len(cat_records), chunk_size):
+                chunk = cat_records[i : i + chunk_size]
+                chunk_num = (i // chunk_size) + 1
+                filename = f"mat-vis-{source}-{tier}-{cat}-{chunk_num}.parquet"
+                path = output_dir / filename
+                write_parquet(chunk, source, tier, path, resolution_px)
+                paths.append(path)
 
     log.info(
         "wrote %d partitioned parquet files for %s %s (%d total records)",


### PR DESCRIPTION
Fixes #40 + #41. Client merges partitioned rowmaps. Parquet auto-splits at 1.8GB. Client tests in CI.