### PR TITLE
refactor(ci): fold bench validator into Dagger validate-release (#88)

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -1118,11 +1118,18 @@ class MatVisCi:
         tag: Annotated[str, Doc("Release tag to validate")] = "v2026.04.0",
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
     ) -> str:
-        """Validate all expected release assets exist and range reads work.
+        """Validate all expected release assets against TWO independent gates.
 
-        Checks the manifest, verifies every source x tier has parquet + rowmap,
-        picks one random material per combination for an HTTP range read, and
-        confirms PNG magic bytes. Exits non-zero on any failure.
+        1. **File integrity** (inlined VALIDATE_RELEASE_SCRIPT) — manifest
+           exists, parquet+rowmap per source × tier, random range reads
+           verify PNG/KTX2 magic bytes, dangling rowmaps caught.
+        2. **Count / regression bench** (``scripts.validate_release``) —
+           cross-tier parity, previous-release regression; uses the
+           ``metrics/bake-metrics.parquet`` committed in the repo.
+
+        Both gates run unconditionally (``set +e``) so a failure in one
+        doesn't mask a failure in the other. Container exits non-zero
+        if either gate reports violations.
         """
         context = src or dag.host().directory(".")
         return await (
@@ -1136,7 +1143,27 @@ class MatVisCi:
                 contents=VALIDATE_RELEASE_SCRIPT,
                 permissions=0o755,
             )
-            .with_exec(["python", "/tmp/validate_release.py"])
+            # Install bench-gate dep, then run both gates with independent
+            # exit codes combined at the end. ``set +e`` keeps the script
+            # going past the first non-zero so we always see both reports.
+            .with_exec(
+                [
+                    "sh",
+                    "-c",
+                    (
+                        "pip install --quiet pyarrow && "
+                        "set +e; "
+                        "echo '=== gate 1: file integrity ==='; "
+                        "python /tmp/validate_release.py; rc1=$?; "
+                        "echo; echo '=== gate 2: count / regression bench ==='; "
+                        "python -m scripts.validate_release "
+                        "  --metrics metrics/bake-metrics.parquet "
+                        "  --tag $VALIDATE_TAG; rc2=$?; "
+                        'echo; echo "integrity_gate_rc=$rc1 bench_gate_rc=$rc2"; '
+                        "[ $rc1 -eq 0 ] && [ $rc2 -eq 0 ]"
+                    ),
+                ]
+            )
             .stdout()
         )
 

--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -61,34 +61,11 @@ jobs:
             validate-release --src=.
             --tag=${{ steps.tag.outputs.tag }}
 
-      # Bench gate (#88): catches tier-parity and cross-release
-      # regressions that the file-existence / PNG-magic checks above
-      # can't see. Blocking — if counts regress or tiers are skewed,
-      # fail the workflow and let the notify-on-failure step open an
-      # issue.
-      #
-      # ``if: always()`` — this is an INDEPENDENT gate from the Dagger
-      # validate-release above. They catch disjoint bug classes: the
-      # Dagger step catches file-level integrity (PNG magic, dangling
-      # rowmaps), the bench gate catches count-level regressions. Both
-      # must run on every release so neither can silently short-circuit
-      # the other. Workflow still fails if either gate fails.
-      - name: Set up Python
-        if: always()
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install pyarrow (bench validator dep)
-        if: always()
-        run: pip install --quiet pyarrow
-
-      - name: Validate bench metrics
-        if: always()
-        run: |
-          python -m scripts.validate_release \
-            --metrics metrics/bake-metrics.parquet \
-            --tag ${{ steps.tag.outputs.tag }}
+      # Both gates (file integrity + count/regression bench) now run
+      # inside the Dagger validate-release function above — it handles
+      # the combined exit code so we match the rest of the CI's
+      # Dagger-wrapped convention. See .dagger/src/mat_vis_ci/main.py
+      # `validate_release`.
 
       - name: Notify on failure
         if: failure()


### PR DESCRIPTION
## Summary

Follow-up to #92: folds the bench count-regression gate into the existing Dagger \`validate-release\` function so all CI validation goes through one convention.

**Why:** #92 wired the bench gate as raw GH Actions Python steps (\`setup-python\` → \`pip install pyarrow\` → \`python -m scripts.validate_release\`). Everything else in this repo's CI (bake, test, probe, validate) runs inside Dagger containers. Two conventions for "run a validator" is drift. #92 proved the gate works end-to-end — this PR unifies the pattern.

## What changes

- \`.dagger/src/mat_vis_ci/main.py\` \`validate_release\`: extended with a shell wrapper that runs both gates under \`set +e\` and combines exit codes. Container exits non-zero if either gate fails.
- \`.github/workflows/release-validate.yml\`: drops the three now-redundant Actions steps (setup-python, pip install, bench validator). A single Dagger call covers both gates.

## Proof it still works

The end-to-end run on the PRIOR commit (run \`24627030996\`, after #92 merged with \`if: always()\`) showed both gates firing independently:

- File-integrity gate: 2 dangling rowmaps caught
- Bench gate: all 7 parity violations caught (gpuopen 256/512/1k, ambientcg 1k, polyhaven 1k/2k, gpuopen 2k)

This PR keeps the same coverage — the bench validator is still invoked with the same args; the difference is it now runs inside the Dagger container alongside the file-integrity script.

## Test plan

- [ ] Merge
- [ ] \`gh workflow run release-validate.yml -f release-tag=v2026.04.0\`
- [ ] Expect same two findings as run \`24627030996\`, but emitted from one Dagger step with \`integrity_gate_rc=1 bench_gate_rc=1\` in the output tail.