### PR TITLE
feat(baker): phase 1 primitives — tar_writer + hf_push (#102)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ baker = [
     "pyarrow>=15",
     "requests>=2.31",
     "pillow>=10.0",
+    "huggingface_hub>=0.25",
 ]
 materialx = [
     "materialx>=1.39",

--- a/src/mat_vis_baker/hf_push.py
+++ b/src/mat_vis_baker/hf_push.py
@@ -1,0 +1,92 @@
+"""Atomic multi-file push to a Hugging Face dataset.
+
+Wrapper around ``huggingface_hub.HfApi.create_commit`` that mirrors
+what the v0.5.0 baker needs: push a list of ``(local_path,
+path_in_repo)`` pairs to a named revision of a dataset repo as a
+single atomic commit. If the target revision doesn't exist yet, it's
+created as a branch from ``main`` first.
+
+Atomicity is the substrate-level guarantee that makes the rowmap ↔
+tar consistency invariant hold without a validator pass (ADR-0007,
+bug class #79).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+log = logging.getLogger("mat-vis-baker.hf_push")
+
+
+def push_to_hf(
+    repo_id: str,
+    files: list[tuple[Path, str]],
+    revision: str,
+    commit_message: str,
+    *,
+    token: str | None = None,
+    create_branch_if_missing: bool = True,
+) -> str:
+    """Push a set of files to an HF dataset revision atomically.
+
+    Args:
+        repo_id: e.g. ``"gerchowl/mat-vis"``.
+        files: list of ``(local_path, path_in_repo)`` pairs. Every file
+            lands in one ``create_commit`` call.
+        revision: target branch/tag (e.g. ``"v2026.05.0"``).
+        commit_message: commit message.
+        token: HF access token. Falls back to the ``HF_TOKEN`` env var.
+        create_branch_if_missing: if True and ``revision`` is not an
+            existing branch, create it from ``main`` before committing.
+
+    Returns:
+        The commit SHA of the created commit, or ``""`` when ``files``
+        is empty (no-op, no API call).
+    """
+    if not files:
+        log.info("push_to_hf: no files, skipping")
+        return ""
+
+    from huggingface_hub import CommitOperationAdd, HfApi
+    from huggingface_hub.errors import RevisionNotFoundError
+
+    resolved_token = token if token is not None else os.environ.get("HF_TOKEN")
+    api = HfApi(token=resolved_token)
+
+    if create_branch_if_missing:
+        try:
+            api.list_repo_commits(repo_id=repo_id, repo_type="dataset", revision=revision)
+        except RevisionNotFoundError:
+            log.info("creating branch %s on %s", revision, repo_id)
+            api.create_branch(
+                repo_id=repo_id,
+                repo_type="dataset",
+                branch=revision,
+                revision="main",
+                exist_ok=True,
+            )
+
+    operations = [
+        CommitOperationAdd(path_in_repo=path_in_repo, path_or_fileobj=str(local_path))
+        for local_path, path_in_repo in files
+    ]
+
+    commit_info = api.create_commit(
+        repo_id=repo_id,
+        repo_type="dataset",
+        operations=operations,
+        commit_message=commit_message,
+        revision=revision,
+    )
+
+    sha = getattr(commit_info, "oid", "") or getattr(commit_info, "commit_oid", "")
+    log.info(
+        "push_to_hf: %d files → %s@%s (%s)",
+        len(files),
+        repo_id,
+        revision,
+        sha[:12] if sha else "?",
+    )
+    return sha

--- a/src/mat_vis_baker/tar_writer.py
+++ b/src/mat_vis_baker/tar_writer.py
@@ -1,0 +1,99 @@
+"""Streaming tar writer for (source, tier) bundles + offset/length sidecar.
+
+Counterpart to ``parquet_writer`` for the v0.5.0 HF-substrate substrate.
+One ``TarWriter`` per (source, tier). Each ``add_channel`` call appends
+one texture blob under ``{material_id}/{channel}.{ext}`` and records the
+exact byte offset (first byte after the 512-byte tar header) + length
+so HTTP range reads can slice the payload without untarring.
+
+The resulting rowmap has the same shape as the parquet-era rowmap:
+
+    {material_id: {channel: {"offset": int, "length": int}}}
+
+so downstream consumers stay unchanged (see ADR-0007).
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import tarfile
+from pathlib import Path
+
+log = logging.getLogger("mat-vis-baker.tar")
+
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+_KTX2_MAGIC = b"\xabKTX 20\xbb\r\n\x1a\n"
+
+
+def _detect_extension(data: bytes) -> str:
+    if data.startswith(_KTX2_MAGIC):
+        return "ktx2"
+    if data.startswith(_PNG_MAGIC):
+        return "png"
+    return "bin"
+
+
+class TarWriter:
+    """Append-only tar writer with an authoritative offset/length sidecar.
+
+    Every ``add_channel`` call writes one entry. Duplicates (same
+    ``material_id``/``channel`` pair) raise — an accidental double-add
+    would leave two payloads in the archive and clobber one rowmap
+    entry, silently dropping a channel.
+    """
+
+    def __init__(self, output_path: Path) -> None:
+        self._output_path = output_path
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        self._tar = tarfile.open(output_path, mode="w", format=tarfile.USTAR_FORMAT)
+        self._materials: dict[str, dict[str, dict[str, int]]] = {}
+        self._closed = False
+
+    def add_channel(self, material_id: str, channel: str, data: bytes) -> None:
+        if self._closed:
+            raise RuntimeError(f"TarWriter({self._output_path}) already finalized")
+        channels = self._materials.setdefault(material_id, {})
+        if channel in channels:
+            raise ValueError(
+                f"duplicate entry: {material_id}/{channel} already added to "
+                f"{self._output_path.name}"
+            )
+
+        ext = _detect_extension(data)
+        info = tarfile.TarInfo(name=f"{material_id}/{channel}.{ext}")
+        info.size = len(data)
+
+        # `tarfile.addfile` copies the TarInfo internally and modifies
+        # the copy, so ``info.offset_data`` on our instance stays at its
+        # default. Capture the block start from ``self._tar.offset``
+        # before the write; the header is always 512 bytes so the
+        # payload starts at ``block_start + 512``.
+        block_start = self._tar.offset
+        self._tar.addfile(info, io.BytesIO(data))
+
+        channels[channel] = {
+            "offset": block_start + tarfile.BLOCKSIZE,
+            "length": len(data),
+        }
+
+    def finalize(self) -> dict[str, dict[str, dict[str, int]]]:
+        if not self._closed:
+            self._tar.close()
+            self._closed = True
+        log.info(
+            "wrote %s (%d materials, %d channels, %.1f MB)",
+            self._output_path,
+            len(self._materials),
+            sum(len(v) for v in self._materials.values()),
+            self._output_path.stat().st_size / 1e6,
+        )
+        return self._materials
+
+    def __enter__(self) -> TarWriter:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if not self._closed:
+            self._tar.close()
+            self._closed = True

--- a/tests/test_hf_push.py
+++ b/tests/test_hf_push.py
@@ -1,0 +1,149 @@
+"""Tests for the hf_push primitive (ADR-0007 Phase 1).
+
+All HF API calls are mocked — these tests must not touch the network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mat_vis_baker.hf_push import push_to_hf
+
+
+@pytest.fixture
+def fake_files(tmp_path: Path) -> list[tuple[Path, str]]:
+    paths = []
+    for i, name in enumerate(["manifest.json", "a.tar", "a-rowmap.json"]):
+        p = tmp_path / name
+        p.write_bytes(f"payload-{i}".encode())
+        paths.append((p, name))
+    return paths
+
+
+def test_three_files_one_create_commit_call(fake_files: list[tuple[Path, str]]) -> None:
+    with patch("huggingface_hub.HfApi") as api_cls:
+        api = api_cls.return_value
+        api.list_repo_commits.return_value = [MagicMock()]
+        api.create_commit.return_value = MagicMock(oid="abc123def456")
+
+        sha = push_to_hf(
+            repo_id="gerchowl/mat-vis",
+            files=fake_files,
+            revision="v2026.05.0",
+            commit_message="test",
+            token="t0k",
+        )
+
+        assert sha == "abc123def456"
+        assert api.create_commit.call_count == 1
+        kwargs = api.create_commit.call_args.kwargs
+        assert kwargs["repo_id"] == "gerchowl/mat-vis"
+        assert kwargs["repo_type"] == "dataset"
+        assert kwargs["revision"] == "v2026.05.0"
+        assert len(kwargs["operations"]) == 3
+
+
+def test_empty_file_list_is_noop() -> None:
+    with patch("huggingface_hub.HfApi") as api_cls:
+        sha = push_to_hf(
+            repo_id="gerchowl/mat-vis",
+            files=[],
+            revision="v2026.05.0",
+            commit_message="noop",
+            token="t0k",
+        )
+    assert sha == ""
+    api_cls.assert_not_called()
+
+
+def test_explicit_token_overrides_env(
+    monkeypatch: pytest.MonkeyPatch, fake_files: list[tuple[Path, str]]
+) -> None:
+    monkeypatch.setenv("HF_TOKEN", "from-env")
+
+    with patch("huggingface_hub.HfApi") as api_cls:
+        api = api_cls.return_value
+        api.list_repo_commits.return_value = [MagicMock()]
+        api.create_commit.return_value = MagicMock(oid="sha1")
+
+        push_to_hf(
+            repo_id="gerchowl/mat-vis",
+            files=fake_files,
+            revision="main",
+            commit_message="m",
+            token="explicit-token",
+        )
+
+        api_cls.assert_called_once_with(token="explicit-token")
+
+
+def test_env_token_used_when_none_passed(
+    monkeypatch: pytest.MonkeyPatch, fake_files: list[tuple[Path, str]]
+) -> None:
+    monkeypatch.setenv("HF_TOKEN", "from-env")
+
+    with patch("huggingface_hub.HfApi") as api_cls:
+        api = api_cls.return_value
+        api.list_repo_commits.return_value = [MagicMock()]
+        api.create_commit.return_value = MagicMock(oid="sha1")
+
+        push_to_hf(
+            repo_id="gerchowl/mat-vis",
+            files=fake_files,
+            revision="main",
+            commit_message="m",
+        )
+
+        api_cls.assert_called_once_with(token="from-env")
+
+
+def test_missing_revision_creates_branch(fake_files: list[tuple[Path, str]]) -> None:
+    from huggingface_hub.errors import RevisionNotFoundError
+
+    with patch("huggingface_hub.HfApi") as api_cls:
+        api = api_cls.return_value
+        api.list_repo_commits.side_effect = RevisionNotFoundError(
+            "nope", response=MagicMock(status_code=404)
+        )
+        api.create_commit.return_value = MagicMock(oid="sha1")
+
+        push_to_hf(
+            repo_id="gerchowl/mat-vis",
+            files=fake_files,
+            revision="v2026.05.0",
+            commit_message="m",
+            token="t0k",
+        )
+
+        api.create_branch.assert_called_once()
+        api.create_commit.assert_called_once()
+        assert api.create_branch.call_args.kwargs["branch"] == "v2026.05.0"
+        assert api.create_branch.call_args.kwargs["revision"] == "main"
+
+
+def test_no_branch_creation_when_disabled(fake_files: list[tuple[Path, str]]) -> None:
+    from huggingface_hub.errors import RevisionNotFoundError
+
+    with patch("huggingface_hub.HfApi") as api_cls:
+        api = api_cls.return_value
+        api.list_repo_commits.side_effect = RevisionNotFoundError(
+            "nope", response=MagicMock(status_code=404)
+        )
+        api.create_commit.side_effect = RevisionNotFoundError(
+            "still nope", response=MagicMock(status_code=404)
+        )
+
+        with pytest.raises(RevisionNotFoundError):
+            push_to_hf(
+                repo_id="gerchowl/mat-vis",
+                files=fake_files,
+                revision="v2026.05.0",
+                commit_message="m",
+                token="t0k",
+                create_branch_if_missing=False,
+            )
+
+        api.create_branch.assert_not_called()

--- a/tests/test_tar_writer.py
+++ b/tests/test_tar_writer.py
@@ -1,0 +1,128 @@
+"""Tests for the tar_writer primitive (ADR-0007 Phase 1)."""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from mat_vis_baker.tar_writer import TarWriter
+
+_PNG_HEAD = b"\x89PNG\r\n\x1a\n"
+
+
+def _fake_png(seed: int, size: int = 64) -> bytes:
+    body = bytes((seed + i) % 256 for i in range(size - len(_PNG_HEAD)))
+    return _PNG_HEAD + body
+
+
+def test_roundtrip_three_materials_two_channels(tmp_path: Path) -> None:
+    """Offset/length from the sidecar must slice back the exact bytes."""
+    out = tmp_path / "ambientcg-1k.tar"
+    payload: dict[str, dict[str, bytes]] = {}
+    with TarWriter(out) as w:
+        for i, mid in enumerate(["Bricks080", "Wood033", "Metal001"]):
+            payload[mid] = {
+                "color": _fake_png(seed=i, size=128),
+                "normal": _fake_png(seed=i + 100, size=96),
+            }
+            for ch, data in payload[mid].items():
+                w.add_channel(mid, ch, data)
+        rowmap = w.finalize()
+
+    raw = out.read_bytes()
+    for mid, channels in payload.items():
+        for ch, expected in channels.items():
+            off = rowmap[mid][ch]["offset"]
+            length = rowmap[mid][ch]["length"]
+            assert length == len(expected)
+            assert raw[off : off + length] == expected
+
+
+def test_empty_tar_is_valid(tmp_path: Path) -> None:
+    out = tmp_path / "empty.tar"
+    with TarWriter(out) as w:
+        rowmap = w.finalize()
+
+    assert rowmap == {}
+    with tarfile.open(out, "r") as tf:
+        assert tf.getmembers() == []
+
+
+def test_filename_layout_inside_tar(tmp_path: Path) -> None:
+    out = tmp_path / "layout.tar"
+    with TarWriter(out) as w:
+        w.add_channel("Bricks080", "color", _fake_png(1))
+        w.add_channel("Bricks080", "normal", _fake_png(2))
+        w.finalize()
+
+    with tarfile.open(out, "r") as tf:
+        names = sorted(m.name for m in tf.getmembers())
+    assert names == ["Bricks080/color.png", "Bricks080/normal.png"]
+
+
+def test_multi_channel_material(tmp_path: Path) -> None:
+    """All 5 channels of one material must each slice back correctly."""
+    out = tmp_path / "multi.tar"
+    blobs = {
+        ch: _fake_png(i, size=128 + i)
+        for i, ch in enumerate(["color", "normal", "roughness", "metalness", "ao"])
+    }
+    with TarWriter(out) as w:
+        for ch, data in blobs.items():
+            w.add_channel("MatX", ch, data)
+        rowmap = w.finalize()
+
+    raw = out.read_bytes()
+    for ch, expected in blobs.items():
+        off = rowmap["MatX"][ch]["offset"]
+        length = rowmap["MatX"][ch]["length"]
+        assert raw[off : off + length] == expected
+
+
+def test_large_blob_roundtrips(tmp_path: Path) -> None:
+    """5 MB blob — offset arithmetic must not be capped at small sizes."""
+    out = tmp_path / "large.tar"
+    big = _PNG_HEAD + b"\x00" * (5 * 1024 * 1024 - len(_PNG_HEAD))
+    with TarWriter(out) as w:
+        w.add_channel("Huge", "color", big)
+        rowmap = w.finalize()
+
+    raw = out.read_bytes()
+    off = rowmap["Huge"]["color"]["offset"]
+    length = rowmap["Huge"]["color"]["length"]
+    assert length == len(big)
+    assert raw[off : off + length] == big
+
+
+def test_duplicate_add_raises(tmp_path: Path) -> None:
+    out = tmp_path / "dup.tar"
+    with TarWriter(out) as w:
+        w.add_channel("M1", "color", _fake_png(1))
+        with pytest.raises(ValueError, match="duplicate"):
+            w.add_channel("M1", "color", _fake_png(2))
+        w.finalize()
+
+
+def test_ktx2_extension_detected(tmp_path: Path) -> None:
+    """KTX2 payloads get .ktx2 extension, PNG gets .png."""
+    out = tmp_path / "mixed.tar"
+    ktx2 = b"\xabKTX 20\xbb\r\n\x1a\n" + b"\x00" * 32
+    with TarWriter(out) as w:
+        w.add_channel("M1", "color", _fake_png(1))
+        w.add_channel("M2", "color", ktx2)
+        w.finalize()
+
+    with tarfile.open(out, "r") as tf:
+        names = sorted(m.name for m in tf.getmembers())
+    assert names == ["M1/color.png", "M2/color.ktx2"]
+
+
+def test_add_after_finalize_raises(tmp_path: Path) -> None:
+    out = tmp_path / "closed.tar"
+    w = TarWriter(out)
+    w.add_channel("M1", "color", _fake_png(1))
+    w.finalize()
+    with pytest.raises(RuntimeError, match="finalized"):
+        w.add_channel("M2", "color", _fake_png(2))


### PR DESCRIPTION
## Summary

Phase 1 of the v0.5.0 HF-substrate migration (umbrella #100). Two
standalone primitives, no integration yet (Phase 3 wires them in).

- `tar_writer.TarWriter` — append-only tar writer with authoritative
  offset/length sidecar. `finalize()` returns the rowmap-shaped
  `{material_id: {channel: {offset, length}}}`. Offset points at the
  first byte past the 512-byte tar header (tarfile copies the
  `TarInfo` on `addfile`, so the writer captures `tar.offset` before
  the write and derives the payload offset manually). Duplicates
  raise.
- `hf_push.push_to_hf` — atomic multi-file `HfApi.create_commit`.
  Creates the revision branch from `main` on demand.
- `pyproject.toml` — add `huggingface_hub>=0.25` to baker optional-deps.

## Acceptance criteria (from #102)

- [x] New tests pass — 14 new cases (`tests/test_tar_writer.py` × 8,
      `tests/test_hf_push.py` × 6).
- [x] `from mat_vis_baker.tar_writer import TarWriter` works in a
      fresh REPL; `TarWriter(Path("/tmp/x.tar")).finalize()` returns
      `{}` and leaves a valid empty tar.
- [x] `from mat_vis_baker.hf_push import push_to_hf` importable.
- [x] No changes to `__main__.py`, `ktx2.py`, `derive_from_release.py`,
      or any client code — primitives-only phase.
- [x] Full suite green locally: 224 passed / 10 skipped.

## Test plan

- [x] `pytest tests/test_tar_writer.py tests/test_hf_push.py -v` — 14 pass.
- [x] Full suite — 224 passed / 10 skipped (live-network tests).
- [ ] CI green on PR.

Closes #102
Refs #100