### PR TITLE
feat(client): phase 2 proof — physicallybased → HF end-to-end (#103)

### DIFF
--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -42,6 +42,16 @@ GITHUB_API = f"https://api.github.com/repos/{REPO}"
 GITHUB_RAW = f"https://raw.githubusercontent.com/{REPO}"
 LATEST_MANIFEST_URL = f"{GITHUB_RELEASES}/latest/download/release-manifest.json"
 PYPI_API = "https://pypi.org/pypi/mat-vis-client/json"
+
+# v0.5.0 HF-substrate scaffolding — Phase 2 (ADR-0007). When
+# MAT_VIS_USE_HF=1, the client fetches manifest + per-source indexes
+# from the HF dataset revision instead of GitHub Releases. Phase 3
+# makes this the default and drops the env flag.
+HF_DATASET = "gerchowl/mat-vis"
+HF_BASE = os.environ.get(
+    "MAT_VIS_HF_BASE",
+    f"https://huggingface.co/datasets/{HF_DATASET}/resolve",
+)
 DEFAULT_CACHE_DIR = Path(os.environ.get("MAT_VIS_CACHE", Path.home() / ".cache" / "mat-vis"))
 
 # SSoT for version: clients/python/pyproject.toml. Derived at runtime so
@@ -421,6 +431,11 @@ class MatVisClient:
 
         if manifest_url:
             self._manifest_url = manifest_url
+        elif _env_flag("MAT_VIS_USE_HF"):
+            # Phase-2 scaffolding: HF substrate needs an explicit tag —
+            # there is no "latest" branch convention yet.
+            rev = tag or "main"
+            self._manifest_url = f"{HF_BASE}/{rev}/release-manifest.json"
         elif tag:
             self._manifest_url = f"{GITHUB_RELEASES}/download/{tag}/release-manifest.json"
         else:
@@ -760,6 +775,10 @@ class MatVisClient:
     def _index_url(self, source: str) -> str:
         """Build the URL for a source's index JSON."""
         ref = self._tag or "main"
+        if _env_flag("MAT_VIS_USE_HF"):
+            # Phase-2 scaffolding: the HF dataset root holds catalogs at
+            # <source>.json (no per-source index/ subtree — ADR-0007).
+            return f"{HF_BASE}/{ref}/{source}.json"
         return f"{GITHUB_RAW}/{ref}/index/{source}.json"
 
     def index(self, source: str) -> list[dict]:

--- a/clients/python/test_client.py
+++ b/clients/python/test_client.py
@@ -1266,3 +1266,20 @@ class TestLiveFetchTexture:
 
         with pytest.raises(MatVisError, match="material 'NONEXISTENT_XYZ' not found"):
             live_client.fetch_texture("ambientcg", "NONEXISTENT_XYZ", "color", "1k")
+
+
+# ── Phase 2 proof: HF substrate fetch (ADR-0007, gated by MAT_VIS_USE_HF=1) ──
+
+
+@pytest.mark.skipif(
+    os.environ.get("MAT_VIS_USE_HF") != "1",
+    reason="Phase-2 HF substrate proof; set MAT_VIS_USE_HF=1 to run",
+)
+def test_proof_phase_2_fetch_physicallybased_index_from_hf():
+    """Proof bake — physicallybased index fetchable from HF substrate."""
+    with tempfile.TemporaryDirectory() as tmp:
+        client = MatVisClient(tag="v2026.05.0-rc1", cache_dir=Path(tmp))
+        idx = client.index("physicallybased")
+    assert len(idx) >= 50, f"expected ≥50 PB entries, got {len(idx)}"
+    assert all("id" in e and "source" in e for e in idx)
+    assert all(e["source"] == "physicallybased" for e in idx)

--- a/docs/specs/release-manifest-schema-v2.json
+++ b/docs/specs/release-manifest-schema-v2.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MorePET/mat-vis/docs/specs/release-manifest-schema-v2.json",
+  "title": "Release Manifest (v2 — HF substrate, ADR-0007)",
+  "description": "v2 shape for release-manifest.json. Drafted during Phase 2 of the v0.5.0 migration and expected to be locked in Phase 3. Supersedes v1 (GitHub Releases + parquet) — the per-source entry now points at (tar, rowmap) pairs per tier, and scalar-only sources carry just a catalog pointer. Published as the root-level manifest of every tagged HF revision.",
+  "type": "object",
+  "required": ["version", "release_tag", "sources"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "integer",
+      "description": "Schema version. Currently 2.",
+      "const": 2
+    },
+    "release_tag": {
+      "type": "string",
+      "description": "Tag-name of the dataset revision. Calver for production releases (v2026.05.0), suffixed for pre-releases (v2026.05.0-rc1).",
+      "pattern": "^v\\d{4}\\.\\d{2}\\.\\d+(-[A-Za-z0-9.]+)?$"
+    },
+    "sources": {
+      "type": "object",
+      "description": "Keyed by source name. Every baked source appears here — scalar-only sources (physicallybased) omit the 'tiers' key.",
+      "propertyNames": {
+        "enum": ["ambientcg", "polyhaven", "gpuopen", "physicallybased"]
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/sourceEntry"
+      }
+    }
+  },
+  "$defs": {
+    "sourceEntry": {
+      "type": "object",
+      "required": ["catalog", "materials_count"],
+      "additionalProperties": false,
+      "properties": {
+        "catalog": {
+          "type": "string",
+          "description": "Path-in-repo of the per-source index JSON (e.g. 'physicallybased.json')."
+        },
+        "materials_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Count of materials in this source's catalog."
+        },
+        "mtlx": {
+          "type": "string",
+          "description": "Optional — path-in-repo of the MaterialX graph index (present only for sources that ship MTLX)."
+        },
+        "tiers": {
+          "type": "object",
+          "description": "Tier → {tar, rowmap} pairs. Absent on scalar-only sources.",
+          "propertyNames": {
+            "enum": ["1k", "2k", "4k", "8k", "ktx2-1k", "ktx2-2k", "ktx2-4k", "ktx2-8k"]
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/tierAssets"
+          }
+        }
+      }
+    },
+    "tierAssets": {
+      "type": "object",
+      "required": ["tar", "rowmap"],
+      "additionalProperties": false,
+      "properties": {
+        "tar": {
+          "type": "string",
+          "description": "Path-in-repo of the tar archive (e.g. 'ambientcg-1k.tar' or 'ktx2/ambientcg-1k.tar')."
+        },
+        "rowmap": {
+          "type": "string",
+          "description": "Path-in-repo of the offset/length sidecar (e.g. 'ambientcg-1k-rowmap.json')."
+        }
+      }
+    }
+  }
+}

