### PR TITLE
fix(ci): bench validator runs independently of Dagger validate-release (#88)

### DIFF
--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -66,15 +66,25 @@ jobs:
       # can't see. Blocking — if counts regress or tiers are skewed,
       # fail the workflow and let the notify-on-failure step open an
       # issue.
+      #
+      # ``if: always()`` — this is an INDEPENDENT gate from the Dagger
+      # validate-release above. They catch disjoint bug classes: the
+      # Dagger step catches file-level integrity (PNG magic, dangling
+      # rowmaps), the bench gate catches count-level regressions. Both
+      # must run on every release so neither can silently short-circuit
+      # the other. Workflow still fails if either gate fails.
       - name: Set up Python
+        if: always()
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
       - name: Install pyarrow (bench validator dep)
+        if: always()
         run: pip install --quiet pyarrow
 
       - name: Validate bench metrics
+        if: always()
         run: |
           python -m scripts.validate_release \
             --metrics metrics/bake-metrics.parquet \


### PR DESCRIPTION
## Problem

The end-to-end test of the QA bench against v2026.04.0 (run \`24626714712\`) revealed the bench validator **never ran**. The workflow was:

\`\`\`yaml
- Validate release assets   # Dagger step, file integrity
- Set up Python
- Install pyarrow
- Validate bench metrics    # our new count-regression gate
\`\`\`

Dagger step failed on 2 unrelated issues:
\`\`\`
FAIL ambientcg/ktx2-1k: ambientcg-ktx2-1k-ceramic-rowmap.json has 0 materials
FAIL ambientcg/ktx2-1k: ambientcg-ktx2-1k-organic-rowmap.json has 0 materials
\`\`\`

GitHub Actions default-short-circuits subsequent steps on failure, so the bench validator never got to fire against the 7 count-level gaps it was designed to catch.

## Fix

\`if: always()\` on the three bench-validator steps. They're **orthogonal** to the Dagger gate — different bug classes, no dependency. Both must run so neither can silently hide the other's class of failure.

Workflow still fails overall if either gate reports a violation.

## Test plan

- [ ] Merge
- [ ] Re-run \`gh workflow run release-validate.yml -f release-tag=v2026.04.0\`
- [ ] Expect two independent failures logged: (a) Dagger's "2 FAILURES — release is incomplete" (rowmap/parquet mismatches), (b) bench validator's "7 cross-tier parity violations"
- [ ] Both gates firing = proof the full QA surface is live