### PR TITLE
refactor(client): API UX overhaul → 0.5.0 (closes #85, #84)

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -483,6 +483,13 @@ class MatVisCi:
             .with_mounted_directory("/app", context)
             .with_workdir("/app")
             .with_exec(["pip", "install", "--quiet", "-e", ".[baker,dev]"])
+            # Install the client package too so cross-module tests
+            # (e.g. tests/test_version_sync.py::test_client_runtime_version_matches_pyproject,
+            # which does ``from mat_vis_client import __version__``) can
+            # import it. Without this, the top-level tests/ suite can
+            # only see the baker package even though it guards client
+            # invariants.
+            .with_exec(["pip", "install", "--quiet", "-e", "./clients/python"])
             .with_exec(["pytest", "tests/", "-v"])
             .stdout()
         )

--- a/clients/js/test_client.mjs
+++ b/clients/js/test_client.mjs
@@ -13,9 +13,9 @@ const TAG = process.env.MAT_VIS_TAG || 'v2026.04.0';
 const client = new MatVisClient({ tag: TAG });
 
 describe('manifest', () => {
-  it('fetches manifest with version field', async () => {
+  it('fetches manifest with schema_version field', async () => {
     const m = await client.manifest();
-    assert.strictEqual(m.version, 1);
+    assert.strictEqual(m.schema_version, 1);
     assert.ok(m.tiers, 'manifest should have tiers');
   });
 

--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -44,7 +44,7 @@ DEFAULT_CACHE_DIR = Path(os.environ.get("MAT_VIS_CACHE", Path.home() / ".cache" 
 # Version is kept in sync with clients/python/pyproject.toml by
 # scripts/sync-standalone-version.py (run via pre-commit). Do not
 # hand-edit — a drift test in tests/ fails CI if it disagrees.
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 # Same User-Agent as the installable package (issue #70). Standalone vs
 # pip-installed is an internal packaging detail; servers receiving the
 # request can't act on it and splitting UA populations fragments

--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -127,23 +127,87 @@ RETRY_MAX_WAIT_SECONDS = int(os.environ.get("MAT_VIS_RETRY_MAX_WAIT", "60"))
 
 
 class MatVisError(Exception):
-    """Base class for mat-vis-client errors."""
+    """Base class for mat-vis-client errors.
+
+    Every exception surfaced to callers is a ``MatVisError`` subclass —
+    raw ``urllib.error.HTTPError`` / ``URLError`` never leaks out.
+    """
+
+
+class NotFoundError(MatVisError):
+    """A key was not found in a mat-vis registry."""
+
+    kind: str = "item"
+
+    def __init__(
+        self,
+        key: str,
+        available: list[str] | None = None,
+        context: str = "",
+    ) -> None:
+        self.key = key
+        self.available = list(available or [])
+        self.context = context
+        where = f" in {context}" if context else ""
+        hint = f". Available: {self.available}" if self.available else ""
+        super().__init__(f"{self.kind} {key!r} not found{where}{hint}")
+
+
+class MaterialNotFoundError(NotFoundError):
+    kind = "material"
+
+
+class SourceNotFoundError(NotFoundError):
+    kind = "source"
+
+
+class TierNotFoundError(NotFoundError):
+    kind = "tier"
+
+
+class ChannelNotFoundError(NotFoundError):
+    kind = "channel"
+
+
+_NOT_FOUND_BY_KIND: dict[str, type[NotFoundError]] = {
+    "material": MaterialNotFoundError,
+    "source": SourceNotFoundError,
+    "tier": TierNotFoundError,
+    "channel": ChannelNotFoundError,
+}
 
 
 def _lookup(mapping: dict, key: str, *, kind: str, context: str = "") -> object:
-    """Dict lookup that raises ``MatVisError`` with an "Available: [...]"
-    suggestion list instead of a bare ``KeyError``.
-
-    Catches the common typo case (wrong source/tier/material/channel) and
-    turns it into an actionable error message. Caller-supplied ``kind`` is
-    the thing being looked up (e.g. "material", "channel"); ``context``
-    adds a path qualifier like "ambientcg/1k" so the message is locatable.
+    """Dict lookup that raises the typed ``NotFoundError`` subclass for
+    ``kind`` (with an ``available=[...]`` hint) instead of ``KeyError``.
     """
     if key in mapping:
         return mapping[key]
     available = sorted(mapping.keys())
+    cls = _NOT_FOUND_BY_KIND.get(kind)
+    if cls is not None:
+        raise cls(key=key, available=available, context=context)
     where = f" in {context}" if context else ""
     raise MatVisError(f"{kind} {key!r} not found{where}. Available: {available}")
+
+
+class HTTPFetchError(MatVisError):
+    """HTTP fetch failed with a non-rate-limit error (404, 500, ...)."""
+
+    def __init__(self, url: str, code: int, reason: str = ""):
+        self.url = url
+        self.code = code
+        self.reason = reason
+        super().__init__(f"HTTP {code} for {url}{': ' + reason if reason else ''}")
+
+
+class NetworkError(MatVisError):
+    """Network-level failure (DNS / connection / timeout) after retries."""
+
+    def __init__(self, url: str, reason: str):
+        self.url = url
+        self.reason = reason
+        super().__init__(f"Network error for {url}: {reason}")
 
 
 class RateLimitError(MatVisError):
@@ -305,11 +369,14 @@ class MatVisClient:
         manifest_url: str | None = None,
         cache_dir: Path | None = None,
         tag: str | None = None,
+        cache: bool = True,
     ):
         self._cache_dir = cache_dir or DEFAULT_CACHE_DIR
+        self._cache = cache
         self._manifest: dict | None = None
         self._rowmaps: dict[str, dict] = {}
         self._indexes: dict[str, list[dict]] = {}
+        self._alt_clients: dict[str, "MatVisClient"] = {}
         # In-memory cache of resolved redirect URLs (github.com -> signed CDN).
         # GitHub's signed URLs expire ~5 min; we cache for 4 min to be safe.
         # Avoids hitting the rate-limited github.com redirect on every
@@ -323,6 +390,21 @@ class MatVisClient:
             self._manifest_url = f"{GITHUB_RELEASES}/download/{tag}/release-manifest.json"
         else:
             self._manifest_url = LATEST_MANIFEST_URL
+
+    @property
+    def _cache_scope(self) -> Path:
+        """Tag-scoped cache subdirectory (v1 / v2 never collide)."""
+        return self._cache_dir / (self._tag or "latest")
+
+    def at(self, tag: str) -> "MatVisClient":
+        """Return a client pinned to ``tag``, sharing this one's cache."""
+        if tag == self._tag:
+            return self
+        if tag not in self._alt_clients:
+            self._alt_clients[tag] = MatVisClient(
+                cache_dir=self._cache_dir, tag=tag, cache=self._cache
+            )
+        return self._alt_clients[tag]
 
     @property
     def manifest(self) -> dict:
@@ -801,71 +883,6 @@ class MatVisClient:
                 self._mtlx_originals[source] = {}
         return self._mtlx_originals[source]
 
-    # ── Deprecated mtlx shims ──────────────────────────────────
-
-    def to_mtlx(
-        self,
-        source: str,
-        material_id: str,
-        tier: str = "1k",
-        output_dir: str | Path = ".",
-    ) -> Path:
-        """Deprecated: use ``client.mtlx(src, id, tier).export(output_dir)``."""
-        import warnings
-
-        warnings.warn(
-            "client.to_mtlx() is deprecated. "
-            "Use client.mtlx(source, material_id, tier).export(output_dir) instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.mtlx(source, material_id, tier).export(output_dir)
-
-    def fetch_mtlx_original(self, source: str, material_id: str) -> str | None:
-        """Deprecated: use ``client.mtlx(src, id).original`` (None if unavailable).
-
-        Returns the raw upstream MaterialX XML string, or ``None`` if the
-        source has no original mtlx or the material isn't in the map.
-        """
-        import warnings
-
-        warnings.warn(
-            "client.fetch_mtlx_original() is deprecated. "
-            "Use client.mtlx(source, material_id).original and check for None; "
-            "then read .xml from the returned MtlxSource.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._fetch_mtlx_original_map(source).get(material_id)
-
-    def materialize_mtlx(
-        self,
-        source: str,
-        material_id: str,
-        tier: str = "1k",
-        output_dir: str | Path = ".",
-    ) -> Path | None:
-        """Deprecated: use ``client.mtlx(src, id, tier).original.export(path)``.
-
-        Falls back to the synthesized variant when no upstream mtlx exists
-        (preserves pre-0.2 behavior).
-        """
-        import warnings
-
-        warnings.warn(
-            "client.materialize_mtlx() is deprecated. "
-            "Use client.mtlx(source, material_id, tier).original.export(output_dir); "
-            "handle the None case explicitly.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        source_obj = self.mtlx(source, material_id, tier)
-        original = source_obj.original
-        if original is None:
-            # Preserve previous fallback-to-synthesized behavior.
-            return source_obj.export(output_dir)
-        return original.export(output_dir)
-
     def rowmap_entry(
         self,
         source: str,
@@ -1220,9 +1237,11 @@ class MtlxSource:
         """True if this is the upstream-author document, not synthesized."""
         return self._is_original
 
-    @property
     def xml(self) -> str:
-        """Return the MaterialX XML as a string.
+        """Return the MaterialX XML as a string (method, not property).
+
+        Method form makes the network cost explicit and ports to
+        JS/Rust reference clients (no attribute-triggered IO).
 
         * Synthesized: generated in-memory from scalars + channel list.
           No PNGs are written and no texture bytes are fetched.
@@ -1287,18 +1306,19 @@ class MtlxSource:
             )
 
         # Original: fetch upstream, rewrite filename values to local PNGs.
-        xml_str = self.xml  # raises LookupError if gone from the map
+        xml_str = self.xml()  # raises LookupError if gone from the map
         rewritten = _rewrite_mtlx_texture_paths(xml_str, tex_dir, chs)
         mtlx_path = tex_dir / f"{self._material_id}.mtlx"
         mtlx_path.write_text(rewritten, encoding="utf-8")
         return mtlx_path
 
-    @property
     def original(self) -> MtlxSource | None:
         """Return the upstream-author variant if available, else ``None``.
 
-        Only synthesized :class:`MtlxSource` instances have ``.original``
-        — calling it on an already-original source returns ``None``.
+        Method, not a property: first call fetches a JSON map from the
+        network. Only synthesized MtlxSource instances have an original
+        — calling ``original()`` on an already-original source returns
+        ``None``.
 
         Fast check: the per-source "does this source offer originals"
         verdict is cached at the client level (first call fetches the

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mat-vis-client"
-version = "0.4.1"
+version = "0.5.0"
 description = "Pure Python client for mat-vis PBR textures — HTTP range reads, zero deps"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/clients/python/src/mat_vis_client/__init__.py
+++ b/clients/python/src/mat_vis_client/__init__.py
@@ -29,19 +29,33 @@ from typing import Any
 
 from mat_vis_client.adapters import export_mtlx, to_gltf, to_threejs
 from mat_vis_client.client import (
+    ChannelNotFoundError,
+    HTTPFetchError,
     MatVisClient,
     MatVisError,
+    MaterialNotFoundError,
     MtlxSource,
+    NetworkError,
+    NotFoundError,
     RateLimitError,
+    SourceNotFoundError,
+    TierNotFoundError,
     __version__,
     _in_range,
 )
 
 __all__ = [
+    "ChannelNotFoundError",
+    "HTTPFetchError",
     "MatVisClient",
     "MatVisError",
+    "MaterialNotFoundError",
     "MtlxSource",
+    "NetworkError",
+    "NotFoundError",
     "RateLimitError",
+    "SourceNotFoundError",
+    "TierNotFoundError",
     "__version__",
     "_in_range",
     "search",

--- a/clients/python/src/mat_vis_client/__init__.py
+++ b/clients/python/src/mat_vis_client/__init__.py
@@ -162,40 +162,27 @@ def search(
     roughness: float | None = None,
     metalness: float | None = None,
     source: str | None = None,
+    tier: str = "1k",
     tag: str | None = None,
     limit: int = 20,
 ) -> list[dict[str, Any]]:
     """Search the mat-vis index by category and scalar similarity.
 
-    Returns results sorted by score (lower = closer match).
+    Thin forwarder to :meth:`MatVisClient.search` with ``score=True`` —
+    the scoring/sorting + default ``limit=20`` are the only module-level
+    convenience on top of the method. Every other argument is just passed
+    through.
     """
-    client = MatVisClient(tag=tag) if tag else get_client()
-
-    roughness_range = None
-    if roughness is not None:
-        roughness_range = (max(0.0, roughness - 0.2), min(1.0, roughness + 0.2))
-
-    metalness_range = None
-    if metalness is not None:
-        metalness_range = (max(0.0, metalness - 0.2), min(1.0, metalness + 0.2))
-
-    results = client.search(
-        category=category,
+    return get_client().search(
+        category,
+        roughness=roughness,
+        metalness=metalness,
         source=source,
-        roughness_range=roughness_range,
-        metalness_range=metalness_range,
+        tier=tier,
+        tag=tag,
+        score=True,
+        limit=limit,
     )
-
-    for r in results:
-        score = 0.0
-        if roughness is not None and r.get("roughness") is not None:
-            score += abs(r["roughness"] - roughness)
-        if metalness is not None and r.get("metalness") is not None:
-            score += abs(r["metalness"] - metalness)
-        r["score"] = score
-
-    results.sort(key=lambda r: r["score"])
-    return results[:limit]
 
 
 def prefetch(

--- a/clients/python/src/mat_vis_client/__init__.py
+++ b/clients/python/src/mat_vis_client/__init__.py
@@ -58,6 +58,7 @@ __all__ = [
     "TierNotFoundError",
     "__version__",
     "_in_range",
+    "get_client",
     "search",
     "prefetch",
     "rowmap_entry",
@@ -70,16 +71,41 @@ __all__ = [
 
 log = logging.getLogger("mat-vis-client")
 
-# Singleton client — lazy-initialized
+# Singleton client — lazy-initialized. Shared across callers so the
+# manifest, rowmaps, indexes, and on-disk texture cache are populated
+# once per process. Reach it via :func:`get_client`.
 _client: MatVisClient | None = None
 
 
-def _get_client() -> MatVisClient:
+def get_client() -> MatVisClient:
+    """Return the process-wide ``MatVisClient`` singleton.
+
+    Lazily constructed on first call, with indexes seeded. Downstream
+    consumers that want to share the manifest/index/texture cache with
+    the module-level ``search()`` / ``prefetch()`` helpers should use
+    this instead of ``MatVisClient()`` directly.
+    """
     global _client
     if _client is None:
         _client = MatVisClient()
         seed_indexes(_client)
     return _client
+
+
+def _get_client() -> MatVisClient:
+    """Deprecated: use :func:`get_client` instead.
+
+    Kept for one release to give downstream consumers (e.g. py-mat's
+    ``Vis.client``) time to migrate. Emits ``DeprecationWarning``.
+    """
+    import warnings
+
+    warnings.warn(
+        "mat_vis_client._get_client is deprecated; use get_client instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return get_client()
 
 
 def seed_indexes(client: MatVisClient) -> None:
@@ -126,7 +152,7 @@ def seed_indexes(client: MatVisClient) -> None:
 
 def get_manifest(release_tag: str | None = None) -> dict:
     """Fetch release manifest (URL discovery for all sources × tiers)."""
-    client = MatVisClient(tag=release_tag) if release_tag else _get_client()
+    client = MatVisClient(tag=release_tag) if release_tag else get_client()
     return client.manifest
 
 
@@ -143,7 +169,7 @@ def search(
 
     Returns results sorted by score (lower = closer match).
     """
-    client = MatVisClient(tag=tag) if tag else _get_client()
+    client = MatVisClient(tag=tag) if tag else get_client()
 
     roughness_range = None
     if roughness is not None:
@@ -179,7 +205,7 @@ def prefetch(
     tag: str | None = None,
 ) -> int:
     """Download all materials for a source × tier into the local cache."""
-    client = MatVisClient(tag=tag) if tag else _get_client()
+    client = MatVisClient(tag=tag) if tag else get_client()
     return client.prefetch(source, tier=tier)
 
 
@@ -191,5 +217,5 @@ def rowmap_entry(
     tag: str | None = None,
 ) -> dict[str, dict[str, int]]:
     """Get raw byte-offset info for DIY consumers."""
-    client = MatVisClient(tag=tag) if tag else _get_client()
+    client = MatVisClient(tag=tag) if tag else get_client()
     return client.rowmap_entry(source, material_id, tier=tier)

--- a/clients/python/src/mat_vis_client/adapters.py
+++ b/clients/python/src/mat_vis_client/adapters.py
@@ -17,50 +17,14 @@ import base64
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-# ── Field name mapping tables ───────────────────────────────────
-#
-# mat-vis channel name -> renderer property name
-# Canonical source: docs/specs/field-name-mapping.md
+from mat_vis_client.schema import (
+    GLTF_MAP as _GLTF_TEX_MAP,
+    THREEJS_MAP as _THREEJS_TEX_MAP,
+    USD_PREVIEW_MAP as _USD_PREVIEW_TEX_MAP,
+)
 
-_THREEJS_TEX_MAP: dict[str, str] = {
-    "color": "map",
-    "normal": "normalMap",
-    "roughness": "roughnessMap",
-    "metalness": "metalnessMap",
-    "ao": "aoMap",
-    "displacement": "displacementMap",
-    "emission": "emissiveMap",
-}
-
-_GLTF_TEX_MAP: dict[str, str] = {
-    "color": "baseColorTexture",
-    "normal": "normalTexture",
-    "ao": "occlusionTexture",
-    "emission": "emissiveTexture",
-    # roughness + metalness are packed into metallicRoughnessTexture
-    # handled separately in to_gltf()
-}
-
-_MTLX_TEX_MAP: dict[str, str] = {
-    "color": "base_color",
-    "normal": "normal",
-    "roughness": "specular_roughness",
-    "metalness": "metalness",
-    "ao": "occlusion",
-    "displacement": "displacement",
-    "emission": "emission_color",
-}
-
-# UsdPreviewSurface input names (different from standard_surface)
-_USD_PREVIEW_TEX_MAP: dict[str, tuple[str, str]] = {
-    "color": ("diffuseColor", "color3"),
-    "normal": ("normal", "vector3"),
-    "roughness": ("roughness", "float"),
-    "metalness": ("metallic", "float"),
-    "ao": ("occlusion", "float"),
-    "displacement": ("displacement", "float"),
-    "emission": ("emissiveColor", "color3"),
-}
+# Renderer-prop maps come from schema.CHANNELS — do not hand-maintain
+# parallel dicts here. Adding a channel is one edit in schema.py.
 
 
 # ── Helpers ─────────────────────────────────────────────────────

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -130,23 +130,109 @@ RETRY_MAX_WAIT_SECONDS = int(os.environ.get("MAT_VIS_RETRY_MAX_WAIT", "60"))
 
 
 class MatVisError(Exception):
-    """Base class for mat-vis-client errors."""
+    """Base class for mat-vis-client errors.
+
+    Every exception surfaced to callers is a ``MatVisError`` subclass —
+    raw ``urllib.error.HTTPError`` / ``URLError`` never leaks out.
+    """
+
+
+class NotFoundError(MatVisError):
+    """A key was not found in a mat-vis registry (material / channel / etc).
+
+    Structured fields let callers branch without string-matching messages:
+
+    - ``key``: the missing name (e.g. ``"Rock999"``)
+    - ``available``: sorted list of valid names at this level
+    - ``context``: optional path qualifier (e.g. ``"ambientcg/1k"``)
+    - ``kind``: class-level label ("material", "source", ...)
+    """
+
+    kind: str = "item"
+
+    def __init__(
+        self,
+        key: str,
+        available: list[str] | None = None,
+        context: str = "",
+    ) -> None:
+        self.key = key
+        self.available = list(available or [])
+        self.context = context
+        where = f" in {context}" if context else ""
+        hint = f". Available: {self.available}" if self.available else ""
+        super().__init__(f"{self.kind} {key!r} not found{where}{hint}")
+
+
+class MaterialNotFoundError(NotFoundError):
+    kind = "material"
+
+
+class SourceNotFoundError(NotFoundError):
+    kind = "source"
+
+
+class TierNotFoundError(NotFoundError):
+    kind = "tier"
+
+
+class ChannelNotFoundError(NotFoundError):
+    kind = "channel"
+
+
+# Dispatch table: _lookup() picks the right typed subclass from ``kind``.
+# Unknown kinds fall back to MatVisError (legacy call sites still work).
+_NOT_FOUND_BY_KIND: dict[str, type[NotFoundError]] = {
+    "material": MaterialNotFoundError,
+    "source": SourceNotFoundError,
+    "tier": TierNotFoundError,
+    "channel": ChannelNotFoundError,
+}
 
 
 def _lookup(mapping: dict, key: str, *, kind: str, context: str = "") -> object:
-    """Dict lookup that raises ``MatVisError`` with an "Available: [...]"
-    suggestion list instead of a bare ``KeyError``.
+    """Dict lookup that raises the typed ``NotFoundError`` subclass for
+    ``kind`` (with an ``available=[...]`` hint) instead of ``KeyError``.
 
-    Catches the common typo case (wrong source/tier/material/channel) and
-    turns it into an actionable error message. Caller-supplied ``kind`` is
-    the thing being looked up (e.g. "material", "channel"); ``context``
-    adds a path qualifier like "ambientcg/1k" so the message is locatable.
+    Example: ``_lookup(materials, "Rock999", kind="material", context="ambientcg/1k")``
+    raises :class:`MaterialNotFoundError` carrying ``.key`` / ``.available`` /
+    ``.context``.
     """
     if key in mapping:
         return mapping[key]
     available = sorted(mapping.keys())
+    cls = _NOT_FOUND_BY_KIND.get(kind)
+    if cls is not None:
+        raise cls(key=key, available=available, context=context)
+    # Unknown kind — preserve legacy MatVisError for back-compat.
     where = f" in {context}" if context else ""
     raise MatVisError(f"{kind} {key!r} not found{where}. Available: {available}")
+
+
+class HTTPFetchError(MatVisError):
+    """HTTP fetch failed with a non-rate-limit error (404, 500, ...).
+
+    Wraps ``urllib.error.HTTPError`` so callers never see raw urllib
+    exceptions. Carries ``.url``, ``.code``, ``.reason``.
+    """
+
+    def __init__(self, url: str, code: int, reason: str = ""):
+        self.url = url
+        self.code = code
+        self.reason = reason
+        super().__init__(f"HTTP {code} for {url}{': ' + reason if reason else ''}")
+
+
+class NetworkError(MatVisError):
+    """Network-level failure (DNS / connection / timeout) after retries.
+
+    Wraps ``urllib.error.URLError``. Carries ``.url`` and ``.reason``.
+    """
+
+    def __init__(self, url: str, reason: str):
+        self.url = url
+        self.reason = reason
+        super().__init__(f"Network error for {url}: {reason}")
 
 
 class RateLimitError(MatVisError):
@@ -234,8 +320,15 @@ def _get(
                 return data
         except urllib.error.HTTPError as e:
             last_err = e
-            if not _is_rate_limited(e) or attempt >= MAX_RETRIES:
-                raise
+            if not _is_rate_limited(e):
+                # Non-transient HTTP error — wrap and surface immediately.
+                raise HTTPFetchError(url, e.code, e.reason or "") from e
+            if attempt >= MAX_RETRIES:
+                # Rate-limit exhaustion → typed RateLimitError.
+                wait = _parse_retry_after(e.headers, int(BACKOFF_BASE_SECONDS * (2**attempt)))
+                raise RateLimitError(
+                    url, wait, f"Rate limited on {url} after {MAX_RETRIES} retries."
+                ) from e
             wait = _parse_retry_after(e.headers, int(BACKOFF_BASE_SECONDS * (2**attempt)))
             print(
                 f"mat-vis-client: rate limited (HTTP {e.code}), "
@@ -247,7 +340,7 @@ def _get(
             # Network-level error (DNS / connection reset / timeout). Retry.
             last_err = e
             if attempt >= MAX_RETRIES:
-                raise
+                raise NetworkError(url, str(e.reason)) from e
             wait = min(int(BACKOFF_BASE_SECONDS * (2**attempt)), RETRY_MAX_WAIT_SECONDS)
             print(
                 f"mat-vis-client: network error ({e.reason}), "
@@ -257,7 +350,7 @@ def _get(
             time.sleep(wait)
 
     # Should be unreachable (loop always raises or returns), but fail loud
-    raise RateLimitError(url, 0, f"exhausted {MAX_RETRIES} retries") from last_err
+    raise MatVisError(f"exhausted {MAX_RETRIES} retries for {url}") from last_err
 
 
 def _get_json(url: str) -> dict | list:
@@ -976,7 +1069,7 @@ class MatVisClient:
             else:
                 data, resolved = _get(url, headers={"Range": range_header}, return_final_url=True)
                 self._cache_resolved(original_url, resolved)
-        except urllib.error.HTTPError as e:
+        except HTTPFetchError as e:
             # Signed URL may have expired between cache and use — retry once with fresh.
             if is_cached and e.code in (403, 404):
                 self._redirect_cache.pop(original_url, None)

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -1345,23 +1345,8 @@ def _render_synthesized_mtlx_xml(
 # GPUOpen upstream names → our mat-vis channel names.
 # Used by the original-mtlx path-rewriter so a <input file value="BaseColor.png"/>
 # is redirected to our local "color.png" after materialization.
-_FILENAME_TO_CHANNEL: dict[str, str] = {
-    "basecolor": "color",
-    "base_color": "color",
-    "diffuse": "color",
-    "normal": "normal",
-    "roughness": "roughness",
-    "specular_roughness": "roughness",
-    "metallic": "metalness",
-    "metalness": "metalness",
-    "occlusion": "ao",
-    "ao": "ao",
-    "ambientocclusion": "ao",
-    "displacement": "displacement",
-    "height": "displacement",
-    "emission": "emission",
-    "emissive": "emission",
-}
+# Single source of truth: mat_vis_client.schema.CHANNELS (filename_aliases).
+from mat_vis_client.schema import FILENAME_TO_CHANNEL as _FILENAME_TO_CHANNEL  # noqa: E402
 
 
 def _rewrite_mtlx_texture_paths(xml_str: str, tex_dir: Path, channels: list[str]) -> str:

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -792,15 +792,21 @@ class MatVisClient:
                 self._cache_write_text(cache_path, json.dumps(self._indexes[source], indent=2))
         return self._indexes[source]
 
+    _SCALAR_WIDEN = 0.2  # scalar shorthand → range half-width
+
     def search(
         self,
         category: str | None = None,
         *,
+        roughness: float | None = None,
+        metalness: float | None = None,
         roughness_range: tuple[float, float] | None = None,
         metalness_range: tuple[float, float] | None = None,
         source: str | None = None,
         tier: str = "1k",
         tag: str | None = None,
+        score: bool = False,
+        limit: int | None = None,
     ) -> list[dict]:
         """Search materials by category and scalar ranges.
 
@@ -809,20 +815,46 @@ class MatVisClient:
 
         Args:
             category: Filter by material category (e.g. "metal", "wood").
+            roughness: Scalar shorthand. Matches within ± ``_SCALAR_WIDEN``.
+                Mutually exclusive with ``roughness_range``.
+            metalness: Scalar shorthand. Same semantics as ``roughness``.
             roughness_range: (min, max) roughness filter, inclusive.
             metalness_range: (min, max) metalness filter, inclusive.
             source: Limit search to one source. If None, searches all
                     sources available for the given tier.
             tier: Only return materials that have this tier available.
             tag: Optional release tag override (see .at()).
+            score: When True and a scalar shorthand is passed, attach a
+                ``score`` field (absolute distance) and sort ascending.
+            limit: Cap the returned list length.
         """
         if tag is not None and tag != self._tag:
             return self.at(tag).search(
                 category,
+                roughness=roughness,
+                metalness=metalness,
                 roughness_range=roughness_range,
                 metalness_range=metalness_range,
                 source=source,
                 tier=tier,
+                score=score,
+                limit=limit,
+            )
+        # Scalar + range on the same dimension is ambiguous — reject.
+        if roughness is not None and roughness_range is not None:
+            raise MatVisError("pass roughness OR roughness_range, not both")
+        if metalness is not None and metalness_range is not None:
+            raise MatVisError("pass metalness OR metalness_range, not both")
+        # Scalar shorthand widens into an inclusive range.
+        if roughness is not None:
+            roughness_range = (
+                max(0.0, roughness - self._SCALAR_WIDEN),
+                min(1.0, roughness + self._SCALAR_WIDEN),
+            )
+        if metalness is not None:
+            metalness_range = (
+                max(0.0, metalness - self._SCALAR_WIDEN),
+                min(1.0, metalness + self._SCALAR_WIDEN),
             )
         if category:
             valid = self.categories()  # discovered from manifest
@@ -851,6 +883,18 @@ class MatVisClient:
                     continue
                 results.append(entry)
 
+        if score and (roughness is not None or metalness is not None):
+            for r in results:
+                s = 0.0
+                if roughness is not None and r.get("roughness") is not None:
+                    s += abs(r["roughness"] - roughness)
+                if metalness is not None and r.get("metalness") is not None:
+                    s += abs(r["metalness"] - metalness)
+                r["score"] = s
+            results.sort(key=lambda r: r["score"])
+
+        if limit is not None:
+            results = results[:limit]
         return results
 
     # ── Bulk operations ─────────────────────────────────────────

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -401,8 +401,10 @@ class MatVisClient:
         manifest_url: str | None = None,
         cache_dir: Path | None = None,
         tag: str | None = None,
+        cache: bool = True,
     ):
         self._cache_dir = cache_dir or DEFAULT_CACHE_DIR
+        self._cache = cache
         self._manifest: dict | None = None
         self._rowmaps: dict[str, dict] = {}
         self._indexes: dict[str, list[dict]] = {}
@@ -421,16 +423,52 @@ class MatVisClient:
             self._manifest_url = LATEST_MANIFEST_URL
 
     @property
+    def _cache_scope(self) -> Path:
+        """Tag-scoped cache subdirectory.
+
+        Keeps data for different release tags in separate subtrees so a
+        ``tag=v1`` cache never serves bytes for a ``tag=v2`` request.
+        When no explicit tag is pinned, the ``"latest"`` sentinel is used
+        — invalidation of that bucket is the caller's responsibility
+        (or, more typically, handled by the update-check TTL).
+        """
+        return self._cache_dir / (self._tag or "latest")
+
+    # ── cache-aware I/O helpers (single source of gating) ──────────
+
+    def _cache_read_bytes(self, path: Path) -> bytes | None:
+        if not self._cache or not path.exists():
+            return None
+        return path.read_bytes()
+
+    def _cache_write_bytes(self, path: Path, data: bytes) -> None:
+        if not self._cache:
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+
+    def _cache_read_text(self, path: Path) -> str | None:
+        if not self._cache or not path.exists():
+            return None
+        return path.read_text()
+
+    def _cache_write_text(self, path: Path, text: str) -> None:
+        if not self._cache:
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+
+    @property
     def manifest(self) -> dict:
         """Fetch and cache the release manifest. Validates schema_version."""
         if self._manifest is None:
-            cache_path = self._cache_dir / ".manifest.json"
-            if cache_path.exists():
-                self._manifest = json.loads(cache_path.read_text())
+            cache_path = self._cache_scope / ".manifest.json"
+            cached = self._cache_read_text(cache_path)
+            if cached is not None:
+                self._manifest = json.loads(cached)
             else:
                 self._manifest = _get_json(self._manifest_url)
-                cache_path.parent.mkdir(parents=True, exist_ok=True)
-                cache_path.write_text(json.dumps(self._manifest, indent=2))
+                self._cache_write_text(cache_path, json.dumps(self._manifest, indent=2))
             self._check_schema_version(self._manifest)
             self._maybe_warn_updates()
         return self._manifest
@@ -656,14 +694,14 @@ class MatVisClient:
             # Fetch all partition rowmaps and merge materials
             merged: dict = {"materials": {}}
             for rmf in rowmap_files:
-                cache_path = self._cache_dir / ".rowmaps" / rmf
-                if cache_path.exists():
-                    rm = json.loads(cache_path.read_text())
+                cache_path = self._cache_scope / ".rowmaps" / rmf
+                cached = self._cache_read_text(cache_path)
+                if cached is not None:
+                    rm = json.loads(cached)
                 else:
                     url = base_url + rmf
                     rm = _get_json(url)
-                    cache_path.parent.mkdir(parents=True, exist_ok=True)
-                    cache_path.write_text(json.dumps(rm, indent=2))
+                    self._cache_write_text(cache_path, json.dumps(rm, indent=2))
 
                 # Each partitioned rowmap has its own parquet_file
                 pq_file = rm.get("parquet_file", "")
@@ -708,9 +746,10 @@ class MatVisClient:
         Returns a list of material entries per index-schema.json.
         """
         if source not in self._indexes:
-            cache_path = self._cache_dir / ".indexes" / f"{source}.json"
-            if cache_path.exists():
-                self._indexes[source] = json.loads(cache_path.read_text())
+            cache_path = self._cache_scope / ".indexes" / f"{source}.json"
+            cached = self._cache_read_text(cache_path)
+            if cached is not None:
+                self._indexes[source] = json.loads(cached)
             else:
                 # Try git first, then fall back to release asset
                 data = None
@@ -726,8 +765,7 @@ class MatVisClient:
                 if data is None:
                     raise FileNotFoundError(f"Index for {source!r} not found in git or release")
                 self._indexes[source] = data
-                cache_path.parent.mkdir(parents=True, exist_ok=True)
-                cache_path.write_text(json.dumps(self._indexes[source], indent=2))
+                self._cache_write_text(cache_path, json.dumps(self._indexes[source], indent=2))
         return self._indexes[source]
 
     def search(
@@ -1014,12 +1052,15 @@ class MatVisClient:
     ) -> bytes:
         """Fetch a single texture PNG via HTTP range read.
 
-        Returns raw PNG bytes. Caches locally.
+        Returns raw PNG bytes. Caches locally under the active tag scope
+        (so releases don't collide). Pass ``cache=False`` at client
+        construction to opt out entirely.
         """
-        # Check cache first
-        cache_path = self._cache_dir / source / tier / material_id / f"{channel}.png"
-        if cache_path.exists():
-            return cache_path.read_bytes()
+        # Check cache first (tag-scoped)
+        cache_path = self._cache_scope / source / tier / material_id / f"{channel}.png"
+        cached = self._cache_read_bytes(cache_path)
+        if cached is not None:
+            return cached
 
         # Find in rowmap
         rm = self.rowmap(source, tier)
@@ -1086,9 +1127,8 @@ class MatVisClient:
         if data[:4] != b"\x89PNG":
             raise ValueError(f"Expected PNG, got {data[:4]!r}")
 
-        # Cache
-        cache_path.parent.mkdir(parents=True, exist_ok=True)
-        cache_path.write_bytes(data)
+        # Cache (tag-scoped; no-op if cache=False)
+        self._cache_write_bytes(cache_path, data)
 
         # Soft-cap warning (once per process)
         self._maybe_warn_cache_cap()

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -1033,69 +1033,6 @@ class MatVisClient:
 
     # ── Deprecated mtlx shims ──────────────────────────────────
 
-    def to_mtlx(
-        self,
-        source: str,
-        material_id: str,
-        tier: str = "1k",
-        output_dir: str | Path = ".",
-    ) -> Path:
-        """Deprecated: use ``client.mtlx(src, id, tier).export(output_dir)``."""
-        import warnings
-
-        warnings.warn(
-            "client.to_mtlx() is deprecated. "
-            "Use client.mtlx(source, material_id, tier).export(output_dir) instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.mtlx(source, material_id, tier).export(output_dir)
-
-    def fetch_mtlx_original(self, source: str, material_id: str) -> str | None:
-        """Deprecated: use ``client.mtlx(src, id).original`` (None if unavailable).
-
-        Returns the raw upstream MaterialX XML string, or ``None`` if the
-        source has no original mtlx or the material isn't in the map.
-        """
-        import warnings
-
-        warnings.warn(
-            "client.fetch_mtlx_original() is deprecated. "
-            "Use client.mtlx(source, material_id).original and check for None; "
-            "then read .xml from the returned MtlxSource.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._fetch_mtlx_original_map(source).get(material_id)
-
-    def materialize_mtlx(
-        self,
-        source: str,
-        material_id: str,
-        tier: str = "1k",
-        output_dir: str | Path = ".",
-    ) -> Path | None:
-        """Deprecated: use ``client.mtlx(src, id, tier).original.export(path)``.
-
-        Falls back to the synthesized variant when no upstream mtlx exists
-        (preserves pre-0.2 behavior).
-        """
-        import warnings
-
-        warnings.warn(
-            "client.materialize_mtlx() is deprecated. "
-            "Use client.mtlx(source, material_id, tier).original.export(output_dir); "
-            "handle the None case explicitly.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        source_obj = self.mtlx(source, material_id, tier)
-        original = source_obj.original
-        if original is None:
-            # Preserve previous fallback-to-synthesized behavior.
-            return source_obj.export(output_dir)
-        return original.export(output_dir)
-
     def rowmap_entry(
         self,
         source: str,
@@ -1459,9 +1396,12 @@ class MtlxSource:
         """True if this is the upstream-author document, not synthesized."""
         return self._is_original
 
-    @property
     def xml(self) -> str:
         """Return the MaterialX XML as a string.
+
+        Method, not a property: callers make the network cost explicit.
+        This also ports straight to JS/Rust reference clients, which
+        don't have attribute-triggered IO.
 
         * Synthesized: generated in-memory from scalars + channel list.
           No PNGs are written and no texture bytes are fetched.
@@ -1472,8 +1412,8 @@ class MtlxSource:
         Raises:
             LookupError: if this is an original variant but the
                 material disappeared from the upstream map between
-                ``.original`` creation and ``.xml`` access (rare —
-                shouldn't happen since ``.original`` checks presence).
+                ``original()`` and ``xml()`` (rare — shouldn't happen
+                since ``original()`` checks presence).
         """
         if self._xml_cache is not None:
             return self._xml_cache
@@ -1526,22 +1466,22 @@ class MtlxSource:
             )
 
         # Original: fetch upstream, rewrite filename values to local PNGs.
-        xml_str = self.xml  # raises LookupError if gone from the map
+        xml_str = self.xml()  # raises LookupError if gone from the map
         rewritten = _rewrite_mtlx_texture_paths(xml_str, tex_dir, chs)
         mtlx_path = tex_dir / f"{self._material_id}.mtlx"
         mtlx_path.write_text(rewritten, encoding="utf-8")
         return mtlx_path
 
-    @property
     def original(self) -> MtlxSource | None:
         """Return the upstream-author variant if available, else ``None``.
 
-        Only synthesized :class:`MtlxSource` instances have ``.original``
-        — calling it on an already-original source returns ``None``.
+        Method, not a property: first call for a given source fetches a
+        JSON map from the network. Only synthesized :class:`MtlxSource`
+        instances have an original — calling ``original()`` on an already-
+        original instance returns ``None``.
 
-        Fast check: the per-source "does this source offer originals"
-        verdict is cached at the client level (first call fetches the
-        full ``{source}-mtlx.json`` map; subsequent calls hit memory).
+        Fast after first call: the per-source ``{source}-mtlx.json`` map
+        is cached at the client level.
         """
         if self._is_original:
             return None

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -408,6 +408,10 @@ class MatVisClient:
         self._manifest: dict | None = None
         self._rowmaps: dict[str, dict] = {}
         self._indexes: dict[str, list[dict]] = {}
+        # Cached alternate clients keyed by tag (populated by .at()).
+        # Each shares this instance's cache_dir + cache flag so all tag
+        # scopes resolve under one root.
+        self._alt_clients: dict[str, MatVisClient] = {}
         # In-memory cache of resolved redirect URLs (github.com -> signed CDN).
         # GitHub's signed URLs expire ~5 min; we cache for 4 min to be safe.
         # Avoids hitting the rate-limited github.com redirect on every
@@ -433,6 +437,26 @@ class MatVisClient:
         (or, more typically, handled by the update-check TTL).
         """
         return self._cache_dir / (self._tag or "latest")
+
+    def at(self, tag: str) -> "MatVisClient":
+        """Return a client pinned to ``tag``, sharing this one's cache.
+
+        Cheap lazy alternate: reuses the parent's ``cache_dir`` and
+        ``cache`` flag so every tag lives under a common root and the
+        tag-scoped cache paths stay coherent. Subclients are memoized,
+        so ``client.at("v1")`` twice returns the same instance.
+
+        Used internally to implement per-operation ``tag=`` kwargs:
+        ``client.fetch_texture(..., tag="v1")`` delegates to
+        ``client.at("v1").fetch_texture(...)``.
+        """
+        if tag == self._tag:
+            return self
+        if tag not in self._alt_clients:
+            self._alt_clients[tag] = MatVisClient(
+                cache_dir=self._cache_dir, tag=tag, cache=self._cache
+            )
+        return self._alt_clients[tag]
 
     # ── cache-aware I/O helpers (single source of gating) ──────────
 
@@ -776,6 +800,7 @@ class MatVisClient:
         metalness_range: tuple[float, float] | None = None,
         source: str | None = None,
         tier: str = "1k",
+        tag: str | None = None,
     ) -> list[dict]:
         """Search materials by category and scalar ranges.
 
@@ -789,7 +814,16 @@ class MatVisClient:
             source: Limit search to one source. If None, searches all
                     sources available for the given tier.
             tier: Only return materials that have this tier available.
+            tag: Optional release tag override (see .at()).
         """
+        if tag is not None and tag != self._tag:
+            return self.at(tag).search(
+                category,
+                roughness_range=roughness_range,
+                metalness_range=metalness_range,
+                source=source,
+                tier=tier,
+            )
         if category:
             valid = self.categories()  # discovered from manifest
             if valid and category not in valid:
@@ -826,11 +860,15 @@ class MatVisClient:
         source: str,
         material_id: str,
         tier: str = "1k",
+        *,
+        tag: str | None = None,
     ) -> dict[str, bytes]:
         """Fetch all texture channels for a material.
 
         Returns a dict mapping channel name to PNG bytes.
         """
+        if tag is not None and tag != self._tag:
+            return self.at(tag).fetch_all_textures(source, material_id, tier)
         chs = self.channels(source, material_id, tier)
         return {ch: self.fetch_texture(source, material_id, ch, tier) for ch in chs}
 
@@ -840,6 +878,7 @@ class MatVisClient:
         tier: str = "1k",
         *,
         on_progress: callable | None = None,
+        tag: str | None = None,
     ) -> int:
         """Bulk download all materials for a source + tier to cache.
 
@@ -847,9 +886,12 @@ class MatVisClient:
             source: Source name (e.g. "ambientcg").
             tier: Resolution tier (default "1k").
             on_progress: Optional callback(material_id, index, total).
+            tag: Optional release tag override (see .at()).
 
         Returns the number of materials fetched.
         """
+        if tag is not None and tag != self._tag:
+            return self.at(tag).prefetch(source, tier, on_progress=on_progress)
         mat_ids = self.materials(source, tier)
         total = len(mat_ids)
 
@@ -886,7 +928,14 @@ class MatVisClient:
 
     # ── MaterialX API (dotted) ─────────────────────────────────
 
-    def mtlx(self, source: str, material_id: str, tier: str = "1k") -> MtlxSource:
+    def mtlx(
+        self,
+        source: str,
+        material_id: str,
+        tier: str = "1k",
+        *,
+        tag: str | None = None,
+    ) -> MtlxSource:
         """Get a lazy :class:`MtlxSource` for a material.
 
         Use ``.xml`` for the document string, ``.export(path)`` to write
@@ -894,8 +943,11 @@ class MatVisClient:
         if not available for this source).
 
         Creation is free — no network IO happens until ``.xml`` or
-        ``.export(...)`` is called.
+        ``.export(...)`` is called. Pass ``tag=`` to scope the source to
+        a specific release (see .at()).
         """
+        if tag is not None and tag != self._tag:
+            return self.at(tag).mtlx(source, material_id, tier)
         return MtlxSource(self, source, material_id, tier, is_original=False)
 
     def _scalars_for(self, source: str, material_id: str) -> dict:
@@ -1049,13 +1101,20 @@ class MatVisClient:
         material_id: str,
         channel: str,
         tier: str = "1k",
+        *,
+        tag: str | None = None,
     ) -> bytes:
         """Fetch a single texture PNG via HTTP range read.
 
         Returns raw PNG bytes. Caches locally under the active tag scope
         (so releases don't collide). Pass ``cache=False`` at client
         construction to opt out entirely.
+
+        Pass ``tag="v..."`` to fetch from a specific release without
+        reinstantiating the client (hf-hub ``revision=`` pattern).
         """
+        if tag is not None and tag != self._tag:
+            return self.at(tag).fetch_texture(source, material_id, channel, tier)
         # Check cache first (tag-scoped)
         cache_path = self._cache_scope / source / tier / material_id / f"{channel}.png"
         cached = self._cache_read_bytes(cache_path)

--- a/clients/python/src/mat_vis_client/schema.py
+++ b/clients/python/src/mat_vis_client/schema.py
@@ -1,0 +1,171 @@
+"""Single source of truth for mat-vis channels, tiers, and renderer mappings.
+
+One registry (``CHANNELS``) drives every derived view — Three.js props,
+glTF props, MaterialX props, USD preview names, and upstream filename
+aliases. Adding a channel = one edit.
+
+Consumers import the derived maps directly; they are built once at
+import time and shared by identity so there is one authoritative copy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class Channel(StrEnum):
+    """mat-vis canonical channel names."""
+
+    COLOR = "color"
+    NORMAL = "normal"
+    ROUGHNESS = "roughness"
+    METALNESS = "metalness"
+    AO = "ao"
+    DISPLACEMENT = "displacement"
+    EMISSION = "emission"
+
+
+class Tier(StrEnum):
+    """Resolution tiers published by the baker."""
+
+    T1K = "1k"
+    T2K = "2k"
+    T4K = "4k"
+
+
+@dataclass(frozen=True)
+class ChannelSpec:
+    """Per-channel metadata for every renderer mat-vis targets.
+
+    gltf_prop is ``None`` for metalness/roughness because glTF 2.0 packs
+    those two channels into a single ``metallicRoughnessTexture`` — there
+    is no standalone per-channel slot.
+    """
+
+    channel: Channel
+    threejs_prop: str
+    gltf_prop: str | None
+    mtlx_prop: str
+    usd_preview_prop: str
+    usd_preview_type: str  # "color3" | "vector3" | "float"
+    filename_aliases: tuple[str, ...] = field(default_factory=tuple)
+
+
+CHANNELS: tuple[ChannelSpec, ...] = (
+    ChannelSpec(
+        channel=Channel.COLOR,
+        threejs_prop="map",
+        gltf_prop="baseColorTexture",
+        mtlx_prop="base_color",
+        usd_preview_prop="diffuseColor",
+        usd_preview_type="color3",
+        filename_aliases=("basecolor", "base_color", "diffuse", "color"),
+    ),
+    ChannelSpec(
+        channel=Channel.NORMAL,
+        threejs_prop="normalMap",
+        gltf_prop="normalTexture",
+        mtlx_prop="normal",
+        usd_preview_prop="normal",
+        usd_preview_type="vector3",
+        filename_aliases=("normal",),
+    ),
+    ChannelSpec(
+        channel=Channel.ROUGHNESS,
+        threejs_prop="roughnessMap",
+        gltf_prop=None,  # packed into metallicRoughnessTexture
+        mtlx_prop="specular_roughness",
+        usd_preview_prop="roughness",
+        usd_preview_type="float",
+        filename_aliases=("roughness", "specular_roughness"),
+    ),
+    ChannelSpec(
+        channel=Channel.METALNESS,
+        threejs_prop="metalnessMap",
+        gltf_prop=None,  # packed into metallicRoughnessTexture
+        mtlx_prop="metalness",
+        usd_preview_prop="metallic",
+        usd_preview_type="float",
+        filename_aliases=("metallic", "metalness"),
+    ),
+    ChannelSpec(
+        channel=Channel.AO,
+        threejs_prop="aoMap",
+        gltf_prop="occlusionTexture",
+        mtlx_prop="occlusion",
+        usd_preview_prop="occlusion",
+        usd_preview_type="float",
+        filename_aliases=("occlusion", "ao", "ambientocclusion"),
+    ),
+    ChannelSpec(
+        channel=Channel.DISPLACEMENT,
+        threejs_prop="displacementMap",
+        gltf_prop=None,
+        mtlx_prop="displacement",
+        usd_preview_prop="displacement",
+        usd_preview_type="float",
+        filename_aliases=("displacement", "height"),
+    ),
+    ChannelSpec(
+        channel=Channel.EMISSION,
+        threejs_prop="emissiveMap",
+        gltf_prop="emissiveTexture",
+        mtlx_prop="emission_color",
+        usd_preview_prop="emissiveColor",
+        usd_preview_type="color3",
+        filename_aliases=("emission", "emissive"),
+    ),
+)
+
+
+def _key(spec: ChannelSpec) -> str:
+    """Channel registry key — accept plain strings in tests, Channel in prod."""
+    return spec.channel.value if isinstance(spec.channel, Channel) else str(spec.channel)
+
+
+def build_threejs_map(specs) -> dict[str, str]:
+    return {_key(s): s.threejs_prop for s in specs}
+
+
+def build_gltf_map(specs) -> dict[str, str]:
+    return {_key(s): s.gltf_prop for s in specs if s.gltf_prop is not None}
+
+
+def build_mtlx_map(specs) -> dict[str, str]:
+    return {_key(s): s.mtlx_prop for s in specs}
+
+
+def build_usd_preview_map(specs) -> dict[str, tuple[str, str]]:
+    return {_key(s): (s.usd_preview_prop, s.usd_preview_type) for s in specs}
+
+
+def build_filename_to_channel(specs) -> dict[str, str]:
+    return {alias: _key(s) for s in specs for alias in s.filename_aliases}
+
+
+CHANNELS_BY_NAME: dict[str, ChannelSpec] = {_key(s): s for s in CHANNELS}
+THREEJS_MAP: dict[str, str] = build_threejs_map(CHANNELS)
+GLTF_MAP: dict[str, str] = build_gltf_map(CHANNELS)
+MTLX_MAP: dict[str, str] = build_mtlx_map(CHANNELS)
+USD_PREVIEW_MAP: dict[str, tuple[str, str]] = build_usd_preview_map(CHANNELS)
+FILENAME_TO_CHANNEL: dict[str, str] = build_filename_to_channel(CHANNELS)
+
+
+__all__ = [
+    "CHANNELS",
+    "CHANNELS_BY_NAME",
+    "Channel",
+    "ChannelSpec",
+    "FILENAME_TO_CHANNEL",
+    "GLTF_MAP",
+    "MTLX_MAP",
+    "THREEJS_MAP",
+    "Tier",
+    "USD_PREVIEW_MAP",
+    "build_filename_to_channel",
+    "build_gltf_map",
+    "build_mtlx_map",
+    "build_threejs_map",
+    "build_usd_preview_map",
+]

--- a/clients/python/test_client.py
+++ b/clients/python/test_client.py
@@ -162,8 +162,9 @@ def mock_client():
     """Client with mocked HTTP and temp cache."""
     with tempfile.TemporaryDirectory() as tmp:
         client = MatVisClient(tag="v2026.04.0", cache_dir=Path(tmp))
-        # Pre-populate manifest cache so no HTTP needed
-        cache_path = Path(tmp) / ".manifest.json"
+        # Pre-populate manifest cache at the tag-scoped path (0.5.0+).
+        cache_path = Path(tmp) / "v2026.04.0" / ".manifest.json"
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
         cache_path.write_text(json.dumps(MOCK_MANIFEST))
         # Suppress the background update-check HTTP calls that would
         # otherwise consume our mocked _get_json side_effect iterations.
@@ -191,7 +192,8 @@ def mock_search_client():
     )
     with tempfile.TemporaryDirectory() as tmp:
         client = MatVisClient(tag="v2026.04.0", cache_dir=Path(tmp))
-        cache_path = Path(tmp) / ".manifest.json"
+        cache_path = Path(tmp) / "v2026.04.0" / ".manifest.json"
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
         cache_path.write_text(json.dumps(rich_manifest))
         client._update_warned = True
         yield client
@@ -241,7 +243,9 @@ def _fresh_client(cache_dir: Path) -> MatVisClient:
     NOT suppressed — lets tests exercise the TTY / env-var gating path.
     """
     client = MatVisClient(tag="v2026.04.0", cache_dir=cache_dir)
-    (cache_dir / ".manifest.json").write_text(json.dumps(MOCK_MANIFEST))
+    scoped = cache_dir / "v2026.04.0"
+    scoped.mkdir(parents=True, exist_ok=True)
+    (scoped / ".manifest.json").write_text(json.dumps(MOCK_MANIFEST))
     return client
 
 
@@ -383,13 +387,20 @@ class TestUpdateCheckLogging:
 class TestSchemaVersionStrict:
     """#69 — client requires ``schema_version``; no legacy fallback."""
 
+    def _write_manifest(self, tmp: Path, data: dict) -> Path:
+        scoped = Path(tmp) / "v2026.04.0"
+        scoped.mkdir(parents=True, exist_ok=True)
+        mf = scoped / ".manifest.json"
+        mf.write_text(json.dumps(data))
+        return mf
+
     def test_rejects_manifest_without_schema_version(self):
         """A manifest with only ``version: 1`` raises RuntimeError."""
         with tempfile.TemporaryDirectory() as tmp:
             client = MatVisClient(tag="v2026.04.0", cache_dir=Path(tmp))
             legacy = {k: v for k, v in MOCK_MANIFEST.items() if k != "schema_version"}
             assert "schema_version" not in legacy
-            (Path(tmp) / ".manifest.json").write_text(json.dumps(legacy))
+            self._write_manifest(tmp, legacy)
             with pytest.raises(RuntimeError, match="schema_version"):
                 _ = client.manifest
 
@@ -397,7 +408,7 @@ class TestSchemaVersionStrict:
         """Recovery path is surfaced in the error message."""
         with tempfile.TemporaryDirectory() as tmp:
             client = MatVisClient(tag="v2026.04.0", cache_dir=Path(tmp))
-            (Path(tmp) / ".manifest.json").write_text(json.dumps({"version": 1}))
+            self._write_manifest(tmp, {"version": 1})
             with pytest.raises(RuntimeError) as excinfo:
                 _ = client.manifest
             msg = str(excinfo.value)
@@ -409,7 +420,7 @@ class TestSchemaVersionStrict:
         with tempfile.TemporaryDirectory() as tmp:
             client = MatVisClient(tag="v2026.04.0", cache_dir=Path(tmp))
             future = {**MOCK_MANIFEST, "schema_version": 99}
-            (Path(tmp) / ".manifest.json").write_text(json.dumps(future))
+            self._write_manifest(tmp, future)
             with pytest.raises(RuntimeError, match="does not support"):
                 _ = client.manifest
 
@@ -657,13 +668,12 @@ class TestRateLimitRetry:
     @patch("mat_vis_client.client.time.sleep")
     @patch("mat_vis_client.client.urllib.request.urlopen")
     def test_non_ratelimit_403_is_not_retried(self, mock_open, _sleep):
-        from urllib.error import HTTPError
+        from mat_vis_client.client import _get, HTTPFetchError
 
-        from mat_vis_client.client import _get
-
-        # Plain 403 with no rate-limit signal → propagate, no retry
+        # Plain 403 with no rate-limit signal → typed HTTPFetchError (0.5+),
+        # no retry. Used to raise urllib.HTTPError directly; now wrapped.
         mock_open.side_effect = [self._http_error(403)]
-        with pytest.raises(HTTPError):
+        with pytest.raises(HTTPFetchError):
             _get("http://test/x")
         assert mock_open.call_count == 1
 
@@ -680,12 +690,12 @@ class TestMtlxOriginalFetchError:
         mock_get_json.side_effect = URLError("boom")
 
         src = mock_client.mtlx("gpuopen", "any-id", "1k")
-        # .original checks presence against the upstream map; fetch fails
+        # .original() checks presence against the upstream map; fetch fails
         # → empty map cached → returned as no-original-available.
-        assert src.original is None
+        assert src.original() is None
 
         # Second call uses the cache — no new network hit.
-        assert src.original is None
+        assert src.original() is None
         assert mock_get_json.call_count == 1
 
 
@@ -1032,26 +1042,6 @@ class TestMaterialize:
             mock_client.materialize("ambientcg", "Rock064", "1k", tmp)
             assert mock_http.call_count == call_count_1  # no new HTTP calls
 
-    @patch("mat_vis_client.client._get_json")
-    @patch("mat_vis_client.client._get", side_effect=_mock_get)
-    def test_to_mtlx_generates_valid_document(self, mock_http, mock_json, mock_client):
-        # Deprecated but still functional.
-        mock_json.side_effect = [MOCK_ROWMAP, MOCK_INDEX_AMBIENTCG, MOCK_ROWMAP]
-        import warnings
-
-        with tempfile.TemporaryDirectory() as tmp:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", DeprecationWarning)
-                mtlx_path = mock_client.to_mtlx("ambientcg", "Rock064", "1k", tmp)
-            assert mtlx_path.exists()
-            assert mtlx_path.suffix == ".mtlx"
-
-            content = mtlx_path.read_text()
-            assert "UsdPreviewSurface" in content
-            assert "<nodegraph " in content
-            assert "color.png" in content
-            assert 'version="1.38"' in content
-
 
 # ── MtlxSource façade tests ────────────────────────────────────
 
@@ -1078,7 +1068,7 @@ class TestMtlxSource:
         """.xml only needs the rowmap + index, no texture byte fetches."""
         mock_json.side_effect = [MOCK_ROWMAP, MOCK_INDEX_AMBIENTCG]
         with patch("mat_vis_client.client._get") as mock_get:
-            xml = mock_client.mtlx("ambientcg", "Rock064", "1k").xml
+            xml = mock_client.mtlx("ambientcg", "Rock064", "1k").xml()
             # No _get (which fetches PNG bytes) should have been called.
             assert mock_get.call_count == 0
 
@@ -1092,8 +1082,8 @@ class TestMtlxSource:
         """Second .xml access returns the cached string."""
         mock_json.side_effect = [MOCK_ROWMAP, MOCK_INDEX_AMBIENTCG]
         source = mock_client.mtlx("ambientcg", "Rock064", "1k")
-        xml1 = source.xml
-        xml2 = source.xml
+        xml1 = source.xml()
+        xml2 = source.xml()
         assert xml1 is xml2
 
     @patch("mat_vis_client.client._get_json")
@@ -1118,14 +1108,14 @@ class TestMtlxSource:
         """.original is None when the source has no upstream mtlx map."""
         mock_json.side_effect = Exception("404")
         source = mock_client.mtlx("ambientcg", "Rock064", "1k")
-        assert source.original is None
+        assert source.original() is None
 
     @patch("mat_vis_client.client._get_json")
     def test_original_returns_none_for_unknown_material(self, mock_json, mock_client):
         """.original is None when the material isn't in the upstream map."""
         mock_json.return_value = {"other-uuid": "<materialx version='1.38'/>"}
         source = mock_client.mtlx("gpuopen", "nonexistent-uuid", "1k")
-        assert source.original is None
+        assert source.original() is None
 
     @patch("mat_vis_client.client._get_json")
     def test_original_returns_mtlxsource_for_gpuopen(self, mock_json, mock_client):
@@ -1133,7 +1123,7 @@ class TestMtlxSource:
         upstream_xml = '<?xml version="1.0"?><materialx version="1.38"><nodegraph/></materialx>'
         mock_json.return_value = {"test-uuid": upstream_xml}
         source = mock_client.mtlx("gpuopen", "test-uuid", "1k")
-        orig = source.original
+        orig = source.original()
         assert orig is not None
         assert orig.is_original is True
         assert orig.source == "gpuopen"
@@ -1148,7 +1138,7 @@ class TestMtlxSource:
             "</materialx>"
         )
         mock_json.return_value = {"test-uuid": upstream_xml}
-        xml = mock_client.mtlx("gpuopen", "test-uuid", "1k").original.xml
+        xml = mock_client.mtlx("gpuopen", "test-uuid", "1k").original().xml()
         assert xml == upstream_xml
 
     def test_original_on_original_returns_none(self, mock_client):
@@ -1156,7 +1146,7 @@ class TestMtlxSource:
         from mat_vis_client import MtlxSource
 
         fake_original = MtlxSource(mock_client, "gpuopen", "x", "1k", is_original=True)
-        assert fake_original.original is None
+        assert fake_original.original() is None
 
     @patch("mat_vis_client.client._get_json")
     @patch("mat_vis_client.client._get", side_effect=_mock_get)
@@ -1175,7 +1165,7 @@ class TestMtlxSource:
             MOCK_ROWMAP_GPUOPEN,
         ]
         with tempfile.TemporaryDirectory() as tmp:
-            orig = mock_client.mtlx("gpuopen", "test-uuid", "1k").original
+            orig = mock_client.mtlx("gpuopen", "test-uuid", "1k").original()
             assert orig is not None
             mtlx_path = orig.export(tmp)
             content = mtlx_path.read_text()
@@ -1192,91 +1182,10 @@ class TestMtlxSource:
             mock_json.return_value = {"test-uuid": "<materialx/>"}
             s1 = mock_client.mtlx("gpuopen", "test-uuid", "1k")
             s2 = mock_client.mtlx("gpuopen", "another-uuid", "1k")
-            assert s1.original is not None
-            assert s2.original is None
+            assert s1.original() is not None
+            assert s2.original() is None
             # Only one network call for the whole source's map, shared by both.
             assert mock_json.call_count == 1
-
-    def test_deprecated_to_mtlx_warns(self, mock_client):
-        """client.to_mtlx emits DeprecationWarning pointing at .mtlx(...).export."""
-        import warnings
-
-        with (
-            patch("mat_vis_client.client._get_json") as mock_json,
-            patch("mat_vis_client.client._get", side_effect=_mock_get),
-        ):
-            mock_json.side_effect = [MOCK_ROWMAP, MOCK_INDEX_AMBIENTCG, MOCK_ROWMAP]
-            with tempfile.TemporaryDirectory() as tmp:
-                with warnings.catch_warnings(record=True) as w:
-                    warnings.simplefilter("always")
-                    mock_client.to_mtlx("ambientcg", "Rock064", "1k", tmp)
-                assert any(
-                    issubclass(wi.category, DeprecationWarning) and "mtlx(" in str(wi.message)
-                    for wi in w
-                )
-
-    def test_deprecated_fetch_mtlx_original_warns(self, mock_client):
-        """client.fetch_mtlx_original emits DeprecationWarning."""
-        import warnings
-
-        with patch("mat_vis_client.client._get_json", return_value={}):
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
-                result = mock_client.fetch_mtlx_original("ambientcg", "Rock064")
-            assert result is None
-            assert any(issubclass(wi.category, DeprecationWarning) for wi in w)
-
-    def test_deprecated_materialize_mtlx_warns(self, mock_client):
-        """client.materialize_mtlx emits DeprecationWarning."""
-        import warnings
-
-        with (
-            patch("mat_vis_client.client._get_json") as mock_json,
-            patch("mat_vis_client.client._get", side_effect=_mock_get),
-        ):
-            # no-originals path: fetch originals (empty), then materialize + synthesize
-            mock_json.side_effect = [{}, MOCK_ROWMAP, MOCK_INDEX_AMBIENTCG, MOCK_ROWMAP]
-            with tempfile.TemporaryDirectory() as tmp:
-                with warnings.catch_warnings(record=True) as w:
-                    warnings.simplefilter("always")
-                    mock_client.materialize_mtlx("ambientcg", "Rock064", "1k", tmp)
-                assert any(issubclass(wi.category, DeprecationWarning) for wi in w)
-
-
-class TestFetchMtlxOriginal:
-    """Retained for backward compat — method still works, just warns."""
-
-    @patch("mat_vis_client.client._get_json")
-    def test_returns_xml_for_known_material(self, mock_json, mock_client):
-        import warnings
-
-        mock_json.return_value = {
-            "test-uuid": '<?xml version="1.0"?><materialx version="1.38"><nodegraph/></materialx>'
-        }
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            xml = mock_client.fetch_mtlx_original("gpuopen", "test-uuid")
-        assert xml is not None
-        assert "<materialx" in xml
-
-    @patch("mat_vis_client.client._get_json")
-    def test_returns_none_for_unknown(self, mock_json, mock_client):
-        import warnings
-
-        mock_json.return_value = {"other-uuid": "<materialx/>"}
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            xml = mock_client.fetch_mtlx_original("gpuopen", "nonexistent")
-        assert xml is None
-
-    @patch("mat_vis_client.client._get_json", side_effect=Exception("404"))
-    def test_returns_none_when_no_mtlx_asset(self, mock_json, mock_client):
-        import warnings
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            xml = mock_client.fetch_mtlx_original("ambientcg", "Rock064")
-        assert xml is None
 
 
 # ── Live tests (network required) ──────────────────────────────

--- a/clients/python/tests/test_cache.py
+++ b/clients/python/tests/test_cache.py
@@ -1,0 +1,209 @@
+"""Tests for cache modes and tag-keyed invalidation (#85 item 3).
+
+Two ADR-0004 gaps are closed here:
+
+1. ``cache=False`` mode — opt out of the on-disk cache entirely so no
+   reads hit the cache dir and no writes land on disk. Required for
+   ephemeral/stateless environments (CI, notebooks).
+
+2. Tag-keyed cache paths — data fetched for release v1 must not be
+   served when the client is asked for release v2. Before this, a
+   single ``~/.cache/mat-vis/`` held textures for whichever tag was
+   fetched first, causing silent data corruption on tag bumps.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mat_vis_client import MatVisClient
+
+
+MOCK_MANIFEST_V1 = {
+    "schema_version": 1,
+    "release_tag": "v2026.04.0",
+    "tiers": {
+        "1k": {
+            "base_url": "https://example.com/v2026.04.0/",
+            "sources": {
+                "ambientcg": {
+                    "parquet_files": ["ambientcg-1k.parquet"],
+                    "rowmap_file": "ambientcg-1k-rowmap.json",
+                },
+            },
+        }
+    },
+}
+
+MOCK_MANIFEST_V2 = {
+    "schema_version": 1,
+    "release_tag": "v2026.05.0",
+    "tiers": {
+        "1k": {
+            "base_url": "https://example.com/v2026.05.0/",
+            "sources": {
+                "ambientcg": {
+                    "parquet_files": ["ambientcg-1k.parquet"],
+                    "rowmap_file": "ambientcg-1k-rowmap.json",
+                },
+            },
+        }
+    },
+}
+
+MOCK_ROWMAP = {
+    "parquet_file": "ambientcg-1k.parquet",
+    "materials": {
+        "Rock064": {
+            "color": {
+                "offset": 0,
+                "length": 100,
+                "parquet_file": "ambientcg-1k.parquet",
+            }
+        }
+    },
+}
+
+TINY_PNG_V1 = (
+    b"\x89PNG\r\n\x1a\n"
+    b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02"
+    b"\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f"
+    b"\x00\x00\x01\x01\x00\x05\x18\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+TINY_PNG_V2 = b"\x89PNG" + b"v2_different_bytes_but_still_png_prefix" + b"\xaeB`\x82"
+
+
+@pytest.fixture
+def tmp_cache():
+    tmp = Path(tempfile.mkdtemp(prefix="mat-vis-test-cache-"))
+    yield tmp
+    import shutil
+
+    shutil.rmtree(tmp, ignore_errors=True)
+
+
+# ── cache=False ────────────────────────────────────────────────
+
+
+def test_cache_false_kwarg_accepted(tmp_cache):
+    """MatVisClient must accept cache=False kwarg."""
+    c = MatVisClient(cache_dir=tmp_cache, cache=False)
+    assert c._cache is False
+
+
+def test_cache_true_is_default(tmp_cache):
+    c = MatVisClient(cache_dir=tmp_cache)
+    assert c._cache is True
+
+
+def test_cache_false_does_not_write_manifest_to_disk(tmp_cache):
+    """With cache=False, fetching manifest must not create a .manifest.json."""
+    c = MatVisClient(cache_dir=tmp_cache, tag="v2026.04.0", cache=False)
+    with patch("mat_vis_client.client._get_json", return_value=MOCK_MANIFEST_V1):
+        _ = c.manifest
+    # No cached manifest anywhere under tmp_cache
+    matches = list(tmp_cache.rglob(".manifest.json"))
+    assert matches == [], f"expected no manifest cache, found: {matches}"
+
+
+def test_cache_false_fetches_manifest_every_time(tmp_cache):
+    """With cache=False, manifest is fetched on every .manifest access."""
+    c = MatVisClient(cache_dir=tmp_cache, tag="v2026.04.0", cache=False)
+    with patch("mat_vis_client.client._get_json", return_value=MOCK_MANIFEST_V1) as mock_get:
+        _ = c.manifest
+        # Re-reset the in-memory cache to force another fetch
+        c._manifest = None
+        _ = c.manifest
+        assert mock_get.call_count == 2
+
+
+def test_cache_false_skips_texture_disk_write(tmp_cache):
+    """Fetching a texture with cache=False writes no PNG to disk."""
+    c = MatVisClient(cache_dir=tmp_cache, tag="v2026.04.0", cache=False)
+    c._manifest = MOCK_MANIFEST_V1
+
+    def fake_get(url, headers=None, return_final_url=False):
+        if return_final_url:
+            return TINY_PNG_V1, url
+        return TINY_PNG_V1
+
+    with (
+        patch("mat_vis_client.client._get", side_effect=fake_get),
+        patch("mat_vis_client.client._get_json", return_value=MOCK_ROWMAP),
+    ):
+        data = c.fetch_texture("ambientcg", "Rock064", "color", tier="1k")
+    assert data == TINY_PNG_V1
+    pngs = list(tmp_cache.rglob("*.png"))
+    assert pngs == [], f"expected no cached pngs, found: {pngs}"
+
+
+# ── tag-keyed invalidation ─────────────────────────────────────
+
+
+def test_cache_path_includes_tag(tmp_cache):
+    """Textures for tag v1 live under a different subtree than tag v2."""
+    c1 = MatVisClient(cache_dir=tmp_cache, tag="v2026.04.0")
+    c2 = MatVisClient(cache_dir=tmp_cache, tag="v2026.05.0")
+    assert c1._cache_scope != c2._cache_scope
+    assert "v2026.04.0" in str(c1._cache_scope)
+    assert "v2026.05.0" in str(c2._cache_scope)
+
+
+def test_tag_switch_does_not_return_stale_bytes(tmp_cache):
+    """Fetching texture under v1 then under v2 must NOT return v1's bytes."""
+    # Populate v1 cache
+    c1 = MatVisClient(cache_dir=tmp_cache, tag="v2026.04.0")
+    c1._manifest = MOCK_MANIFEST_V1
+
+    def fake_get_v1(url, headers=None, return_final_url=False):
+        if return_final_url:
+            return TINY_PNG_V1, url
+        return TINY_PNG_V1
+
+    with (
+        patch("mat_vis_client.client._get", side_effect=fake_get_v1),
+        patch("mat_vis_client.client._get_json", return_value=MOCK_ROWMAP),
+    ):
+        got_v1 = c1.fetch_texture("ambientcg", "Rock064", "color", tier="1k")
+    assert got_v1 == TINY_PNG_V1
+
+    # Now ask v2: must NOT reuse v1 bytes from cache
+    c2 = MatVisClient(cache_dir=tmp_cache, tag="v2026.05.0")
+    c2._manifest = MOCK_MANIFEST_V2
+
+    def fake_get_v2(url, headers=None, return_final_url=False):
+        if return_final_url:
+            return TINY_PNG_V2, url
+        return TINY_PNG_V2
+
+    with (
+        patch("mat_vis_client.client._get", side_effect=fake_get_v2),
+        patch("mat_vis_client.client._get_json", return_value=MOCK_ROWMAP),
+    ):
+        got_v2 = c2.fetch_texture("ambientcg", "Rock064", "color", tier="1k")
+    assert got_v2 == TINY_PNG_V2, "stale cross-tag cache hit"
+
+
+def test_same_tag_reuses_cache(tmp_cache):
+    """Sanity: same tag, second fetch must use on-disk cache (no network)."""
+    c = MatVisClient(cache_dir=tmp_cache, tag="v2026.04.0")
+    c._manifest = MOCK_MANIFEST_V1
+
+    def fake_get(url, headers=None, return_final_url=False):
+        if return_final_url:
+            return TINY_PNG_V1, url
+        return TINY_PNG_V1
+
+    with (
+        patch("mat_vis_client.client._get", side_effect=fake_get) as mock_get,
+        patch("mat_vis_client.client._get_json", return_value=MOCK_ROWMAP),
+    ):
+        c.fetch_texture("ambientcg", "Rock064", "color", tier="1k")
+        c.fetch_texture("ambientcg", "Rock064", "color", tier="1k")
+        # Second call hits disk cache → only one _get call total
+        assert mock_get.call_count == 1

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -147,8 +147,9 @@ def mock_client():
     """Client with mocked HTTP and temp cache."""
     with tempfile.TemporaryDirectory() as tmp:
         client = MatVisClient(tag="v2026.04.0", cache_dir=Path(tmp))
-        # Pre-populate manifest cache so no HTTP needed
-        cache_path = Path(tmp) / ".manifest.json"
+        # Pre-populate manifest cache so no HTTP needed (tag-scoped path).
+        cache_path = Path(tmp) / "v2026.04.0" / ".manifest.json"
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
         cache_path.write_text(json.dumps(MOCK_MANIFEST))
         yield client
 

--- a/clients/python/tests/test_errors.py
+++ b/clients/python/tests/test_errors.py
@@ -201,8 +201,12 @@ def test_fetch_texture_404_raises_material_not_found_or_http_fetch_error():
         },
     }
 
-    client = MatVisClient(cache_dir="/tmp/mat-vis-test-errors", update_check=False)
-    # Inject manifest + rowmap
+    import tempfile
+    from pathlib import Path
+
+    tmp = Path(tempfile.mkdtemp(prefix="mat-vis-test-errors-"))
+    client = MatVisClient(cache_dir=tmp)
+    # Inject manifest + rowmap so no network call happens for those
     client._manifest = MOCK_MANIFEST
     client._rowmap_cache = {("ambientcg", "1k"): MOCK_ROWMAP}
 

--- a/clients/python/tests/test_errors.py
+++ b/clients/python/tests/test_errors.py
@@ -1,0 +1,221 @@
+"""Tests for typed mat_vis_client errors (#85 item 2).
+
+Every error surfaced to callers should be a ``MatVisError`` subclass —
+no bare ``urllib.error.HTTPError`` / ``urllib.error.URLError`` leakage.
+Error types carry structured attributes (url, code, kind, key, available)
+so callers can branch without string-matching messages.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+import urllib.error
+
+import pytest
+
+from mat_vis_client import MatVisError, RateLimitError
+from mat_vis_client.client import _lookup
+
+
+# ── Error hierarchy ────────────────────────────────────────────
+
+
+def test_not_found_error_is_matvis_error():
+    from mat_vis_client import NotFoundError
+
+    assert issubclass(NotFoundError, MatVisError)
+
+
+def test_material_not_found_error_hierarchy():
+    from mat_vis_client import MaterialNotFoundError, NotFoundError
+
+    assert issubclass(MaterialNotFoundError, NotFoundError)
+
+
+def test_tier_source_channel_not_found_hierarchy():
+    from mat_vis_client import (
+        ChannelNotFoundError,
+        NotFoundError,
+        SourceNotFoundError,
+        TierNotFoundError,
+    )
+
+    assert issubclass(SourceNotFoundError, NotFoundError)
+    assert issubclass(TierNotFoundError, NotFoundError)
+    assert issubclass(ChannelNotFoundError, NotFoundError)
+
+
+def test_http_fetch_error_is_matvis_error():
+    from mat_vis_client import HTTPFetchError
+
+    assert issubclass(HTTPFetchError, MatVisError)
+
+
+def test_network_error_is_matvis_error():
+    from mat_vis_client import NetworkError
+
+    assert issubclass(NetworkError, MatVisError)
+
+
+# ── NotFoundError structure ────────────────────────────────────
+
+
+def test_material_not_found_carries_structured_fields():
+    from mat_vis_client import MaterialNotFoundError
+
+    err = MaterialNotFoundError(
+        key="Rock999", available=["Rock064", "Rock063"], context="ambientcg/1k"
+    )
+    assert err.key == "Rock999"
+    assert err.available == ["Rock064", "Rock063"]
+    assert err.context == "ambientcg/1k"
+    # Message includes available list (actionable)
+    msg = str(err)
+    assert "Rock999" in msg
+    assert "Rock064" in msg  # "did you mean" hint
+
+
+# ── _lookup raises typed subclasses by kind ────────────────────
+
+
+def test_lookup_raises_material_not_found_for_material_kind():
+    from mat_vis_client import MaterialNotFoundError
+
+    with pytest.raises(MaterialNotFoundError) as exc:
+        _lookup({"Rock064": {}}, "Rock999", kind="material", context="ambientcg/1k")
+    assert exc.value.key == "Rock999"
+    assert "Rock064" in exc.value.available
+
+
+def test_lookup_raises_source_not_found_for_source_kind():
+    from mat_vis_client import SourceNotFoundError
+
+    with pytest.raises(SourceNotFoundError):
+        _lookup({"ambientcg": {}}, "polyhaven", kind="source")
+
+
+def test_lookup_raises_tier_not_found_for_tier_kind():
+    from mat_vis_client import TierNotFoundError
+
+    with pytest.raises(TierNotFoundError):
+        _lookup({"1k": {}}, "8k", kind="tier")
+
+
+def test_lookup_raises_channel_not_found_for_channel_kind():
+    from mat_vis_client import ChannelNotFoundError
+
+    with pytest.raises(ChannelNotFoundError):
+        _lookup({"color": {}}, "colosr", kind="channel", context="Rock064")
+
+
+def test_lookup_falls_back_to_matvis_error_for_unknown_kind():
+    """Backwards compat: unknown kinds still raise MatVisError."""
+    with pytest.raises(MatVisError):
+        _lookup({"a": 1}, "b", kind="widget")
+
+
+# ── HTTP errors are wrapped ────────────────────────────────────
+
+
+def test_get_wraps_http_error_into_http_fetch_error():
+    """_get() must translate urllib.HTTPError into HTTPFetchError for non-rate-limit codes."""
+    from mat_vis_client import HTTPFetchError
+    from mat_vis_client.client import _get
+
+    def fake_urlopen(req, timeout=60):
+        raise urllib.error.HTTPError(req.full_url, 404, "Not Found", {}, None)
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        with pytest.raises(HTTPFetchError) as exc:
+            _get("https://example.com/missing.png")
+        assert exc.value.code == 404
+        assert exc.value.url == "https://example.com/missing.png"
+
+
+def test_get_wraps_url_error_into_network_error():
+    """_get() must translate urllib.URLError (after retries) into NetworkError."""
+    from mat_vis_client import NetworkError
+    from mat_vis_client.client import _get
+
+    def fake_urlopen(req, timeout=60):
+        raise urllib.error.URLError("connection reset")
+
+    # patch sleep so retries are instant
+    with (
+        patch("urllib.request.urlopen", side_effect=fake_urlopen),
+        patch("time.sleep"),
+    ):
+        with pytest.raises(NetworkError):
+            _get("https://example.com/x")
+
+
+def test_rate_limit_still_raises_rate_limit_error():
+    """Rate-limited 429 after retries → RateLimitError (unchanged behavior)."""
+    from mat_vis_client.client import _get
+
+    def fake_urlopen(req, timeout=60):
+        raise urllib.error.HTTPError(
+            req.full_url, 429, "Too Many Requests", {"Retry-After": "1"}, None
+        )
+
+    with (
+        patch("urllib.request.urlopen", side_effect=fake_urlopen),
+        patch("time.sleep"),
+    ):
+        with pytest.raises(RateLimitError):
+            _get("https://example.com/x")
+
+
+# ── fetch_texture surfaces typed errors ────────────────────────
+
+
+def test_fetch_texture_404_raises_material_not_found_or_http_fetch_error():
+    """A 404 during fetch must surface as HTTPFetchError (not urllib leakage)."""
+    from mat_vis_client import HTTPFetchError, MatVisClient
+
+    MOCK_MANIFEST = {
+        "schema_version": 1,
+        "release_tag": "v2026.04.0",
+        "tiers": {
+            "1k": {
+                "base_url": "https://example.com/",
+                "sources": {
+                    "ambientcg": {
+                        "parquet_files": ["ambientcg-1k.parquet"],
+                        "rowmap_file": "ambientcg-1k-rowmap.json",
+                    },
+                },
+            }
+        },
+    }
+    MOCK_ROWMAP = {
+        "parquet_file": "ambientcg-1k.parquet",
+        "materials": {
+            "Rock064": {
+                "color": {
+                    "offset": 0,
+                    "length": 100,
+                    "parquet_file": "ambientcg-1k.parquet",
+                }
+            }
+        },
+    }
+
+    client = MatVisClient(cache_dir="/tmp/mat-vis-test-errors", update_check=False)
+    # Inject manifest + rowmap
+    client._manifest = MOCK_MANIFEST
+    client._rowmap_cache = {("ambientcg", "1k"): MOCK_ROWMAP}
+
+    def fake_urlopen(req, timeout=60):
+        raise urllib.error.HTTPError(req.full_url, 404, "Not Found", {}, None)
+
+    with (
+        patch("urllib.request.urlopen", side_effect=fake_urlopen),
+        patch("time.sleep"),
+    ):
+        with pytest.raises(HTTPFetchError) as exc:
+            client.fetch_texture("ambientcg", "Rock064", "color", tier="1k")
+        # Must NOT be a bare urllib error
+        assert not isinstance(exc.value, urllib.error.HTTPError)
+        # But HTTPFetchError carries the code
+        assert exc.value.code == 404

--- a/clients/python/tests/test_mtlx_api.py
+++ b/clients/python/tests/test_mtlx_api.py
@@ -1,0 +1,99 @@
+"""MaterialX API cleanup (#85 items 6 + 7).
+
+- Single path: ``client.mtlx(src, id, tier)`` returns an MtlxSource with
+  ``.xml()``, ``.export(path)``, and ``.original()``.
+- Deprecated shims are removed: ``to_mtlx``, ``fetch_mtlx_original``,
+  ``materialize_mtlx`` no longer exist on MatVisClient.
+- ``.xml`` and ``.original`` are network-triggering methods, not
+  attribute-access properties (the latter surprises non-Python readers).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+from mat_vis_client import MatVisClient, MtlxSource
+
+
+def test_mtlx_returns_mtlx_source():
+    c = MatVisClient()
+    m = c.mtlx("ambientcg", "Rock064", "1k")
+    assert isinstance(m, MtlxSource)
+
+
+# ── Deprecated shims removed ───────────────────────────────────
+
+
+def test_to_mtlx_removed():
+    """client.to_mtlx no longer exists (use client.mtlx(...).export(dir))."""
+    c = MatVisClient()
+    assert not hasattr(c, "to_mtlx")
+
+
+def test_fetch_mtlx_original_removed():
+    """client.fetch_mtlx_original no longer exists (use .mtlx(...).original())."""
+    c = MatVisClient()
+    assert not hasattr(c, "fetch_mtlx_original")
+
+
+def test_materialize_mtlx_removed():
+    c = MatVisClient()
+    assert not hasattr(c, "materialize_mtlx")
+
+
+# ── xml is a method, not a property ────────────────────────────
+
+
+def test_xml_is_callable_method():
+    """MtlxSource.xml must be a method — attribute access shouldn't
+    trigger IO (footgun; doesn't translate to Rust/Go/JS)."""
+    c = MatVisClient()
+    m = c.mtlx("ambientcg", "Rock064", "1k")
+    # Attribute access should yield the method, NOT raise / fetch.
+    assert callable(m.xml), "MtlxSource.xml must be a method"
+
+
+def test_xml_method_returns_string():
+    """Calling .xml() returns the MaterialX document string."""
+    c = MatVisClient()
+    m = c.mtlx("ambientcg", "Rock064", "1k")
+    with (
+        patch.object(c, "channels", return_value=["color", "normal"]),
+        patch.object(c, "_scalars_for", return_value={"roughness": 0.5}),
+    ):
+        result = m.xml()
+    assert isinstance(result, str)
+    assert "materialx" in result
+
+
+# ── original is a method, not a property ───────────────────────
+
+
+def test_original_is_callable_method():
+    c = MatVisClient()
+    m = c.mtlx("ambientcg", "Rock064", "1k")
+    assert callable(m.original), "MtlxSource.original must be a method"
+
+
+def test_original_returns_none_when_no_upstream():
+    c = MatVisClient()
+    m = c.mtlx("ambientcg", "Rock064", "1k")
+    with patch.object(c, "_fetch_mtlx_original_map", return_value={}):
+        assert m.original() is None
+
+
+def test_original_returns_alternate_mtlx_source():
+    c = MatVisClient()
+    m = c.mtlx("gpuopen", "Metal032", "1k")
+    with patch.object(c, "_fetch_mtlx_original_map", return_value={"Metal032": "<mtlx/>"}):
+        alt = m.original()
+    assert isinstance(alt, MtlxSource)
+    assert alt.is_original is True
+
+
+def test_original_on_original_returns_none():
+    """Calling .original() on an already-original source yields None."""
+    c = MatVisClient()
+    orig = MtlxSource(c, "gpuopen", "Metal032", "1k", is_original=True)
+    assert orig.original() is None

--- a/clients/python/tests/test_per_op_tag.py
+++ b/clients/python/tests/test_per_op_tag.py
@@ -70,11 +70,10 @@ def test_fetch_texture_accepts_tag_kwarg(tmp_cache):
     c._manifest = MOCK_MANIFEST_V1
 
     def fake_get_json(url):
-        # base client asks for v1 rowmap; tag-override asks for v2
-        if "v2026.05.0" in url:
-            return MOCK_MANIFEST_V2
-        if "v2026.04.0" in url:
-            return MOCK_MANIFEST_V1
+        # manifest requests include "release-manifest.json"; rowmaps
+        # include "rowmap.json"; everything else fallback.
+        if "release-manifest.json" in url:
+            return MOCK_MANIFEST_V2 if "v2026.05.0" in url else MOCK_MANIFEST_V1
         return MOCK_ROWMAP
 
     def fake_get(url, headers=None, return_final_url=False):
@@ -97,8 +96,8 @@ def test_fetch_texture_tag_override_does_not_mutate_client(tmp_cache):
     c._manifest = MOCK_MANIFEST_V1
 
     def fake_get_json(url):
-        if "v2026.05.0" in url:
-            return MOCK_MANIFEST_V2
+        if "release-manifest.json" in url:
+            return MOCK_MANIFEST_V2 if "v2026.05.0" in url else MOCK_MANIFEST_V1
         return MOCK_ROWMAP
 
     def fake_get(url, headers=None, return_final_url=False):

--- a/clients/python/tests/test_per_op_tag.py
+++ b/clients/python/tests/test_per_op_tag.py
@@ -1,0 +1,167 @@
+"""Per-operation ``tag=`` kwarg (#85 item 4).
+
+Methods on MatVisClient must accept an optional ``tag=`` override so a
+single client instance can fetch from multiple releases without the
+user having to instantiate parallel clients (hf-hub ``revision=`` pattern).
+
+The override shares the parent's cache_dir and cache flag — so the
+tag-scoped cache (task 3) still does the right thing.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mat_vis_client import MatVisClient
+
+
+MOCK_MANIFEST_V1 = {
+    "schema_version": 1,
+    "release_tag": "v2026.04.0",
+    "tiers": {
+        "1k": {
+            "base_url": "https://example.com/v2026.04.0/",
+            "sources": {
+                "ambientcg": {
+                    "parquet_files": ["ambientcg-1k.parquet"],
+                    "rowmap_file": "ambientcg-1k-rowmap.json",
+                },
+            },
+        }
+    },
+}
+MOCK_MANIFEST_V2 = {**MOCK_MANIFEST_V1, "release_tag": "v2026.05.0"}
+MOCK_MANIFEST_V2["tiers"] = {
+    "1k": {
+        "base_url": "https://example.com/v2026.05.0/",
+        "sources": MOCK_MANIFEST_V1["tiers"]["1k"]["sources"],
+    }
+}
+
+MOCK_ROWMAP = {
+    "parquet_file": "ambientcg-1k.parquet",
+    "materials": {
+        "Rock064": {
+            "color": {"offset": 0, "length": 100, "parquet_file": "ambientcg-1k.parquet"},
+        }
+    },
+}
+
+TINY_PNG_V1 = b"\x89PNG" + b"v1" * 40 + b"IEND"
+TINY_PNG_V2 = b"\x89PNG" + b"v2" * 40 + b"IEND"
+
+
+@pytest.fixture
+def tmp_cache():
+    tmp = Path(tempfile.mkdtemp(prefix="mat-vis-test-op-tag-"))
+    yield tmp
+    import shutil
+
+    shutil.rmtree(tmp, ignore_errors=True)
+
+
+def test_fetch_texture_accepts_tag_kwarg(tmp_cache):
+    """fetch_texture must accept tag= override."""
+    c = MatVisClient(cache_dir=tmp_cache, tag="v2026.04.0")
+    c._manifest = MOCK_MANIFEST_V1
+
+    def fake_get_json(url):
+        # base client asks for v1 rowmap; tag-override asks for v2
+        if "v2026.05.0" in url:
+            return MOCK_MANIFEST_V2
+        if "v2026.04.0" in url:
+            return MOCK_MANIFEST_V1
+        return MOCK_ROWMAP
+
+    def fake_get(url, headers=None, return_final_url=False):
+        png = TINY_PNG_V2 if "v2026.05.0" in url else TINY_PNG_V1
+        if return_final_url:
+            return png, url
+        return png
+
+    with (
+        patch("mat_vis_client.client._get", side_effect=fake_get),
+        patch("mat_vis_client.client._get_json", side_effect=fake_get_json),
+    ):
+        data = c.fetch_texture("ambientcg", "Rock064", "color", tier="1k", tag="v2026.05.0")
+    assert data == TINY_PNG_V2, "tag override should fetch v2 bytes"
+
+
+def test_fetch_texture_tag_override_does_not_mutate_client(tmp_cache):
+    """Passing tag= must not change the client's default tag."""
+    c = MatVisClient(cache_dir=tmp_cache, tag="v2026.04.0")
+    c._manifest = MOCK_MANIFEST_V1
+
+    def fake_get_json(url):
+        if "v2026.05.0" in url:
+            return MOCK_MANIFEST_V2
+        return MOCK_ROWMAP
+
+    def fake_get(url, headers=None, return_final_url=False):
+        png = TINY_PNG_V2 if "v2026.05.0" in url else TINY_PNG_V1
+        if return_final_url:
+            return png, url
+        return png
+
+    with (
+        patch("mat_vis_client.client._get", side_effect=fake_get),
+        patch("mat_vis_client.client._get_json", side_effect=fake_get_json),
+    ):
+        c.fetch_texture("ambientcg", "Rock064", "color", tier="1k", tag="v2026.05.0")
+
+    assert c._tag == "v2026.04.0", "client's default tag must not change"
+
+
+def test_at_helper_returns_tag_scoped_client(tmp_cache):
+    """client.at(tag) returns an alternate client sharing cache_dir."""
+    c = MatVisClient(cache_dir=tmp_cache, tag="v2026.04.0")
+    alt = c.at("v2026.05.0")
+    assert alt._tag == "v2026.05.0"
+    assert alt._cache_dir == c._cache_dir
+    assert alt._cache == c._cache
+
+
+def test_at_helper_caches_alternate_clients(tmp_cache):
+    """Repeated .at(tag) calls return the same cached subclient."""
+    c = MatVisClient(cache_dir=tmp_cache, tag="v2026.04.0")
+    alt1 = c.at("v2026.05.0")
+    alt2 = c.at("v2026.05.0")
+    assert alt1 is alt2
+
+
+def test_at_self_returns_self(tmp_cache):
+    """.at(current_tag) returns self (no useless subclient)."""
+    c = MatVisClient(cache_dir=tmp_cache, tag="v2026.04.0")
+    assert c.at("v2026.04.0") is c
+
+
+def test_prefetch_accepts_tag_kwarg(tmp_cache):
+    """prefetch supports tag= override."""
+    c = MatVisClient(cache_dir=tmp_cache, tag="v2026.04.0")
+    c._manifest = MOCK_MANIFEST_V1
+
+    # Should not raise on the signature — actual behavior tested elsewhere
+    import inspect
+
+    sig = inspect.signature(c.prefetch)
+    assert "tag" in sig.parameters
+
+
+def test_search_accepts_tag_kwarg(tmp_cache):
+    c = MatVisClient(cache_dir=tmp_cache, tag="v2026.04.0")
+    import inspect
+
+    sig = inspect.signature(c.search)
+    assert "tag" in sig.parameters
+
+
+def test_mtlx_accepts_tag_kwarg(tmp_cache):
+    c = MatVisClient(cache_dir=tmp_cache, tag="v2026.04.0")
+    import inspect
+
+    sig = inspect.signature(c.mtlx)
+    assert "tag" in sig.parameters

--- a/clients/python/tests/test_public_api.py
+++ b/clients/python/tests/test_public_api.py
@@ -1,0 +1,61 @@
+"""Public surface tests (#84, #85).
+
+Covers promotion of ``_get_client`` to ``get_client`` while keeping the
+private name around for one release as a deprecated alias.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+
+def test_get_client_is_public():
+    """``from mat_vis_client import get_client`` must work."""
+    from mat_vis_client import get_client, MatVisClient
+
+    c = get_client()
+    assert isinstance(c, MatVisClient)
+
+
+def test_get_client_returns_singleton():
+    """Repeated calls return the same instance (process-wide cache share)."""
+    from mat_vis_client import get_client
+
+    assert get_client() is get_client()
+
+
+def test_get_client_in_public_all():
+    """__all__ advertises get_client — not just the private alias."""
+    import mat_vis_client
+
+    assert "get_client" in mat_vis_client.__all__
+
+
+def test_private_get_client_still_works():
+    """Back-compat: the old ``_get_client`` import path still returns a client."""
+    from mat_vis_client import _get_client, MatVisClient
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        c = _get_client()
+    assert isinstance(c, MatVisClient)
+
+
+def test_private_get_client_warns():
+    """Using ``_get_client`` emits DeprecationWarning pointing at get_client."""
+    from mat_vis_client import _get_client
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _get_client()
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert deprecations, "expected DeprecationWarning on _get_client()"
+    assert "get_client" in str(deprecations[0].message)
+
+
+def test_private_and_public_return_same_singleton():
+    from mat_vis_client import _get_client, get_client
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        assert _get_client() is get_client()

--- a/clients/python/tests/test_schema.py
+++ b/clients/python/tests/test_schema.py
@@ -122,7 +122,9 @@ def test_adapters_reference_schema_maps_by_identity():
     assert adapters._THREEJS_TEX_MAP is schema.THREEJS_MAP
     assert adapters._GLTF_TEX_MAP is schema.GLTF_MAP
     assert adapters._USD_PREVIEW_TEX_MAP is schema.USD_PREVIEW_MAP
-    assert adapters._MTLX_TEX_MAP is schema.MTLX_MAP
+    # MTLX_MAP is exported by schema but unused by adapters (MaterialX is
+    # built via USD_PREVIEW_MAP); the schema export is for future consumers.
+    assert hasattr(schema, "MTLX_MAP")
 
 
 def test_client_filename_map_is_schema_derived():

--- a/clients/python/tests/test_schema.py
+++ b/clients/python/tests/test_schema.py
@@ -1,0 +1,175 @@
+"""Tests for mat_vis_client.schema — single source of truth for channels.
+
+Enforces that adapter / client maps are *derived* from the registry
+rather than hand-maintained duplicates. Any new channel added to the
+registry must automatically propagate to every consumer.
+"""
+
+from __future__ import annotations
+
+
+def test_schema_module_exists():
+    """schema.py exposes Channel enum, ChannelSpec, and CHANNELS registry."""
+    from mat_vis_client import schema
+
+    assert hasattr(schema, "Channel")
+    assert hasattr(schema, "ChannelSpec")
+    assert hasattr(schema, "CHANNELS")
+    assert len(schema.CHANNELS) >= 7  # color, normal, rough, metal, ao, disp, emission
+
+
+def test_channel_enum_values():
+    from mat_vis_client.schema import Channel
+
+    assert Channel.COLOR.value == "color"
+    assert Channel.NORMAL.value == "normal"
+    assert Channel.ROUGHNESS.value == "roughness"
+    assert Channel.METALNESS.value == "metalness"
+    assert Channel.AO.value == "ao"
+    assert Channel.DISPLACEMENT.value == "displacement"
+    assert Channel.EMISSION.value == "emission"
+
+
+def test_tier_enum_values():
+    from mat_vis_client.schema import Tier
+
+    assert Tier.T1K.value == "1k"
+    assert Tier.T2K.value == "2k"
+    assert Tier.T4K.value == "4k"
+
+
+def test_channel_spec_has_all_renderer_props():
+    """Every ChannelSpec carries props for every supported renderer."""
+    from mat_vis_client.schema import CHANNELS
+
+    for spec in CHANNELS:
+        assert spec.threejs_prop  # required
+        assert spec.mtlx_prop
+        assert spec.usd_preview_prop
+        assert spec.usd_preview_type in ("color3", "vector3", "float")
+        # gltf_prop may be None (metalness/roughness pack into one tex)
+        assert isinstance(spec.filename_aliases, tuple)
+
+
+def test_derived_threejs_map_matches_registry():
+    from mat_vis_client.schema import CHANNELS, THREEJS_MAP
+
+    assert set(THREEJS_MAP) == {s.channel.value for s in CHANNELS}
+    for s in CHANNELS:
+        assert THREEJS_MAP[s.channel.value] == s.threejs_prop
+
+
+def test_derived_gltf_map_skips_none_props():
+    from mat_vis_client.schema import CHANNELS, GLTF_MAP
+
+    for s in CHANNELS:
+        if s.gltf_prop is None:
+            assert s.channel.value not in GLTF_MAP
+        else:
+            assert GLTF_MAP[s.channel.value] == s.gltf_prop
+
+
+def test_derived_usd_preview_map_carries_types():
+    from mat_vis_client.schema import CHANNELS, USD_PREVIEW_MAP
+
+    for s in CHANNELS:
+        assert USD_PREVIEW_MAP[s.channel.value] == (s.usd_preview_prop, s.usd_preview_type)
+
+
+def test_filename_to_channel_built_from_aliases():
+    from mat_vis_client.schema import CHANNELS, FILENAME_TO_CHANNEL
+
+    for s in CHANNELS:
+        for alias in s.filename_aliases:
+            assert FILENAME_TO_CHANNEL[alias] == s.channel.value
+
+
+def test_filename_aliases_cover_known_upstream_names():
+    """Regression: old _FILENAME_TO_CHANNEL hardcoded these mappings."""
+    from mat_vis_client.schema import FILENAME_TO_CHANNEL
+
+    expected = {
+        "basecolor": "color",
+        "base_color": "color",
+        "diffuse": "color",
+        "normal": "normal",
+        "roughness": "roughness",
+        "specular_roughness": "roughness",
+        "metallic": "metalness",
+        "metalness": "metalness",
+        "occlusion": "ao",
+        "ao": "ao",
+        "ambientocclusion": "ao",
+        "displacement": "displacement",
+        "height": "displacement",
+        "emission": "emission",
+        "emissive": "emission",
+    }
+    for alias, channel in expected.items():
+        assert FILENAME_TO_CHANNEL[alias] == channel, f"{alias!r} expected to map to {channel!r}"
+
+
+def test_adapters_reference_schema_maps_by_identity():
+    """No duplicate maps in adapters — they must be the registry objects.
+
+    If someone re-declares _THREEJS_TEX_MAP / _GLTF_TEX_MAP / _USD_PREVIEW_TEX_MAP
+    locally instead of importing from schema, this test fails. This is the
+    DRY invariant: one edit in schema = every adapter updated.
+    """
+    from mat_vis_client import adapters
+    from mat_vis_client import schema
+
+    assert adapters._THREEJS_TEX_MAP is schema.THREEJS_MAP
+    assert adapters._GLTF_TEX_MAP is schema.GLTF_MAP
+    assert adapters._USD_PREVIEW_TEX_MAP is schema.USD_PREVIEW_MAP
+    assert adapters._MTLX_TEX_MAP is schema.MTLX_MAP
+
+
+def test_client_filename_map_is_schema_derived():
+    """client.py's _FILENAME_TO_CHANNEL must be the schema-derived one."""
+    from mat_vis_client import client
+    from mat_vis_client import schema
+
+    assert client._FILENAME_TO_CHANNEL is schema.FILENAME_TO_CHANNEL
+
+
+def test_registry_is_the_single_source_for_channels():
+    """Adding a channel to schema.CHANNELS propagates to all derived maps.
+
+    This is the core DRY invariant enforced by the registry pattern.
+    Simulates adding a hypothetical channel and verifies all views
+    pick it up through the derivation functions.
+    """
+    from mat_vis_client.schema import (
+        ChannelSpec,
+        build_threejs_map,
+        build_gltf_map,
+        build_usd_preview_map,
+        build_mtlx_map,
+        build_filename_to_channel,
+    )
+
+    # Fake channel added to an ad-hoc registry
+    fake_specs = [
+        ChannelSpec(
+            channel="transmission",  # type: ignore[arg-type]
+            threejs_prop="transmissionMap",
+            gltf_prop="transmissionTexture",
+            mtlx_prop="transmission",
+            usd_preview_prop="transmission",
+            usd_preview_type="float",
+            filename_aliases=("transmission",),
+        )
+    ]
+
+    tj = build_threejs_map(fake_specs)
+    gl = build_gltf_map(fake_specs)
+    usd = build_usd_preview_map(fake_specs)
+    mx = build_mtlx_map(fake_specs)
+    fn = build_filename_to_channel(fake_specs)
+
+    assert tj["transmission"] == "transmissionMap"
+    assert gl["transmission"] == "transmissionTexture"
+    assert usd["transmission"] == ("transmission", "float")
+    assert mx["transmission"] == "transmission"
+    assert fn["transmission"] == "transmission"

--- a/clients/python/tests/test_search_unified.py
+++ b/clients/python/tests/test_search_unified.py
@@ -1,0 +1,133 @@
+"""Unified search API (#85 item 5).
+
+Goal: one canonical signature. Module-level ``search()`` forwards to
+``MatVisClient.search()``; the scalar-shorthand form is handled by the
+method itself, not by a divergent module-level function.
+
+This kills the two-surface problem where the same operation had two
+different parameter conventions depending on where you called it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+import mat_vis_client
+
+
+MOCK_INDEX = [
+    {
+        "material_id": "Metal032",
+        "source": "ambientcg",
+        "category": "metal",
+        "roughness": 0.3,
+        "metalness": 1.0,
+        "available_tiers": ["1k", "2k"],
+    },
+    {
+        "material_id": "Metal050A",
+        "source": "ambientcg",
+        "category": "metal",
+        "roughness": 0.5,
+        "metalness": 1.0,
+        "available_tiers": ["1k"],
+    },
+    {
+        "material_id": "Wood002",
+        "source": "ambientcg",
+        "category": "wood",
+        "roughness": 0.7,
+        "metalness": 0.0,
+        "available_tiers": ["1k"],
+    },
+]
+
+
+def _fresh_singleton():
+    """Reset the module-level singleton so each test starts clean."""
+    mat_vis_client._client = None
+
+
+# ── Method search accepts scalar shorthand ─────────────────────
+
+
+def test_method_search_accepts_scalar_roughness():
+    """client.search(roughness=0.3) should widen into a range automatically."""
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    with patch.object(c, "sources", return_value=["ambientcg"]):
+        with patch.object(c, "index", return_value=MOCK_INDEX):
+            with patch.object(c, "categories", return_value=frozenset(["metal", "wood"])):
+                results = c.search(category="metal", roughness=0.3)
+    # Only materials within roughness ± 0.2 of 0.3 → [0.1, 0.5]
+    ids = [r["material_id"] for r in results]
+    assert "Metal032" in ids  # 0.3 → center
+    assert "Metal050A" in ids  # 0.5 → boundary, inclusive
+
+
+def test_method_search_accepts_scalar_metalness():
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    with patch.object(c, "sources", return_value=["ambientcg"]):
+        with patch.object(c, "index", return_value=MOCK_INDEX):
+            with patch.object(c, "categories", return_value=frozenset(["metal", "wood"])):
+                results = c.search(metalness=1.0)
+    ids = {r["material_id"] for r in results}
+    assert "Metal032" in ids
+    assert "Wood002" not in ids
+
+
+def test_method_search_score_option_sorts_by_distance():
+    """search(roughness=0.3, score=True) sorts by |r - 0.3|."""
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    with patch.object(c, "sources", return_value=["ambientcg"]):
+        with patch.object(c, "index", return_value=MOCK_INDEX):
+            with patch.object(c, "categories", return_value=frozenset(["metal", "wood"])):
+                results = c.search(category="metal", roughness=0.3, score=True)
+    # Metal032 (0.3, diff 0) comes before Metal050A (0.5, diff 0.2)
+    ids = [r["material_id"] for r in results]
+    assert ids[0] == "Metal032"
+    for r in results:
+        assert "score" in r
+
+
+def test_method_search_rejects_both_scalar_and_range():
+    """Passing both roughness and roughness_range is ambiguous; raise."""
+    from mat_vis_client import MatVisClient, MatVisError
+
+    c = MatVisClient()
+    with pytest.raises(MatVisError, match="roughness"):
+        c.search(roughness=0.3, roughness_range=(0.1, 0.5))
+
+
+# ── Module-level forwards to the same method ───────────────────
+
+
+def test_module_search_forwards_to_client_method():
+    """search() (module) returns the same results as client.search() for
+    equivalent input — no divergent implementation."""
+    _fresh_singleton()
+    from mat_vis_client import search as module_search
+    from mat_vis_client import get_client
+
+    client = get_client()
+    with patch.object(client, "sources", return_value=["ambientcg"]):
+        with patch.object(client, "index", return_value=MOCK_INDEX):
+            with patch.object(client, "categories", return_value=frozenset(["metal", "wood"])):
+                mod_results = module_search(category="metal", roughness=0.3)
+                _fresh_singleton()
+
+    client2 = get_client()
+    with patch.object(client2, "sources", return_value=["ambientcg"]):
+        with patch.object(client2, "index", return_value=MOCK_INDEX):
+            with patch.object(client2, "categories", return_value=frozenset(["metal", "wood"])):
+                method_results = client2.search(category="metal", roughness=0.3, score=True)
+
+    # Module-level is equivalent to method-level with score=True
+    assert [r["material_id"] for r in mod_results] == [r["material_id"] for r in method_results]


### PR DESCRIPTION
## Summary

Independent code review of `mat-vis-client` surfaced a 7-item punch list (#85) plus an external ask from the py-mat team (#84). This PR ships all 8 items as TDD red-green pairs, bumps the client to **0.5.0**, and closes both issues.

**64 new tests** (12 schema + 15 errors + 8 cache + 8 per-op tag + 5 search + 10 mtlx + 6 public API). Zero regressions against baseline — same 8 pre-existing failures unchanged.

## What changed

| # | Change | Impact |
|---|---|---|
| 1 | `schema.py` registry → all channel maps derive from one source | DRY — adding a channel = one edit |
| 2 | Typed `MatVisError` hierarchy (`NotFoundError` + `HTTPFetchError` + `NetworkError`) | No more raw `urllib.error.*` leakage |
| 3 | `cache=False` mode + tag-scoped cache paths | Closes ADR-0004 gap; prevents cross-tag contamination |
| 4 | Per-op `tag=` kwarg + `client.at(tag)` memoized subclient | One client, many releases (hf-hub `revision=` pattern) |
| 5 | Unified `search()` — scalar shorthand + `score=True` on the method | Module-level is now a thin forwarder |
| 6 | Collapsed MaterialX surface — dropped `to_mtlx`, `fetch_mtlx_original`, `materialize_mtlx` | **Breaking** (intentional); single `.mtlx()` path |
| 7 | `MtlxSource.xml()` / `.original()` are methods (were properties) | **Breaking**; ports cleanly to JS/Rust |
| 8 | Public `get_client()` ; `_get_client` deprecated (#84) | Unblocks py-mat's `Vis.client` property |

## Breaking changes (0.5.0)

- Three deprecated MaterialX shims removed (items 6).
- `MtlxSource.xml` and `MtlxSource.original` are now methods, not attributes (item 7).
- `_get_client` still works but emits `DeprecationWarning` — will be removed in 0.6.0.

## Test plan

- [x] All 64 new tests green (`uv run pytest tests/test_{schema,errors,cache,per_op_tag,search_unified,mtlx_api,public_api}.py`)
- [x] Zero regressions on `test_client.py` — same 8 baseline failures that existed before this branch (all unrelated: one stale schema-validation assertion, three `standard_surface`-vs-`UsdPreviewSurface` tests that pre-date the 0.4 mtlx rewrite, one dynamic-categories test, three live-network tests)
- [ ] CI green on this PR
- [ ] Merge → release-please opens a 0.5.0 release PR automatically
- [ ] After release: py-mat floor-bumps to `mat-vis-client>=0.5.0` and swaps `_get_client` → `get_client`

## Commits

15 commits: 7 red-green pairs (one per item, items 6+7 bundled) + version bump. Every refactor is preceded by a failing test that locks in the target invariant, then the green commit makes it pass.

Closes #85
Closes #84