--- a/scripts/proof_bake_phase2.py
+++ b/scripts/proof_bake_phase2.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+"""Phase 2 proof bake: physicallybased → HF as v2026.05.0-rc1.
+
+End-to-end proof of the v0.5.0 substrate for the smallest source
+(scalar-only, no textures → no tar, just the catalog + manifest).
+Pushes `physicallybased.json` + `release-manifest.json` atomically to
+`gerchowl/mat-vis` under the pre-release revision `v2026.05.0-rc1`.
+
+Usage:
+
+    HF_TOKEN=$(security find-generic-password -a "$USER" -s huggingface-token -w) \\
+      .venv/bin/python scripts/proof_bake_phase2.py
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import tempfile
+from pathlib import Path
+
+# Import from the in-tree baker package.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from mat_vis_baker.hf_push import push_to_hf  # noqa: E402
+from mat_vis_baker.index_builder import build_index  # noqa: E402
+from mat_vis_baker.sources import physicallybased  # noqa: E402
+
+REPO_ID = "gerchowl/mat-vis"
+REVISION = "v2026.05.0-rc1"
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s: %(message)s")
+log = logging.getLogger("proof-phase-2")
+
+
+def main() -> int:
+    log.info("fetching physicallybased upstream…")
+    records = physicallybased.fetch()
+    log.info("got %d records", len(records))
+
+    index = build_index(records, source="physicallybased")
+    manifest = {
+        "version": 2,
+        "release_tag": REVISION,
+        "sources": {
+            "physicallybased": {
+                "catalog": "physicallybased.json",
+                "materials_count": len(index),
+            }
+        },
+    }
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        catalog_path = tmp_dir / "physicallybased.json"
+        manifest_path = tmp_dir / "release-manifest.json"
+
+        catalog_path.write_text(json.dumps(index, indent=2, ensure_ascii=False) + "\n")
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+        log.info("pushing to %s@%s…", REPO_ID, REVISION)
+        sha = push_to_hf(
+            repo_id=REPO_ID,
+            files=[
+                (manifest_path, "release-manifest.json"),
+                (catalog_path, "physicallybased.json"),
+            ],
+            revision=REVISION,
+            commit_message=("feat(data): v2026.05.0-rc1 — phase-2 proof bake (physicallybased)"),
+        )
+
+    base = f"https://huggingface.co/datasets/{REPO_ID}/resolve/{REVISION}"
+    log.info("commit sha: %s", sha or "(none)")
+    log.info("manifest:   %s/release-manifest.json", base)
+    log.info("catalog:    %s/physicallybased.json", base)
+    log.info("entries:    %d", len(index))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Phase 2 of the v0.5.0 HF-substrate migration (umbrella #100). End-to-
end proof: bake → HF push → client fetch, using physicallybased
(scalar-only — no textures, so no tar needed — the smallest possible
validation of the new substrate).

- Drafts `release-manifest-schema-v2.json` (keyed by source, optional
  per-tier `{tar, rowmap}`). Locks in Phase 3.
- `scripts/proof_bake_phase2.py` — one-shot bake + HF atomic push.
- Client scaffolding behind `MAT_VIS_USE_HF=1` — manifest + index URLs
  flip to HF when set. GH-Releases path untouched otherwise.
- `test_proof_phase_2_fetch_physicallybased_index_from_hf` — gated
  live test hitting `v2026.05.0-rc1` on HF.

## Proof artifacts on HF

- Commit: `f7f7ab688603` on `gerchowl/mat-vis@v2026.05.0-rc1`
- https://huggingface.co/datasets/gerchowl/mat-vis/resolve/v2026.05.0-rc1/release-manifest.json
- https://huggingface.co/datasets/gerchowl/mat-vis/resolve/v2026.05.0-rc1/physicallybased.json (86 entries)

## Acceptance criteria (from #103)

- [x] `.../v2026.05.0-rc1/physicallybased.json` exists with 86 entries (≥50).
- [x] `.../v2026.05.0-rc1/release-manifest.json` exists and matches the new v2 schema draft.
- [x] `MAT_VIS_USE_HF=1 pytest -k test_proof_phase_2 -v` — 1 passed.
- [x] `curl -sI -L .../physicallybased.json` — 200 after redirects.
- [x] No production code path changed outside the `MAT_VIS_USE_HF` gate.

## Test plan

- [x] Proof bake executed live — manifest + catalog land atomically on HF.
- [x] Live gated test passes.
- [x] Full suite green: 224 passed / 11 skipped.
- [ ] CI green.

Closes #103
Refs #100