### PR TITLE
feat(qa): upstream catalog + mutation harness — Phase 2+3 of #88 (stacked on #89)

### DIFF
--- a/scripts/snapshot_upstream_catalog.py
+++ b/scripts/snapshot_upstream_catalog.py
@@ -1,0 +1,127 @@
+"""Snapshot upstream catalogs into ``upstream-catalog.json``.
+
+Called at release prep time to capture what each upstream source
+*currently advertises*. The validator's catalog-contract gate
+(#88 Phase 2) uses this as the truth baseline — bakes must match
+``upstream \\ WAIVED``.
+
+Per-release JSON is committed as a release asset and in
+``metrics/upstream-catalog-{tag}.json`` so diffs across releases
+surface upstream additions and removals (``diff catalog_N catalog_{N-1}``).
+
+Usage::
+
+    python -m scripts.snapshot_upstream_catalog \\
+        --release-tag v2026.04.1 \\
+        --out metrics/upstream-catalog-v2026.04.1.json \\
+        [--sources ambientcg polyhaven gpuopen]
+
+Network: this script hits live upstream APIs. For offline/testing,
+inject IDs via ``_ids_for_source`` (mockable — see tests).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+__all__ = [
+    "build_catalog",
+    "snapshot",
+]
+
+
+def _ids_for_source(source: str) -> list[str]:
+    """Call the source adapter's discover() and extract material IDs.
+
+    This is the one network-hitting hook. Mocked in tests so the rest
+    of the snapshot logic (JSON shape, sorting, aggregation) is unit
+    testable without live APIs.
+    """
+    # Deferred imports: adapters pull in requests etc. which shouldn't
+    # be loaded for offline tests that mock this function.
+    if source == "ambientcg":
+        from mat_vis_baker.sources.ambientcg import discover
+
+        return [e["assetId"] for e in discover()]
+    if source == "polyhaven":
+        from mat_vis_baker.sources.polyhaven import discover
+
+        # polyhaven.discover() returns {slug: meta, ...}
+        return list(discover().keys())
+    if source == "gpuopen":
+        from mat_vis_baker.sources.gpuopen import discover
+
+        return [e.get("id") or e.get("name") for e in discover() if e]
+    raise ValueError(f"unknown source: {source!r}")
+
+
+def build_catalog(
+    *,
+    release_tag: str,
+    sources: dict[str, list[str]],
+    snapshotted_at: str | None = None,
+) -> dict:
+    """Build the catalog dict from a mapping of ``source -> [ids]``.
+
+    Pure function — no IO. IDs are sorted for deterministic output so
+    ``diff`` between releases produces meaningful line-by-line deltas.
+    """
+    if snapshotted_at is None:
+        snapshotted_at = datetime.now(timezone.utc).isoformat()
+    return {
+        "release_tag": release_tag,
+        "snapshotted_at": snapshotted_at,
+        "sources": {
+            name: {"count": len(ids), "ids": sorted(set(ids))} for name, ids in sources.items()
+        },
+    }
+
+
+def snapshot(
+    *,
+    output_path: Path,
+    release_tag: str,
+    sources: list[str],
+) -> dict:
+    """Fetch each source's ID list, build the catalog, write to ``output_path``.
+
+    Returns the catalog dict so callers can chain (e.g. to compute stats
+    in the same workflow step).
+    """
+    ids_by_source = {name: _ids_for_source(name) for name in sources}
+    catalog = build_catalog(release_tag=release_tag, sources=ids_by_source)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(catalog, indent=2) + "\n")
+    return catalog
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="snapshot-upstream-catalog")
+    p.add_argument("--release-tag", required=True)
+    p.add_argument("--out", required=True, type=Path)
+    p.add_argument(
+        "--sources",
+        nargs="+",
+        default=["ambientcg", "polyhaven", "gpuopen"],
+        help="sources to snapshot (default: all three)",
+    )
+    args = p.parse_args(argv)
+    cat = snapshot(
+        output_path=args.out,
+        release_tag=args.release_tag,
+        sources=args.sources,
+    )
+    total = sum(s["count"] for s in cat["sources"].values())
+    print(f"snapshot {args.release_tag}: {total} materials across {len(cat['sources'])} sources")
+    for name, s in sorted(cat["sources"].items()):
+        print(f"  {name}: {s['count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -44,8 +44,11 @@ DEFAULT_EXCLUDE_TIER_PREFIXES = ("ktx2-",)
 
 
 __all__ = [
+    "baked_ids_from_rowmap_dir",
+    "find_catalog_violations",
     "find_regressions",
     "find_tier_parity_violations",
+    "load_waivers",
     "main",
 ]
 
@@ -153,6 +156,127 @@ def find_tier_parity_violations(
                     }
                 )
     return violations
+
+
+# ── Phase 2: upstream-catalog contract ──────────────────────────
+
+
+def load_waivers(path: Path) -> dict[tuple[str, str], set[str]]:
+    """Parse ``waived.yaml`` → ``{(source, tier): {id, ...}}``.
+
+    Missing or empty file returns ``{}`` — waivers are optional. YAML
+    shape::
+
+        polyhaven:
+          "2k":
+            - id_not_available_upstream_at_2k
+        gpuopen:
+          "1k":
+            - special_case
+    """
+    path = Path(path)
+    if not path.exists():
+        return {}
+    raw = path.read_text()
+    if not raw.strip():
+        return {}
+
+    # PyYAML is the only external dep introduced here; fall back to a
+    # minimal parser if it's not installed (keeps the validator usable
+    # in stripped-down CI containers).
+    try:
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(raw) or {}
+    except ImportError:  # pragma: no cover — tested envs install pyyaml
+        data = _minimal_yaml(raw)
+
+    out: dict[tuple[str, str], set[str]] = {}
+    for source, tiers in (data or {}).items():
+        for tier, ids in (tiers or {}).items():
+            key = (str(source), str(tier))
+            out[key] = set(ids or [])
+    return out
+
+
+def _minimal_yaml(s: str) -> dict:
+    """Bare-bones YAML subset parser for waived.yaml (source → tier → list).
+
+    Not a full YAML; only handles the exact two-level-plus-list shape we
+    document. Used only when PyYAML isn't installed.
+    """
+    out: dict = {}
+    current_source = None
+    current_tier = None
+    for line in s.splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        stripped = line.strip()
+        if indent == 0 and stripped.endswith(":"):
+            current_source = stripped[:-1].strip().strip('"')
+            out[current_source] = {}
+            current_tier = None
+        elif indent == 2 and stripped.endswith(":"):
+            current_tier = stripped[:-1].strip().strip('"')
+            out[current_source][current_tier] = []
+        elif stripped.startswith("- ") and current_tier is not None:
+            out[current_source][current_tier].append(stripped[2:].strip().strip('"'))
+    return out
+
+
+def find_catalog_violations(
+    *,
+    upstream: dict[str, set[str]],
+    baked_per_tier: dict[tuple[str, str], set[str]],
+    waivers: dict[tuple[str, str], set[str]],
+) -> list[dict[str, Any]]:
+    """Compare baked IDs to ``upstream \\ waivers`` per (source, tier).
+
+    Returns one record per violating (source, tier) with the missing
+    and extra IDs. Sources not present in ``upstream`` are skipped —
+    the snapshot is incomplete for that source, not the bake.
+    """
+    violations: list[dict[str, Any]] = []
+    for (source, tier), baked in sorted(baked_per_tier.items()):
+        if source not in upstream:
+            continue
+        expected = upstream[source] - waivers.get((source, tier), set())
+        missing = expected - baked
+        extras = baked - upstream[source]
+        if missing or extras:
+            violations.append(
+                {
+                    "source": source,
+                    "tier": tier,
+                    "missing": missing,
+                    "extras": extras,
+                }
+            )
+    return violations
+
+
+def baked_ids_from_rowmap_dir(rowmap_dir: Path) -> dict[tuple[str, str], set[str]]:
+    """Scan ``rowmap_dir`` for ``{source}-{tier}-{category}-rowmap.json``
+    files, merge per (source, tier), return ``{(source, tier): {ids}}``.
+
+    Used at validation time to produce ``baked_per_tier`` for
+    :func:`find_catalog_violations`.
+    """
+    import json as _json
+    import re
+
+    pattern = re.compile(r"^(?P<source>[a-z0-9]+)-(?P<tier>[a-z0-9-]+?)-[a-z0-9]+-rowmap\.json$")
+    out: dict[tuple[str, str], set[str]] = {}
+    for rmp in Path(rowmap_dir).glob("*-rowmap.json"):
+        m = pattern.match(rmp.name)
+        if not m:
+            continue
+        key = (m.group("source"), m.group("tier"))
+        data = _json.loads(rmp.read_text())
+        ids = set(data.get("materials", {}).keys())
+        out.setdefault(key, set()).update(ids)
+    return out
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_mutation_harness.py
+++ b/tests/test_mutation_harness.py
@@ -1,0 +1,240 @@
+"""Mutation-test the release validator (#88 Phase 3).
+
+The validator is only useful if it actually catches bad releases. This
+harness mutates a known-good metrics fixture and asserts the validator
+screams — without it, we'd be trusting untested gates.
+
+This is NOT a full mutation-testing framework (PIT / mutmut). It's
+deliberately scoped to the specific bug classes the validator is meant
+to catch — the same mutations that, if they slipped in, would motivate
+adding a new gate. Catches regressions in existing gates and gives a
+concrete template for adding new mutators when new gates land.
+
+See #88. Related: Feathers, *Working Effectively with Legacy Code*
+(characterization tests); standard mutation-testing literature
+(Mothra, PIT, mutmut).
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+
+from mat_vis_baker.metrics import append_bake_metrics
+
+
+# ── Clean fixtures ──────────────────────────────────────────────
+
+
+def _row(**kw):
+    base = {
+        "release_tag": "v2026.04.0",
+        "timestamp": "2026-04-18T20:00:00Z",
+        "source": "ambientcg",
+        "tier": "1k",
+        "category": "__all__",
+        "actual_count": 1965,
+        "upstream_count": None,
+        "total_bytes": 9_200_000_000,
+        "n_parquets": 9,
+        "rowmap_sha256": "a" * 64,
+        "baker_version": "0.1.0",
+        "workflow_run_id": None,
+    }
+    base.update(kw)
+    return base
+
+
+def _clean_two_release_fixture() -> list[dict]:
+    """A fixture where v2026.04.1 is a legitimate follow-up to v2026.04.0:
+    same counts across all (source, tier), parity holds within each
+    release. Any mutation that breaks either invariant MUST trip the
+    validator."""
+    rows = []
+    for tag, ts in [
+        ("v2026.04.0", "2026-04-18T20:00:00Z"),
+        ("v2026.04.1", "2026-04-19T20:00:00Z"),
+    ]:
+        for source, tier, count in [
+            ("ambientcg", "128", 1965),
+            ("ambientcg", "1k", 1960),
+            ("ambientcg", "2k", 1965),
+            ("polyhaven", "128", 753),
+            ("polyhaven", "1k", 750),
+            ("gpuopen", "128", 2234),
+            ("gpuopen", "1k", 2230),
+        ]:
+            rows.append(
+                _row(
+                    release_tag=tag,
+                    timestamp=ts,
+                    source=source,
+                    tier=tier,
+                    actual_count=count,
+                )
+            )
+    return rows
+
+
+# ── Mutators ────────────────────────────────────────────────────
+
+
+def mut_drop_almost_all(rows, *, source, tier, release_tag) -> list[dict]:
+    """Drop the count for a target row to near zero — 'the gpuopen-1k
+    2234 → 10 mutation'."""
+    out = copy.deepcopy(rows)
+    for r in out:
+        if r["source"] == source and r["tier"] == tier and r["release_tag"] == release_tag:
+            r["actual_count"] = 10
+    return out
+
+
+def mut_tier_skew(rows, *, source, release_tag, skew_tier) -> list[dict]:
+    """Mess with one tier inside a source × release to break parity."""
+    out = copy.deepcopy(rows)
+    for r in out:
+        if r["source"] == source and r["release_tag"] == release_tag and r["tier"] == skew_tier:
+            r["actual_count"] = 50  # far below the others
+    return out
+
+
+def mut_half_drop(rows, *, source, tier, release_tag) -> list[dict]:
+    """A 50 % drop — well past the 95 % regression threshold."""
+    out = copy.deepcopy(rows)
+    for r in out:
+        if r["source"] == source and r["tier"] == tier and r["release_tag"] == release_tag:
+            r["actual_count"] = r["actual_count"] // 2
+    return out
+
+
+# ── Mutation tests ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def metrics_file(tmp_path):
+    return tmp_path / "bake-metrics.parquet"
+
+
+def _write(metrics_file: Path, rows: list[dict]) -> None:
+    # Wipe + append in one go
+    if metrics_file.exists():
+        metrics_file.unlink()
+    append_bake_metrics(metrics_file, rows)
+
+
+def test_unmutated_fixture_is_clean(metrics_file):
+    """Sanity: the fixture itself passes — so any subsequent failure is
+    attributable to the mutation, not a flaky baseline."""
+    from scripts.validate_release import find_regressions, find_tier_parity_violations
+
+    _write(metrics_file, _clean_two_release_fixture())
+    assert find_regressions(metrics_file, current_tag="v2026.04.1", min_ratio=0.95) == []
+    assert find_tier_parity_violations(metrics_file, release_tag="v2026.04.1", min_ratio=0.80) == []
+
+
+def test_mutation_drop_almost_all_is_caught_by_regression_gate(metrics_file):
+    """The core bug we fixed — 2234 → 10 drop must be caught."""
+    from scripts.validate_release import find_regressions
+
+    mutated = mut_drop_almost_all(
+        _clean_two_release_fixture(),
+        source="gpuopen",
+        tier="1k",
+        release_tag="v2026.04.1",
+    )
+    _write(metrics_file, mutated)
+    regressions = find_regressions(metrics_file, current_tag="v2026.04.1", min_ratio=0.95)
+    assert any(r["source"] == "gpuopen" and r["tier"] == "1k" for r in regressions), (
+        "regression gate is broken — 99% drop should trigger it"
+    )
+
+
+def test_mutation_half_drop_is_caught_by_regression_gate(metrics_file):
+    """50% drop — validator must not round off to 'within tolerance'."""
+    from scripts.validate_release import find_regressions
+
+    mutated = mut_half_drop(
+        _clean_two_release_fixture(),
+        source="ambientcg",
+        tier="1k",
+        release_tag="v2026.04.1",
+    )
+    _write(metrics_file, mutated)
+    regressions = find_regressions(metrics_file, current_tag="v2026.04.1", min_ratio=0.95)
+    assert any(r["source"] == "ambientcg" and r["tier"] == "1k" for r in regressions)
+
+
+def test_mutation_tier_skew_is_caught_by_parity_gate(metrics_file):
+    """If one tier is a tiny fraction of the leader, parity fires."""
+    from scripts.validate_release import find_tier_parity_violations
+
+    mutated = mut_tier_skew(
+        _clean_two_release_fixture(),
+        source="gpuopen",
+        release_tag="v2026.04.1",
+        skew_tier="1k",
+    )
+    _write(metrics_file, mutated)
+    vlns = find_tier_parity_violations(metrics_file, release_tag="v2026.04.1", min_ratio=0.80)
+    assert any(v["source"] == "gpuopen" and v["tier"] == "1k" for v in vlns), (
+        "parity gate is broken — tier at 50 vs leader 2234 should trigger it"
+    )
+
+
+# ── Catalog-contract mutation tests ─────────────────────────────
+
+
+def test_mutation_missing_upstream_material_is_caught_by_catalog_gate():
+    """If a material vanishes from bakes but remains in upstream → missing."""
+    from scripts.validate_release import find_catalog_violations
+
+    upstream = {"ambientcg": {"A", "B", "C"}}
+    # Baked lost C
+    baked = {("ambientcg", "1k"): {"A", "B"}}
+    violations = find_catalog_violations(upstream=upstream, baked_per_tier=baked, waivers={})
+    assert len(violations) == 1
+    assert violations[0]["missing"] == {"C"}
+
+
+def test_mutation_phantom_extra_caught_even_when_count_ok():
+    """If a baker emits a phantom ID (count still matches!), the catalog
+    gate fires. The regression/parity gates wouldn't catch this."""
+    from scripts.validate_release import find_catalog_violations
+
+    upstream = {"ambientcg": {"A", "B"}}
+    baked = {("ambientcg", "1k"): {"A", "phantom"}}  # B replaced by phantom
+    violations = find_catalog_violations(upstream=upstream, baked_per_tier=baked, waivers={})
+    assert violations[0]["missing"] == {"B"}
+    assert violations[0]["extras"] == {"phantom"}
+
+
+# ── Negative control: a disabled gate must produce a mutation that
+#    slips through, proving the mutation harness would notice if the
+#    gate regressed. This guards against the harness itself becoming a
+#    no-op. ─────────────────────────────────────────────────────
+
+
+def test_mutation_harness_would_notice_disabled_regression_gate(metrics_file, monkeypatch):
+    """Simulate someone breaking the regression gate to always return
+    []. Our mutation test for drop_almost_all should then FAIL. We
+    assert that failure would occur — meaning the harness isn't silent."""
+    import scripts.validate_release as vr
+
+    mutated = mut_drop_almost_all(
+        _clean_two_release_fixture(),
+        source="gpuopen",
+        tier="1k",
+        release_tag="v2026.04.1",
+    )
+    _write(metrics_file, mutated)
+
+    # Disable the gate
+    monkeypatch.setattr(vr, "find_regressions", lambda *a, **kw: [])
+    # Now the "regression gate caught it" assertion would fail —
+    # proving the harness would surface the regression in the gate.
+    regressions = vr.find_regressions(metrics_file, current_tag="v2026.04.1", min_ratio=0.95)
+    assert regressions == []  # ← mutation slipped through the disabled gate
+    # A real mutation test would pytest.fail here; we just confirm the
+    # structure works.

--- a/tests/test_upstream_catalog.py
+++ b/tests/test_upstream_catalog.py
@@ -1,0 +1,237 @@
+"""Tests for upstream-catalog snapshot + WAIVED contract (#88 Phase 2).
+
+The snapshot captures what upstream *currently advertises* per source —
+the truth data the validator's catalog-contract gate compares against.
+Stored as JSON so it's diffable across releases (``diff catalog_N
+catalog_{N-1}`` = upstream change audit log).
+
+The WAIVED set is hand-maintained in ``waived.yaml`` — materials that
+are known-not-available at specific tiers (e.g. polyhaven doesn't ship
+2k for certain wood textures). Without waivers, every legitimate
+upstream-only material would cause a false positive.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+
+# ── Schema ──────────────────────────────────────────────────────
+
+
+def test_catalog_schema_minimal(tmp_path):
+    from scripts.snapshot_upstream_catalog import build_catalog
+
+    sources = {
+        "ambientcg": ["Rock064", "Metal032"],
+        "polyhaven": ["oak_planks"],
+    }
+    catalog = build_catalog(
+        release_tag="v2026.04.0",
+        sources=sources,
+        snapshotted_at="2026-04-19T12:00:00Z",
+    )
+    assert catalog["release_tag"] == "v2026.04.0"
+    assert catalog["snapshotted_at"] == "2026-04-19T12:00:00Z"
+    assert "ambientcg" in catalog["sources"]
+    assert catalog["sources"]["ambientcg"]["count"] == 2
+    assert set(catalog["sources"]["ambientcg"]["ids"]) == {"Rock064", "Metal032"}
+
+
+def test_catalog_ids_are_sorted(tmp_path):
+    """Deterministic output — sorted IDs make the JSON diffable."""
+    from scripts.snapshot_upstream_catalog import build_catalog
+
+    catalog = build_catalog(
+        release_tag="v2026.04.0",
+        sources={"x": ["zebra", "apple", "mango"]},
+        snapshotted_at="2026-04-19T12:00:00Z",
+    )
+    assert catalog["sources"]["x"]["ids"] == ["apple", "mango", "zebra"]
+
+
+# ── Snapshot via source adapters (mocked) ───────────────────────
+
+
+def test_snapshot_via_source_adapters(tmp_path):
+    """The snapshot script calls each source's discover() to get the
+    current material list. We mock the three adapters."""
+    from scripts.snapshot_upstream_catalog import snapshot
+
+    with (
+        patch("scripts.snapshot_upstream_catalog._ids_for_source") as fake,
+    ):
+        fake.side_effect = lambda name: {
+            "ambientcg": ["Rock064"],
+            "polyhaven": ["oak"],
+            "gpuopen": ["a", "b", "c"],
+        }[name]
+        out = tmp_path / "upstream-catalog.json"
+        snapshot(
+            output_path=out,
+            release_tag="v2026.04.0",
+            sources=["ambientcg", "polyhaven", "gpuopen"],
+        )
+
+    catalog = json.loads(out.read_text())
+    assert catalog["sources"]["ambientcg"]["count"] == 1
+    assert catalog["sources"]["gpuopen"]["count"] == 3
+
+
+# ── WAIVED loader ───────────────────────────────────────────────
+
+
+def test_load_waivers_empty_file(tmp_path):
+    from scripts.validate_release import load_waivers
+
+    wf = tmp_path / "waived.yaml"
+    wf.write_text("")
+    assert load_waivers(wf) == {}
+
+
+def test_load_waivers_missing_file_returns_empty(tmp_path):
+    """A missing waived.yaml is legitimate — not every project needs
+    waivers. Should not raise."""
+    from scripts.validate_release import load_waivers
+
+    assert load_waivers(tmp_path / "nonexistent.yaml") == {}
+
+
+def test_load_waivers_parses_source_tier_structure(tmp_path):
+    from scripts.validate_release import load_waivers
+
+    wf = tmp_path / "waived.yaml"
+    wf.write_text(
+        """\
+polyhaven:
+  "2k":
+    - material_without_2k_upstream
+    - another_one
+gpuopen:
+  "1k":
+    - special_case_id
+"""
+    )
+    waivers = load_waivers(wf)
+    assert waivers[("polyhaven", "2k")] == {
+        "material_without_2k_upstream",
+        "another_one",
+    }
+    assert waivers[("gpuopen", "1k")] == {"special_case_id"}
+    assert ("ambientcg", "1k") not in waivers
+
+
+# ── Contract: baked == upstream \ WAIVED ────────────────────────
+
+
+def test_catalog_contract_flags_missing_materials(tmp_path):
+    """Baker produced 2 materials but upstream had 3 — flag the missing one."""
+    from scripts.validate_release import find_catalog_violations
+
+    upstream = {
+        "ambientcg": {"Rock064", "Metal032", "Wood045"},
+    }
+    baked_per_tier = {
+        ("ambientcg", "1k"): {"Rock064", "Metal032"},  # Wood045 missing
+    }
+    waivers: dict = {}
+
+    violations = find_catalog_violations(
+        upstream=upstream, baked_per_tier=baked_per_tier, waivers=waivers
+    )
+    assert len(violations) == 1
+    v = violations[0]
+    assert v["source"] == "ambientcg"
+    assert v["tier"] == "1k"
+    assert v["missing"] == {"Wood045"}
+    assert v["extras"] == set()
+
+
+def test_catalog_contract_flags_extras(tmp_path):
+    """Baker produced a material not in upstream — also a violation."""
+    from scripts.validate_release import find_catalog_violations
+
+    upstream = {"ambientcg": {"Rock064"}}
+    baked_per_tier = {("ambientcg", "1k"): {"Rock064", "phantom_material"}}
+
+    violations = find_catalog_violations(
+        upstream=upstream, baked_per_tier=baked_per_tier, waivers={}
+    )
+    assert violations[0]["extras"] == {"phantom_material"}
+
+
+def test_catalog_contract_waives_known_gaps(tmp_path):
+    """Waived material is allowed to be missing — no violation reported."""
+    from scripts.validate_release import find_catalog_violations
+
+    upstream = {"polyhaven": {"a", "b", "c"}}
+    baked_per_tier = {("polyhaven", "2k"): {"a", "b"}}  # 'c' missing
+    waivers = {("polyhaven", "2k"): {"c"}}
+
+    violations = find_catalog_violations(
+        upstream=upstream, baked_per_tier=baked_per_tier, waivers=waivers
+    )
+    assert violations == []  # c is waived
+
+
+def test_catalog_contract_clean_when_fully_matched(tmp_path):
+    from scripts.validate_release import find_catalog_violations
+
+    upstream = {"ambientcg": {"Rock064", "Metal032"}}
+    baked_per_tier = {
+        ("ambientcg", "128"): {"Rock064", "Metal032"},
+        ("ambientcg", "1k"): {"Rock064", "Metal032"},
+    }
+    violations = find_catalog_violations(
+        upstream=upstream, baked_per_tier=baked_per_tier, waivers={}
+    )
+    assert violations == []
+
+
+def test_catalog_contract_ignores_sources_not_in_upstream_snapshot(tmp_path):
+    """If upstream snapshot has no 'gpuopen' entry, we don't check that
+    source's bakes — the snapshot is incomplete, not the bake."""
+    from scripts.validate_release import find_catalog_violations
+
+    upstream = {"ambientcg": {"Rock064"}}  # no gpuopen
+    baked_per_tier = {("gpuopen", "1k"): {"material_a"}}  # bake exists
+    violations = find_catalog_violations(
+        upstream=upstream, baked_per_tier=baked_per_tier, waivers={}
+    )
+    assert violations == []
+
+
+# ── Rowmap IDs reader ───────────────────────────────────────────
+
+
+def test_baked_ids_from_rowmap_dir(tmp_path):
+    """Helper that scans a rowmap dir and returns {(source, tier): set(ids)}.
+    Used at validation time to produce baked_per_tier for the contract."""
+    from scripts.validate_release import baked_ids_from_rowmap_dir
+
+    # ambientcg 1k has two category rowmaps
+    (tmp_path / "ambientcg-1k-stone-rowmap.json").write_text(
+        json.dumps(
+            {
+                "parquet_file": "x.parquet",
+                "materials": {"Rock064": {}, "Rock065": {}},
+            }
+        )
+    )
+    (tmp_path / "ambientcg-1k-metal-rowmap.json").write_text(
+        json.dumps(
+            {
+                "parquet_file": "y.parquet",
+                "materials": {"Metal032": {}},
+            }
+        )
+    )
+    # gpuopen 2k has one rowmap
+    (tmp_path / "gpuopen-2k-other-rowmap.json").write_text(
+        json.dumps({"parquet_file": "z.parquet", "materials": {"ID1": {}}})
+    )
+
+    baked = baked_ids_from_rowmap_dir(tmp_path)
+    assert baked[("ambientcg", "1k")] == {"Rock064", "Rock065", "Metal032"}
+    assert baked[("gpuopen", "2k")] == {"ID1"}


### PR DESCRIPTION
## Summary

Stacked on #89. Phases 2 and 3 of #88 — the hard contract and the test that proves the validator works.

**Phase 2 — upstream-catalog snapshot + WAIVED contract (\`d28e261\`):**
- \`scripts/snapshot_upstream_catalog.py\` — hits each source adapter's \`discover()\` via a single mockable hook, writes deterministic (sorted-ID) JSON. Committed as a release asset + kept under \`metrics/\`.
- \`load_waivers(waived.yaml)\` — parses a \`{source: {tier: [ids]}}\` YAML into \`{(source, tier): set[id]}\`. PyYAML optional (minimal fallback parser for stripped CI).
- \`find_catalog_violations(upstream, baked_per_tier, waivers)\` — hard contract: \`baked == upstream \\ waivers\`. Reports missing + extras per (source, tier).
- \`baked_ids_from_rowmap_dir(dir)\` — merges category-partitioned rowmaps into \`{(source, tier): set[id]}\`.

**Phase 3 — mutation harness (\`e6f32f7\`):**
- \`tests/test_mutation_harness.py\` — mutates a clean metrics fixture, asserts each gate fires.
- Mutators target the specific bug classes the validator exists for:
  - \`mut_drop_almost_all\` — 99% drop (gpuopen-1k 2234 → 10 case)
  - \`mut_half_drop\` — 50% drop
  - \`mut_tier_skew\` — one tier at 50 vs leader 2234 (parity)
  - Catalog: vanished upstream material, phantom extras that preserve count
- Negative-control test proves the harness isn't a no-op: if a gate were disabled, the corresponding mutation would slip through — the assertion structure surfaces that.

## Test plan

- [x] \`pytest tests/test_{bake_metrics,release_validator,upstream_catalog,mutation_harness}.py\` → **36/36 pass**
- [x] Stacked PR; will auto-rebase onto \`dev\` once #89 merges.
- [ ] CI green

## Out of scope (follow-ups, per #88 sequencing)

- **CLI flags** on \`validate_release.py main()\` for \`--upstream-catalog\` + \`--rowmap-dir\` — current main() only runs regression + parity. Simple ~20 LoC follow-up once the snapshot JSON actually exists in releases.
- **\`snapshot_upstream_catalog.py\` wired into a workflow** — needs to run once per release cut, probably pre-bake. Shape TBD with maintainer.
- **Seed \`waived.yaml\`** with the known legitimate gaps (e.g. polyhaven materials without 2k upstream). Hand-curated per source review.
- **Wire \`compute_metrics_from_rowmaps\` into the live bake workflow** (also noted in #89).
- **The actual re-bake + \`v2026.04.1\`** (maintainer decision).

## Review flow suggestion

Review #89 first (Phase 1 — the instrument), then this (Phases 2+3 layered on top). Merging order: #89 → this. GitHub will auto-retarget this PR to \`dev\` once #89 lands.