### PR TITLE
chore(baker): phase 0 prep — LICENSES, gpuopen MIT, ADR-0007 (#101)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,8 @@ result
 # Dagger (generated SDK, not tracked)
 .dagger/sdk/
 .dagger/uv.lock
+
+# Agent-facing handoff doc — kept local for fresh sessions, not part of
+# the repo's user-facing documentation. ADRs + GH issues are the
+# canonical, tracked specification.
+docs/HANDOFF.md

--- a/LICENSES/AMD-NOTICE.txt
+++ b/LICENSES/AMD-NOTICE.txt
@@ -1,0 +1,9 @@
+Copyright (c) 2022 Advanced Micro Devices, Inc.
+
+The AMD GPUOpen MaterialX Library (https://matlib.gpuopen.com) is
+distributed under the MIT License. License verified via per-material
+metadata displayed on matlib.gpuopen.com.
+
+Materials sourced from GPUOpen and redistributed in this dataset
+preserve this attribution. The full MIT License text is in
+LICENSES/MIT.txt.

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSES/README.md
+++ b/LICENSES/README.md
@@ -1,0 +1,14 @@
+# Licenses
+
+Upstream license attribution for every source in this dataset.
+
+| Source | License | File | Notes |
+|---|---|---|---|
+| ambientcg | CC0-1.0 | [CC0-1.0.txt](CC0-1.0.txt) | Public-domain dedication |
+| polyhaven | CC0-1.0 | [CC0-1.0.txt](CC0-1.0.txt) | Public-domain dedication |
+| physicallybased | CC0-1.0 | [CC0-1.0.txt](CC0-1.0.txt) | Public-domain dedication |
+| gpuopen | MIT | [MIT.txt](MIT.txt) + [AMD-NOTICE.txt](AMD-NOTICE.txt) | ©2022 Advanced Micro Devices, Inc.; verified per-material via matlib.gpuopen.com |
+
+This dataset is redistributable under the union of these upstream
+licenses. When redistributing material data derived from gpuopen,
+preserve the AMD attribution in [AMD-NOTICE.txt](AMD-NOTICE.txt).

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -2873,7 +2873,7 @@
 
 ## 💎 gpuopen
 
-> 9 materials | Tiers: 128, 1k, 256, 2k, 512, ktx2-128, ktx2-1k, ktx2-256, ktx2-512 | License: TBV (per material)
+> 9 materials | Tiers: 128, 1k, 256, 2k, 512, ktx2-128, ktx2-1k, ktx2-256, ktx2-512 | License: MIT (©2022 AMD)
 > [https://matlib.gpuopen.com](https://matlib.gpuopen.com)
 
 

--- a/docs/decisions/0007-substrate-move-to-hf-datasets-and-tar-container.md
+++ b/docs/decisions/0007-substrate-move-to-hf-datasets-and-tar-container.md
@@ -1,0 +1,135 @@
+# 0007. Substrate move to Hugging Face Datasets + tar container, drop per-category partitioning
+
+- Status: Accepted
+- Date: 2026-04-19
+- Deciders: @gerchowl
+- Supersedes: ADR-0001 (storage container), ADR-0002 (hosting substrate), ADR-0003 (per-category partitioning)
+- Tracking: umbrella issue #100, milestone `v0.5.0 — HF substrate`
+
+## Context
+
+ADR-0001 chose **Parquet bundles + rowmap JSON sidecar on GitHub Releases**, partitioned per `(source, tier, category)`. ADR-0002 chose **GitHub Releases as the CDN**, ADR-0003 chose **per-category partitioning** for chunk-size management. After 5 months of operation those choices produced four recurring bug classes:
+
+| Bug class | Example | Root | Substrate-attributable? |
+|---|---|---|---|
+| Dangling rowmap → missing parquet | #79 (4 missing parquets in v2026.04.0) | Non-atomic multi-file upload | Yes — GitHub Releases has no atomic multi-file commit |
+| Empty-materials rowmap | #82 | Per-pipeline copy-paste of rowmap-emit loop iterating wrong dict | Partial — cross-pipeline drift, magnified by GH's clobber semantics |
+| Categorization drift between pipelines | #98 | Same fact (filename schema) parsed by 3 different regexes | No — design-internal |
+| Massively incomplete index files | #99 (ambientcg.json: 15/1965 entries; polyhaven.json: 26/753) | Index writers clobber rather than merge across batches | Partial — clobber-friendly substrate makes it worse |
+
+### Falsify reviews (2026-04-19)
+
+Three independent adversarial reviewers were spawned with no shared context, each told to **refute** the claim that the current architecture was minimum-complexity. All three returned counterexamples; the agents and verdicts are filed in the umbrella issue.
+
+| Angle | Concrete simplification |
+|---|---|
+| First-principles design-from-scratch | Drop the `category` partitioning dimension — it lives where the schema already says it should (column inside the file + field in `index.json`). Collapses ~120 file pairs to ~12 per release; eliminates "missing parquet per category" + "categorization drift" structurally. |
+| Substrate choice | Move from GitHub Releases to Hugging Face Datasets. Atomic multi-file commits eliminate #79 by construction; immutable revisions eliminate #98/#99 drift class; no 2 GB-per-file cap removes the chunk-rotation state machine; CloudFront-backed range reads eliminate the signed-URL retry/cache complexity in the client. |
+| Implementation reality | The same fact (filename schema, payload length, source-index entries) is encoded in N places that drifted. Consolidate behind single primitives: one `parse_release_filename`, one `RowmapCollector`, one source-index writer. |
+
+### Upstream license verification
+
+| Source | License | HF-redistributable |
+|---|---|:---:|
+| ambientcg | CC0-1.0 | ✅ |
+| polyhaven | CC0-1.0 | ✅ |
+| physicallybased | CC0-1.0 | ✅ |
+| gpuopen | MIT (©2022 AMD; verified via matlib.gpuopen.com per-material display) | ✅ |
+
+`src/mat_vis_baker/sources/gpuopen.py` previously stamped `source_license="TBV"` — fix is part of Phase 0.
+
+## Decision
+
+Combine all three reviewers' simplifications into a single architectural cut, **v0.5.0**.
+
+### Substrate
+
+- **Hugging Face Datasets**, repo `huggingface.co/datasets/gerchowl/mat-vis` (personal account; transfer to org TBD).
+- **Atomic commits** via `huggingface_hub.HfApi.create_commit` — manifest + every parquet/tar lands together or not at all.
+- **Tag-named revisions** retain calver naming (`v2026.05.0`, …) — same external version model.
+- **CloudFront-backed CDN** — `https://huggingface.co/datasets/gerchowl/mat-vis/resolve/<revision>/<path>`. Range reads work natively, no signed URLs.
+
+### Container
+
+- **Tar archives** replace Parquet bundles. One tar per `(source, tier)`.
+- **Layout inside tar**: `{material_id}/{channel}.png` (or `.ktx2`).
+- **Sidecar rowmap** — same JSON shape as today: `{material_id: {channel: {offset, length}}}`. Offset points at first byte after the 512-byte tar header; length is the channel's byte count.
+- **No per-category partitioning** — category becomes a column-equivalent (a field in `index/{source}.json`) and a tag in the `release-manifest.json`. Search-by-category remains a client-side filter on the index, exactly as today.
+
+### Files per release (target)
+
+```
+v2026.05.0/
+  release-manifest.json              # {tier: {source: {tar_url, rowmap_url, materials_count}}}
+  ambientcg.json                     # catalog: id/category/scalars/source_url/source_license
+  polyhaven.json
+  gpuopen.json
+  physicallybased.json
+  ambientcg-1k.tar       + ambientcg-1k-rowmap.json
+  ambientcg-2k.tar       + ambientcg-2k-rowmap.json
+  polyhaven-1k.tar       + polyhaven-1k-rowmap.json
+  ...                                 # 12 source/tier combos × 2 = 24 PNG files
+  ktx2/ambientcg-1k.tar  + ktx2/ambientcg-1k-rowmap.json
+  ...                                 # 12 KTX2 combos × 2 = 24 KTX2 files
+  gpuopen-mtlx.json + polyhaven-mtlx.json + ambientcg-mtlx.json
+```
+
+Total: **~57 files per release** (vs ~440 today).
+
+### Client
+
+- Base URL: `https://huggingface.co/datasets/gerchowl/mat-vis/resolve/<revision>/<path>`.
+- Range arithmetic: `bytes={offset}-{offset+length-1}` against `<base>/<source>-<tier>.tar`.
+- Delete: `_redirect_cache`, signed-URL stale retry, GH-specific 60 req/h rate-limit branch.
+- Keep: `RateLimitError`, `MAX_RETRIES`, exponential backoff (HF rate limits are looser but real).
+
+### Workflow collapse
+
+- DELETE: `release-validate.yml` — immutable revisions don't drift.
+- DELETE: `rebuild-manifest.yml` — atomic commits don't desync.
+- DELETE: `regenerate-rowmaps.yml` — sidecar `RowmapCollector` is authoritative; no scanner re-derivation.
+- DELETE: `promote-data-release.yml` — HF revisions are immutable, no pre-release / promote dance.
+- REWRITE: `bake.yml` — calls baker which pushes to HF directly via `HF_TOKEN` secret.
+- KEEP: `derive-ktx2.yml` — KTX2 transcode pipeline, just pushes to HF instead of GH Releases.
+- KEEP unchanged: `pypi.yml`, `ci.yml`, `labeler.yml`.
+
+## Consequences
+
+### Eliminated by construction
+
+- **#79** dangling rowmap → missing parquet (atomic commits)
+- **#98** categorization drift between pipelines (no per-category partitioning to drift over)
+- **#99** index incompleteness via clobber (atomic commits + single index writer per source)
+- **#83** chunk-split inconsistency across pipelines (no chunk-split needed; HF takes 50 GB+ files)
+- **~330 lines** of substrate-coping code in `upload.py` + `client.py`
+
+### Still requires code changes
+
+- **#82** empty-materials rowmap — partially fixed in current arch (`emit_rowmaps_for_bake` consolidation already landed). The new tar-based emitter must preserve the same "always emit, even if empty" invariant.
+
+### New constraints
+
+- **HF account dependency** — single-vendor risk. Mitigation: HF Datasets is git-LFS-backed and downloadable verbatim; can mirror to a second substrate (Zenodo for archival) if HF ever changes terms.
+- **License attribution** — MIT requires preserving AMD copyright + license text. Handled via `LICENSES/` directory at dataset root + dataset card.
+
+### Back-compat
+
+- `mat-vis-client 0.4.x` continues working against `v2026.04.0` on GitHub Releases. The release stays as-is, frozen, no further updates.
+- `mat-vis-client 0.5.0+` only knows the HF substrate. New base URL, new tar-based access pattern.
+- A grace period of "both work" is unavoidable but bounded — once 0.5.0 is published, encourage migration via the update-check notice.
+
+### Testing strategy
+
+- Tar roundtrip + offset arithmetic tests in `tests/test_tar_writer.py` (new).
+- HF-push primitive mocked via `huggingface_hub` test client.
+- End-to-end proof bake of `physicallybased` (smallest source, scalar-only) for Phase 2.
+- Live tests in `clients/python/test_client.py` repointed to the new HF URL.
+
+## Upgrade triggers
+
+Revisit this ADR if:
+
+- HF changes pricing model for public datasets to non-free.
+- HF rate-limits become more restrictive than GitHub's (currently looser).
+- A multi-vendor mirror requirement emerges (governance, durability concerns).
+- The corpus exceeds HF's practical limits (no documented cap; LAION-5B at 240 TB is the public reference point — we are nowhere near).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -11,6 +11,7 @@ rejected, and what would trigger revisiting.
 4. [0004 — Lazy local cache as default access mode](0004-access-modes-lazy-local-cache-default.md)
 5. [0005 — ~~SQL shim in clients~~ — superseded by ADR-0001](0005-sql-shim-embedded-in-clients.md)
 6. [0006 — Release versioning: client semver + data calver + delta overlays](0006-release-versioning-and-delta-overlays.md)
+7. [0007 — Substrate move to HF Datasets + tar container, drop per-category partitioning](0007-substrate-move-to-hf-datasets-and-tar-container.md) — supersedes 0001/0002/0003
 
 ## Template
 

--- a/docs/specs/source-apis.md
+++ b/docs/specs/source-apis.md
@@ -98,7 +98,7 @@ GET https://api.polyhaven.com/files/<asset_slug>
 | Field            | Value |
 |------------------|-------|
 | Website          | <https://matlib.gpuopen.com> |
-| License          | **TBV** (to be verified per material; check each material's metadata) |
+| License          | **MIT** (©2022 AMD; verified via matlib.gpuopen.com per-material display) |
 | Auth required    | No (currently) |
 | Rate limiting    | Unknown |
 
@@ -115,9 +115,11 @@ GET https://api.matlib.gpuopen.com/api/packages?limit=100&offset=0
 ### Download
 
 - Per-package detail (to get download URL):
+
   ```
   GET https://api.matlib.gpuopen.com/api/packages/<package_id>
   ```
+
 - Downloads are **ZIP packages** containing `.mtlx` + texture files.
 - Download URL is typically in `response.downloadUrl` or a similar field; verify at implementation time.
 
@@ -168,6 +170,7 @@ GET https://api.physicallybased.info/materials
 ### Color conversion
 
 - The `color` field is an RGB tuple in [0,1] range. Convert to `#RRGGBB` hex:
+
   ```python
   hex_color = "#{:02X}{:02X}{:02X}".format(
       int(round(r * 255)),

--- a/src/mat_vis_baker/catalog_from_release.py
+++ b/src/mat_vis_baker/catalog_from_release.py
@@ -77,7 +77,7 @@ SOURCE_URLS = {
 SOURCE_LICENSES = {
     "ambientcg": "CC0-1.0",
     "polyhaven": "CC0-1.0",
-    "gpuopen": "TBV (per material)",
+    "gpuopen": "MIT (©2022 AMD)",
     "physicallybased": "CC0-1.0",
 }
 

--- a/src/mat_vis_baker/sources/gpuopen.py
+++ b/src/mat_vis_baker/sources/gpuopen.py
@@ -1,7 +1,7 @@
 """GPUOpen MaterialX Library fetcher.
 
 API: https://api.matlib.gpuopen.com/api/packages/?limit=100&offset=0
-License: TBV (per material)
+License: MIT (©2022 AMD; verified via matlib.gpuopen.com per-material display)
 Format: ZIP with .mtlx + textures. Some materials have layered graphs.
 """
 
@@ -65,7 +65,7 @@ def _inject_mtlx_comment(mtlx_bytes: bytes, material_id: str, source_url: str) -
     """Inject source attribution comment into mtlx XML."""
     comment = (
         f"<!-- source: {source_url} -->\n"
-        f"<!-- license: TBV -->\n"
+        f"<!-- license: MIT (c)2022 AMD -->\n"
         f"<!-- material: {material_id} -->\n"
         f"<!-- fetched-by: mat-vis-baker -->\n"
     ).encode()
@@ -183,7 +183,7 @@ def _fetch_one(
             category=cat,
             tags=tags,
             source_url=f"https://matlib.gpuopen.com/main/materials/all?material={mid}",
-            source_license="TBV",
+            source_license="MIT",
             last_updated=pkg.get("updated_date", ""),
             available_tiers=[tier] if textures else [],
             maps=sorted(textures.keys()),


### PR DESCRIPTION
## Summary

Phase 0 of the v0.5.0 HF substrate migration (umbrella #100).

- Adds `LICENSES/` at repo root — verbatim CC0-1.0, MIT, AMD-NOTICE + index README for per-source attribution when redistributing via HF Datasets.
- Fixes gpuopen license stamping: `TBV` → `MIT (©2022 AMD)` in 3 in-source occurrences (`sources/gpuopen.py`), `catalog_from_release.SOURCE_LICENSES`, `docs/specs/source-apis.md`, `docs/catalog.md`.
- Lands ADR-0007 (substrate move to HF Datasets + tar container, drop per-category partitioning) + decisions/README index entry.
- Ignores `docs/HANDOFF.md` (local-only fresh-session handoff doc).

Out-of-band (HF push, not a git change):

- Dataset card pushed to `huggingface.co/datasets/gerchowl/mat-vis` — YAML frontmatter declares `license: other`, `license_name: mixed-cc0-mit`, links to `LICENSES/README.md`; body lists per-source attribution + dataset layout.
- `LICENSES/` tree mirrored to the HF dataset root so the card's attribution links resolve.

## Acceptance criteria (from #101)

- [x] `git grep -n TBV src/` returns zero results.
- [x] `LICENSES/` directory exists with the 4 files; CC0 + MIT texts match SPDX canonical.
- [x] `huggingface.co/datasets/gerchowl/mat-vis` shows the dataset card with per-source attribution table visible (license: other, mixed-cc0-mit rendered).
- [x] `pytest tests/` still green (210 passed, 10 skipped — the 10 are live-network tests).

## Test plan

- [x] `just --justfile justfile.project test-fast` — 210 passed / 10 skipped.
- [x] `git grep -n TBV src/` — empty.
- [x] HF dataset card renders the attribution table (visit `huggingface.co/datasets/gerchowl/mat-vis`).
- [ ] CI green on PR.

Closes #101
Refs #100