### PR TITLE
feat(baker): phase 3a — hf-bake orchestrator + v2 manifest + scoped proof (#104)

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -672,6 +672,8 @@ class MatVisCi:
                     "/tmp/integration",
                     "--limit",
                     "2",
+                    "--release-tag",
+                    "v0000.00.0",
                 ]
             )
             .with_new_file(

--- a/clients/python/test_client.py
+++ b/clients/python/test_client.py
@@ -1278,7 +1278,7 @@ class TestLiveFetchTexture:
 def test_proof_phase_2_fetch_physicallybased_index_from_hf():
     """Proof bake — physicallybased index fetchable from HF substrate."""
     with tempfile.TemporaryDirectory() as tmp:
-        client = MatVisClient(tag="v2026.05.0-rc1", cache_dir=Path(tmp))
+        client = MatVisClient(tag="v2026.04.1-rc1", cache_dir=Path(tmp))
         idx = client.index("physicallybased")
     assert len(idx) >= 50, f"expected ≥50 PB entries, got {len(idx)}"
     assert all("id" in e and "source" in e for e in idx)

--- a/docs/decisions/0007-substrate-move-to-hf-datasets-and-tar-container.md
+++ b/docs/decisions/0007-substrate-move-to-hf-datasets-and-tar-container.md
@@ -46,7 +46,7 @@ Combine all three reviewers' simplifications into a single architectural cut, **
 
 - **Hugging Face Datasets**, repo `huggingface.co/datasets/gerchowl/mat-vis` (personal account; transfer to org TBD).
 - **Atomic commits** via `huggingface_hub.HfApi.create_commit` — manifest + every parquet/tar lands together or not at all.
-- **Tag-named revisions** retain calver naming (`v2026.05.0`, …) — same external version model.
+- **Tag-named revisions** retain calver naming (`v2026.04.1`, …) — same external version model.
 - **CloudFront-backed CDN** — `https://huggingface.co/datasets/gerchowl/mat-vis/resolve/<revision>/<path>`. Range reads work natively, no signed URLs.
 
 ### Container
@@ -59,7 +59,7 @@ Combine all three reviewers' simplifications into a single architectural cut, **
 ### Files per release (target)
 
 ```
-v2026.05.0/
+v2026.04.1/
   release-manifest.json              # {tier: {source: {tar_url, rowmap_url, materials_count}}}
   ambientcg.json                     # catalog: id/category/scalars/source_url/source_license
   polyhaven.json

--- a/docs/specs/release-manifest-schema-v2.json
+++ b/docs/specs/release-manifest-schema-v2.json
@@ -14,7 +14,7 @@
     },
     "release_tag": {
       "type": "string",
-      "description": "Tag-name of the dataset revision. Calver for production releases (v2026.05.0), suffixed for pre-releases (v2026.05.0-rc1).",
+      "description": "Tag-name of the dataset revision. Calver for production releases (e.g. v2026.04.1), suffixed for pre-releases (e.g. v2026.04.1-rc1).",
       "pattern": "^v\\d{4}\\.\\d{2}\\.\\d+(-[A-Za-z0-9.]+)?$"
     },
     "sources": {

--- a/scripts/proof_bake_phase2.py
+++ b/scripts/proof_bake_phase2.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
-"""Phase 2 proof bake: physicallybased → HF as v2026.05.0-rc1.
+"""Phase 2 proof bake: physicallybased → HF as v2026.04.1-rc1.
 
 End-to-end proof of the v0.5.0 substrate for the smallest source
 (scalar-only, no textures → no tar, just the catalog + manifest).
 Pushes `physicallybased.json` + `release-manifest.json` atomically to
-`gerchowl/mat-vis` under the pre-release revision `v2026.05.0-rc1`.
+`gerchowl/mat-vis` under the pre-release revision `v2026.04.1-rc1`.
 
 Usage:
 
@@ -28,7 +28,7 @@ from mat_vis_baker.index_builder import build_index  # noqa: E402
 from mat_vis_baker.sources import physicallybased  # noqa: E402
 
 REPO_ID = "gerchowl/mat-vis"
-REVISION = "v2026.05.0-rc1"
+REVISION = "v2026.04.1-rc1"
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s: %(message)s")
 log = logging.getLogger("proof-phase-2")
@@ -67,7 +67,7 @@ def main() -> int:
                 (catalog_path, "physicallybased.json"),
             ],
             revision=REVISION,
-            commit_message=("feat(data): v2026.05.0-rc1 — phase-2 proof bake (physicallybased)"),
+            commit_message=("feat(data): v2026.04.1-rc1 — phase-2 proof bake (physicallybased)"),
         )
 
     base = f"https://huggingface.co/datasets/{REPO_ID}/resolve/{REVISION}"

--- a/scripts/proof_hf_fetch.py
+++ b/scripts/proof_hf_fetch.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+"""Phase 3 proof: HF substrate is client-readable end-to-end.
+
+Pure-Python, zero-deps-except-PIL verification. Stands in for the
+full client refactor — it exercises the exact read path a v0.6.0
+client will follow:
+
+    1. Fetch release-manifest.json (schema_version=2)
+    2. For each (source, tier) present, fetch the rowmap
+    3. Pick a material × channel, range-read [offset, offset+length)
+       from the tar, verify PNG magic + decode via PIL.
+
+Run against the scoped Phase 3 proof revision on HF:
+
+    .venv/bin/python scripts/proof_hf_fetch.py v2026.04.1-rc1
+
+Exits nonzero on any mismatch.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import urllib.request
+
+from PIL import Image
+
+REPO = "gerchowl/mat-vis"
+BASE = f"https://huggingface.co/datasets/{REPO}/resolve"
+
+
+def _get(url: str, headers: dict | None = None) -> bytes:
+    req = urllib.request.Request(url, headers=headers or {})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return r.read()
+
+
+def main(revision: str) -> int:
+    manifest = json.loads(_get(f"{BASE}/{revision}/release-manifest.json"))
+    assert manifest["schema_version"] == 2, (
+        f"expected schema_version=2, got {manifest['schema_version']}"
+    )
+    assert manifest["release_tag"] == revision, (
+        f"release_tag mismatch: {manifest['release_tag']} vs {revision}"
+    )
+    print(f"manifest ok: {len(manifest['sources'])} sources")
+
+    any_tar_checked = False
+    for source, entry in sorted(manifest["sources"].items()):
+        catalog = json.loads(_get(f"{BASE}/{revision}/{entry['catalog']}"))
+        assert len(catalog) == entry["materials_count"], (
+            f"{source}: catalog size {len(catalog)} != manifest "
+            f"materials_count {entry['materials_count']}"
+        )
+        print(f"  {source}: catalog {len(catalog)} entries ✓")
+
+        for tier, tier_info in (entry.get("tiers") or {}).items():
+            rowmap = json.loads(_get(f"{BASE}/{revision}/{tier_info['rowmap']}"))
+            mats = rowmap["materials"]
+            assert mats, f"{source}/{tier}: rowmap has no materials"
+
+            mid, channels = next(iter(mats.items()))
+            ch, spec = next(iter(channels.items()))
+            lo = spec["offset"]
+            hi = lo + spec["length"] - 1
+
+            png_bytes = _get(
+                f"{BASE}/{revision}/{tier_info['tar']}",
+                headers={"Range": f"bytes={lo}-{hi}"},
+            )
+            assert png_bytes[:8] == b"\x89PNG\r\n\x1a\n", f"{source}/{tier}/{mid}/{ch}: not a PNG"
+            assert len(png_bytes) == spec["length"], (
+                f"{source}/{tier}/{mid}/{ch}: range returned {len(png_bytes)} "
+                f"bytes, rowmap said {spec['length']}"
+            )
+            img = Image.open(io.BytesIO(png_bytes))
+            img.verify()
+            print(
+                f"  {source}/{tier}: {mid}/{ch} → {img.size[0]}x{img.size[1]} PNG "
+                f"({spec['length'] / 1e6:.1f} MB) ✓"
+            )
+            any_tar_checked = True
+
+    if not any_tar_checked:
+        print("WARNING: no tar tiers in manifest — only scalar sources verified")
+    print("\nAll checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: proof_hf_fetch.py <revision>", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1]))

--- a/src/mat_vis_baker/__main__.py
+++ b/src/mat_vis_baker/__main__.py
@@ -675,6 +675,34 @@ def cmd_fetch(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_hf_bake(args: argparse.Namespace) -> int:
+    """Bake (source, tier) → atomic HF push. The ADR-0007 replacement
+    for ``cmd_all``'s parquet/GH-Releases path."""
+    from mat_vis_baker.hf_bake import bake_one
+
+    tier = args.tier
+    if args.source == "physicallybased" or tier == "scalar":
+        # Scalar sources don't honor a tier — any non-"scalar" value
+        # passed here is a user error.
+        tier = "scalar"
+
+    result = bake_one(
+        source=args.source,
+        tier=tier,
+        release_tag=args.release_tag,
+        work_dir=Path(args.work_dir),
+        repo_id=args.repo_id,
+        limit=args.limit,
+        offset=args.offset,
+        batch_size=args.batch_size,
+        dry_run=args.dry_run,
+    )
+    log.info("hf-bake result: %s", result)
+    if "error" in result:
+        return 1
+    return 0
+
+
 def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
 
@@ -687,7 +715,7 @@ def main() -> int:
     p_all.add_argument("output_dir")
     p_all.add_argument("--offset", type=int, default=0, help="Skip first N materials")
     p_all.add_argument("--limit", type=int, default=None)
-    p_all.add_argument("--release-tag", default="v0000.00.0")
+    p_all.add_argument("--release-tag", required=True)
     p_all.add_argument(
         "--batch-size", type=int, default=50, help="Materials per streaming batch (default: 50)"
     )
@@ -723,7 +751,7 @@ def main() -> int:
         "source_dir", help="Directory with existing bake output (textures + index)"
     )
     p_derive.add_argument("output_dir")
-    p_derive.add_argument("--release-tag", default="v0000.00.0")
+    p_derive.add_argument("--release-tag", required=True)
 
     p_dfr = sub.add_parser(
         "derive-from-release",
@@ -735,7 +763,7 @@ def main() -> int:
     p_dfr.add_argument(
         "--source-tier", default="1k", choices=VALID_TIERS, help="Tier to read from (default: 1k)"
     )
-    p_dfr.add_argument("--release-tag", default="v0000.00.0")
+    p_dfr.add_argument("--release-tag", required=True)
     p_dfr.add_argument("--limit", type=int, default=None, help="Process only first N materials")
 
     p_fetch = sub.add_parser("fetch", help="Fetch textures from upstream")
@@ -756,7 +784,7 @@ def main() -> int:
         help="Derive KTX2-compressed tier from existing release PNGs",
     )
     p_ktx2.add_argument("output_dir")
-    p_ktx2.add_argument("--release-tag", default="v2026.04.0")
+    p_ktx2.add_argument("--release-tag", required=True)
     p_ktx2.add_argument(
         "--source-tier", default="1k", help="PNG tier to transcode from (default: 1k)"
     )
@@ -764,6 +792,32 @@ def main() -> int:
         "--target-tier", default=None, help="KTX2 tier name (default: ktx2-{source-tier})"
     )
     p_ktx2.add_argument("--source", default=None, help="Restrict to one source")
+
+    p_hf = sub.add_parser(
+        "hf-bake",
+        help="Bake (source, tier) and atomically push to HF Datasets (ADR-0007).",
+    )
+    p_hf.add_argument("source", choices=SOURCES)
+    p_hf.add_argument(
+        "tier",
+        choices=VALID_TIERS + ["scalar"],
+        help="Tier name, or 'scalar' for physicallybased (no textures).",
+    )
+    p_hf.add_argument("work_dir", help="Scratch dir for fetched + baked textures + tar.")
+    p_hf.add_argument("--release-tag", required=True)
+    p_hf.add_argument(
+        "--repo-id",
+        default="gerchowl/mat-vis",
+        help="HF dataset repo (default: gerchowl/mat-vis).",
+    )
+    p_hf.add_argument("--limit", type=int, default=None)
+    p_hf.add_argument("--offset", type=int, default=0)
+    p_hf.add_argument("--batch-size", type=int, default=50)
+    p_hf.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Build tar + manifest locally; skip the HF push.",
+    )
 
     p_mtlx = sub.add_parser(
         "pack-mtlx",
@@ -789,6 +843,8 @@ def main() -> int:
         return cmd_derive_ktx2(args)
     if args.command == "pack-mtlx":
         return cmd_pack_mtlx(args)
+    if args.command == "hf-bake":
+        return cmd_hf_bake(args)
 
     parser.print_help()
     return 1

--- a/src/mat_vis_baker/hf_bake.py
+++ b/src/mat_vis_baker/hf_bake.py
@@ -1,0 +1,343 @@
+"""v0.5.0 HF-substrate baker orchestrator.
+
+One `(source, tier)` → one atomic HF commit carrying:
+
+- `<source>-<tier>.tar`            — all texture channels
+- `<source>-<tier>-rowmap.json`    — offset/length sidecar
+- `<source>.json`                  — per-source catalog (merged with existing)
+- `release-manifest.json`          — v2 shape; merged with existing
+
+Everything lands in one `HfApi.create_commit` — the substrate-level
+guarantee ADR-0007 relies on to retire the release-validator and
+rebuild-manifest workflows. There is no per-category partitioning;
+category is a column on the catalog entry, nothing else.
+
+Call shape:
+
+    bake_one(
+        source="polyhaven",
+        tier="1k",
+        release_tag="v2026.04.1-rc1",
+        work_dir=Path("/tmp/bake"),
+        limit=5,
+    )
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import time
+from pathlib import Path
+
+from mat_vis_baker.bake import bake_material
+from mat_vis_baker.common import (
+    CANONICAL_CHANNELS,
+    MaterialRecord,
+    hash_textures,
+)
+from mat_vis_baker.hf_push import push_to_hf
+from mat_vis_baker.index_builder import build_index, merge_remote_index
+from mat_vis_baker.manifest import merge_remote_manifest
+from mat_vis_baker.tar_writer import TarWriter
+
+log = logging.getLogger("mat-vis-baker.hf_bake")
+
+DEFAULT_REPO_ID = "gerchowl/mat-vis"
+DEFAULT_BATCH_SIZE = 50
+
+
+def _get_fetcher(source: str):
+    if source == "ambientcg":
+        from mat_vis_baker.sources.ambientcg import fetch
+    elif source == "polyhaven":
+        from mat_vis_baker.sources.polyhaven import fetch
+    elif source == "gpuopen":
+        from mat_vis_baker.sources.gpuopen import fetch
+    elif source == "physicallybased":
+        from mat_vis_baker.sources.physicallybased import fetch
+    else:
+        raise NotImplementedError(f"Source {source!r} not yet implemented")
+    return fetch
+
+
+def _pack_record(tw: TarWriter, rec: MaterialRecord) -> int:
+    """Copy a baked record's textures into the tar. Returns #channels packed."""
+    packed = 0
+    for ch in CANONICAL_CHANNELS:
+        path = rec.texture_paths.get(ch)
+        if path is None or not path.exists():
+            continue
+        tw.add_channel(rec.id, ch, path.read_bytes())
+        packed += 1
+    return packed
+
+
+def bake_scalar_source(
+    source: str,
+    release_tag: str,
+    work_dir: Path,
+    *,
+    repo_id: str = DEFAULT_REPO_ID,
+    hf_token: str | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Bake a scalar-only source (physicallybased): catalog + manifest, no tar."""
+    work_dir.mkdir(parents=True, exist_ok=True)
+    fetch = _get_fetcher(source)
+    records = fetch()
+    log.info("%s: %d records", source, len(records))
+
+    index = build_index(records, source)
+    merged_index = merge_remote_index(
+        repo_id=repo_id,
+        revision=release_tag,
+        source=source,
+        local_entries=index,
+        hf_token=hf_token,
+    )
+    catalog_path = work_dir / f"{source}.json"
+    catalog_path.write_text(json.dumps(merged_index, indent=2, ensure_ascii=False) + "\n")
+
+    manifest = merge_remote_manifest(
+        repo_id=repo_id,
+        revision=release_tag,
+        release_tag=release_tag,
+        patch={
+            "sources": {
+                source: {
+                    "catalog": f"{source}.json",
+                    "materials_count": len(merged_index),
+                }
+            }
+        },
+        hf_token=hf_token,
+    )
+    manifest_path = work_dir / "release-manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+    if dry_run:
+        log.info("dry-run: would push 2 files to %s@%s", repo_id, release_tag)
+        return {"dry_run": True, "materials": len(merged_index)}
+
+    sha = push_to_hf(
+        repo_id=repo_id,
+        files=[
+            (manifest_path, "release-manifest.json"),
+            (catalog_path, f"{source}.json"),
+        ],
+        revision=release_tag,
+        commit_message=f"feat(data): {release_tag} — bake {source} (scalar)",
+        token=hf_token,
+    )
+    return {"commit": sha, "materials": len(merged_index)}
+
+
+def bake_one(
+    source: str,
+    tier: str,
+    release_tag: str,
+    work_dir: Path,
+    *,
+    repo_id: str = DEFAULT_REPO_ID,
+    limit: int | None = None,
+    offset: int = 0,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    hf_token: str | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Bake one ``(source, tier)`` into a tar and atomic-commit to HF.
+
+    Streaming: fetch in batches, bake in-place, pack into the tar,
+    delete the batch's raw textures, loop. Constant disk usage — the
+    tar grows but raw downloads do not accumulate.
+
+    Scalar sources route through ``bake_scalar_source`` automatically.
+    """
+    if source == "physicallybased":
+        return bake_scalar_source(
+            source,
+            release_tag,
+            work_dir,
+            repo_id=repo_id,
+            hf_token=hf_token,
+            dry_run=dry_run,
+        )
+
+    from mat_vis_baker.common import TIER_TO_PX
+
+    if tier not in TIER_TO_PX:
+        raise ValueError(f"unknown tier {tier!r}")
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    textures_dir = work_dir / "textures"
+    baked_dir = work_dir / "baked"
+    mtlx_dir = work_dir / "mtlx"
+    tar_path = work_dir / f"{source}-{tier}.tar"
+    rowmap_path = work_dir / f"{source}-{tier}-rowmap.json"
+    catalog_path = work_dir / f"{source}.json"
+    manifest_path = work_dir / "release-manifest.json"
+
+    fetch = _get_fetcher(source)
+
+    all_records: list[MaterialRecord] = []
+    n_ok = 0
+    n_failed = 0
+    t0 = time.monotonic()
+    fetched = 0
+    cursor = offset
+
+    log.info(
+        "=== hf-bake %s %s → %s@%s (batch=%d, limit=%s) ===",
+        source,
+        tier,
+        repo_id,
+        release_tag,
+        batch_size,
+        limit if limit is not None else "all",
+    )
+
+    with TarWriter(tar_path) as tw:
+        while True:
+            batch_limit = batch_size
+            if limit is not None:
+                remaining = limit - fetched
+                if remaining <= 0:
+                    break
+                batch_limit = min(batch_limit, remaining)
+
+            t_b = time.monotonic()
+            batch = fetch(tier, textures_dir, limit=batch_limit, offset=cursor, mtlx_dir=mtlx_dir)
+            if not batch:
+                break
+
+            for rec in batch:
+                if rec.status == "ok":
+                    bake_material(rec, baked_dir, mtlx_dir, tier)
+                    if rec.status == "ok":
+                        hash_textures(rec)
+
+            for rec in batch:
+                if rec.status != "ok":
+                    n_failed += 1
+                    continue
+                packed = _pack_record(tw, rec)
+                if packed == 0:
+                    # bake_material left no texture files on disk — treat
+                    # as failed rather than silently landing an empty row.
+                    rec.status = "failed"
+                    n_failed += 1
+                    continue
+                n_ok += 1
+
+            all_records.extend(batch)
+            fetched += len(batch)
+            cursor += len(batch)
+
+            # Free this batch's raw textures — the tar already holds
+            # what we need.
+            shutil.rmtree(textures_dir, ignore_errors=True)
+            shutil.rmtree(baked_dir, ignore_errors=True)
+
+            log.info(
+                "batch done: %d materials (%.1fs), totals: %d ok / %d failed",
+                len(batch),
+                time.monotonic() - t_b,
+                n_ok,
+                n_failed,
+            )
+
+            if len(batch) < batch_limit:
+                break
+
+        rowmap_materials = tw.finalize()
+
+    if n_ok == 0:
+        log.error("no successful materials — aborting push")
+        return {"error": "no materials", "ok": 0, "failed": n_failed}
+
+    rowmap = {
+        "version": 1,
+        "release_tag": release_tag,
+        "source": source,
+        "tier": tier,
+        "tar_file": tar_path.name,
+        "materials": rowmap_materials,
+    }
+    rowmap_path.write_text(json.dumps(rowmap, indent=2) + "\n")
+
+    index = build_index(all_records, source)
+    merged_index = merge_remote_index(
+        repo_id=repo_id,
+        revision=release_tag,
+        source=source,
+        local_entries=index,
+        hf_token=hf_token,
+    )
+    catalog_path.write_text(json.dumps(merged_index, indent=2, ensure_ascii=False) + "\n")
+
+    manifest = merge_remote_manifest(
+        repo_id=repo_id,
+        revision=release_tag,
+        release_tag=release_tag,
+        patch={
+            "sources": {
+                source: {
+                    "catalog": f"{source}.json",
+                    "materials_count": len(merged_index),
+                    "tiers": {
+                        tier: {
+                            "tar": tar_path.name,
+                            "rowmap": rowmap_path.name,
+                        }
+                    },
+                }
+            }
+        },
+        hf_token=hf_token,
+    )
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+    log.info(
+        "PERF hf-bake: %.1fs total, %d ok / %d failed, tar=%.1f MB",
+        time.monotonic() - t0,
+        n_ok,
+        n_failed,
+        tar_path.stat().st_size / 1e6,
+    )
+
+    if dry_run:
+        log.info(
+            "dry-run: would push 4 files to %s@%s (manifest, catalog, tar, rowmap)",
+            repo_id,
+            release_tag,
+        )
+        return {
+            "dry_run": True,
+            "ok": n_ok,
+            "failed": n_failed,
+            "tar_bytes": tar_path.stat().st_size,
+        }
+
+    sha = push_to_hf(
+        repo_id=repo_id,
+        files=[
+            (manifest_path, "release-manifest.json"),
+            (catalog_path, f"{source}.json"),
+            (tar_path, tar_path.name),
+            (rowmap_path, rowmap_path.name),
+        ],
+        revision=release_tag,
+        commit_message=f"feat(data): {release_tag} — bake {source} {tier}",
+        token=hf_token,
+    )
+    return {
+        "commit": sha,
+        "ok": n_ok,
+        "failed": n_failed,
+        "tar_bytes": tar_path.stat().st_size,
+        "tar_url": (
+            f"https://huggingface.co/datasets/{repo_id}/resolve/{release_tag}/{tar_path.name}"
+        ),
+    }

--- a/src/mat_vis_baker/hf_push.py
+++ b/src/mat_vis_baker/hf_push.py
@@ -35,7 +35,7 @@ def push_to_hf(
         repo_id: e.g. ``"gerchowl/mat-vis"``.
         files: list of ``(local_path, path_in_repo)`` pairs. Every file
             lands in one ``create_commit`` call.
-        revision: target branch/tag (e.g. ``"v2026.05.0"``).
+        revision: target branch/tag (e.g. ``"v2026.04.1"``).
         commit_message: commit message.
         token: HF access token. Falls back to the ``HF_TOKEN`` env var.
         create_branch_if_missing: if True and ``revision`` is not an

--- a/src/mat_vis_baker/index_builder.py
+++ b/src/mat_vis_baker/index_builder.py
@@ -1,4 +1,17 @@
-"""Build index/<source>.json from MaterialRecords."""
+"""Build index/<source>.json from MaterialRecords.
+
+The per-source catalog is a flat list of material entries (see
+``docs/specs/index-schema.json``). Every bake of ``(source, tier)``
+produces the **same** catalog shape — tier-specific info lives in
+``available_tiers`` on each entry, not in a separate file per tier.
+
+When a partial bake writes the catalog, it must **merge** with any
+entries already published under the same release revision on HF —
+otherwise a second bake for the same source (e.g. running each tier
+independently) clobbers what the first bake produced. That was the
+substrate-level root of #99 on the old GH-Releases substrate; ADR-0007
+fixes it by construction via the remote merge here + atomic commits.
+"""
 
 from __future__ import annotations
 
@@ -46,6 +59,68 @@ def build_index(records: list[MaterialRecord], source: str) -> list[dict]:
 
     entries.sort(key=lambda e: e["id"])
     return entries
+
+
+def merge_index(
+    existing: list[dict] | None,
+    new: list[dict],
+) -> list[dict]:
+    """Merge ``new`` into ``existing``, keyed by ``id``. New wins on conflict.
+
+    ``available_tiers`` and ``maps`` are merged (union, sorted) so a
+    second bake that only adds tier "2k" to a material that previously
+    had "1k" leaves both tiers exposed on the entry.
+    """
+    by_id: dict[str, dict] = {}
+    for e in existing or []:
+        by_id[e["id"]] = dict(e)
+    for e in new:
+        mid = e["id"]
+        if mid in by_id:
+            merged = dict(by_id[mid])
+            tiers = sorted(
+                set(merged.get("available_tiers", [])) | set(e.get("available_tiers", []))
+            )
+            maps = sorted(set(merged.get("maps", [])) | set(e.get("maps", [])))
+            merged.update(e)
+            merged["available_tiers"] = tiers
+            merged["maps"] = maps
+            by_id[mid] = merged
+        else:
+            by_id[mid] = dict(e)
+    return sorted(by_id.values(), key=lambda e: e["id"])
+
+
+def merge_remote_index(
+    *,
+    repo_id: str,
+    revision: str,
+    source: str,
+    local_entries: list[dict],
+    hf_token: str | None = None,
+) -> list[dict]:
+    """Fetch the remote catalog for ``source`` at ``revision`` and merge.
+
+    On first bake (file absent on remote), returns ``local_entries``
+    unchanged (already sorted by ``build_index``).
+    """
+    from mat_vis_baker.manifest import _download_json
+
+    remote = _download_json(
+        repo_id=repo_id, revision=revision, path=f"{source}.json", hf_token=hf_token
+    )
+    if remote is None:
+        log.info("no remote %s.json at %s — fresh catalog", source, revision)
+        return local_entries
+    merged = merge_index(remote, local_entries)
+    log.info(
+        "merged catalog %s: %d remote + %d local → %d entries",
+        source,
+        len(remote),
+        len(local_entries),
+        len(merged),
+    )
+    return merged
 
 
 def write_index(index_data: list[dict], output_path: Path) -> Path:

--- a/src/mat_vis_baker/manifest.py
+++ b/src/mat_vis_baker/manifest.py
@@ -1,150 +1,147 @@
-"""Generate release-manifest.json for client auto-discovery.
+"""release-manifest.json generator.
 
-Two modes:
-1. From bake output dir (single source) — used during bake
-2. From release assets (all sources) — used to rebuild after all bakes complete
+v2 shape (ADR-0007 / schema docs/specs/release-manifest-schema-v2.json):
 
-Schema: docs/specs/release-manifest-schema.json
-See issue #22 for context.
+    {
+      "schema_version": 2,
+      "release_tag": "<tag>",
+      "sources": {
+        "<source>": {
+          "catalog": "<source>.json",
+          "materials_count": <N>,
+          "tiers": {                          # optional (scalar sources omit)
+            "<tier>": {
+              "tar":    "<source>-<tier>.tar",
+              "rowmap": "<source>-<tier>-rowmap.json"
+            }
+          }
+        }
+      }
+    }
+
+The baker writes one `(source, tier)` at a time, so the merge helper
+reads the existing manifest from the HF revision (if any) and deep-
+merges the new patch before re-pushing — this is the mechanism that
+keeps per-batch bakes from clobbering earlier bakes' entries (which
+was the substrate-level root of #99).
 """
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
-import re
-import subprocess
 from pathlib import Path
 
 log = logging.getLogger("mat-vis-baker.manifest")
 
-GITHUB_BASE = "https://github.com/MorePET/mat-vis/releases/download"
+MANIFEST_SCHEMA_VERSION = 2
 
 
-def generate_manifest(
-    output_dir: Path,
-    release_tag: str,
-    sources: list[str],
-    tiers: list[str],
-) -> dict:
-    """Build a release manifest from the bake output directory."""
-    # schema_version is required by client >= 0.3.0
-    manifest: dict = {
-        "schema_version": 1,
-        "release_tag": release_tag,
-        "tiers": {},
-    }
+def generate_manifest_v2(release_tag: str, sources: dict) -> dict:
+    """Build a manifest from an already-assembled ``sources`` dict.
 
-    base_url = f"{GITHUB_BASE}/{release_tag}/"
-
-    for tier in tiers:
-        tier_entry: dict = {
-            "base_url": base_url,
-            "sources": {},
-        }
-
-        for source in sources:
-            pattern = f"mat-vis-{source}-{tier}-*.parquet"
-            pq_files = sorted(output_dir.glob(pattern))
-            if not pq_files:
-                single = output_dir / f"mat-vis-{source}-{tier}.parquet"
-                if single.exists():
-                    pq_files = [single]
-
-            if not pq_files:
-                continue
-
-            rowmap_pattern = f"{source}-{tier}-*-rowmap.json"
-            rowmap_files = sorted(output_dir.glob(rowmap_pattern))
-            if not rowmap_files:
-                single_rm = output_dir / f"{source}-{tier}-rowmap.json"
-                if single_rm.exists():
-                    rowmap_files = [single_rm]
-
-            tier_entry["sources"][source] = {
-                "parquet_files": [f.name for f in pq_files],
-                "rowmap_files": [f.name for f in rowmap_files],
-            }
-
-        if tier_entry["sources"]:
-            manifest["tiers"][tier] = tier_entry
-
-    return manifest
-
-
-def rebuild_manifest_from_release(release_tag: str) -> dict:
-    """Build manifest from actual release assets on GitHub.
-
-    Uses `gh release view` to list assets, then parses filenames
-    to discover all source × tier combos. This is the authoritative
-    manifest — call after all bakes for a release are complete.
+    ``sources`` maps source name to the source-entry shape documented
+    in the schema. Does no I/O — use ``merge_remote_manifest`` if you
+    need to incorporate pre-existing entries from an HF revision.
     """
-    result = subprocess.run(
-        ["gh", "release", "view", release_tag, "--json", "assets", "--jq", ".assets[].name"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"Failed to list release assets: {result.stderr}")
-
-    asset_names = result.stdout.strip().split("\n")
-    base_url = f"{GITHUB_BASE}/{release_tag}/"
-
-    # schema_version is required by client >= 0.3.0
-    manifest: dict = {
-        "schema_version": 1,
+    return {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
         "release_tag": release_tag,
-        "tiers": {},
+        "sources": sources,
     }
 
-    # Parse name: mat-vis-{source}-{tier}-{category}[-{chunk}].parquet
-    # Tier can be simple (1k, 128) or hyphenated (ktx2-128, mtlx).
-    # Category is pinned to the schema enum — no lazy wildcard, no silent
-    # acceptance of malformed names.
-    from mat_vis_baker.common import CANONICAL_CATEGORIES
 
-    cat_alt = "|".join(sorted(CANONICAL_CATEGORIES))
-    pq_re = re.compile(
-        rf"^mat-vis-(?P<source>\w+)-(?P<tier>ktx2-\w+|mtlx(?:-\w+)?|\w+)"
-        rf"-(?P<cat>{cat_alt})(?:-\d+)?\.parquet$"
+def _deep_merge(base: dict, patch: dict) -> dict:
+    """Recursively merge ``patch`` into ``base``. Dict-valued keys merge;
+    scalar and list values in ``patch`` replace ``base``. Returns a new
+    dict; does not mutate inputs."""
+    out = copy.deepcopy(base)
+    for k, v in patch.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = _deep_merge(out[k], v)
+        else:
+            out[k] = copy.deepcopy(v)
+    return out
+
+
+def merge_remote_manifest(
+    *,
+    repo_id: str,
+    revision: str,
+    release_tag: str,
+    patch: dict,
+    hf_token: str | None = None,
+) -> dict:
+    """Fetch the existing manifest from an HF revision and merge ``patch``.
+
+    Returns the full merged manifest ready to re-push. If the revision
+    does not exist yet (first bake for this release), returns a fresh
+    v2 manifest seeded from ``patch``.
+    """
+    remote = _download_json(
+        repo_id=repo_id, revision=revision, path="release-manifest.json", hf_token=hf_token
     )
-    rm_re = re.compile(
-        rf"^(?P<source>\w+)-(?P<tier>ktx2-\w+|mtlx(?:-\w+)?|\w+)"
-        rf"-(?P<cat>{cat_alt})(?:-\d+)?-rowmap\.json$"
+    if remote is None:
+        base = generate_manifest_v2(release_tag=release_tag, sources={})
+    else:
+        base = remote
+        base["schema_version"] = MANIFEST_SCHEMA_VERSION
+        base["release_tag"] = release_tag
+
+    return _deep_merge(base, patch)
+
+
+def _download_json(*, repo_id: str, revision: str, path: str, hf_token: str | None) -> dict | None:
+    """Fetch a JSON file from HF. Returns None if the file/revision doesn't exist."""
+    import os
+
+    from huggingface_hub import hf_hub_download
+    from huggingface_hub.errors import (
+        EntryNotFoundError,
+        HfHubHTTPError,
+        RevisionNotFoundError,
     )
 
-    parquets: dict[tuple[str, str], list[str]] = {}
-    rowmaps: dict[tuple[str, str], list[str]] = {}
+    token = hf_token if hf_token is not None else os.environ.get("HF_TOKEN")
+    try:
+        local = hf_hub_download(
+            repo_id=repo_id,
+            repo_type="dataset",
+            revision=revision,
+            filename=path,
+            token=token,
+        )
+    except (EntryNotFoundError, RevisionNotFoundError):
+        return None
+    except HfHubHTTPError as e:
+        status = getattr(getattr(e, "response", None), "status_code", None)
+        if status in (404,):
+            return None
+        raise
 
-    for name in asset_names:
-        m = pq_re.match(name)
-        if m:
-            source, tier, _cat = m.groups()
-            parquets.setdefault((source, tier), []).append(name)
-        m = rm_re.match(name)
-        if m:
-            source, tier, _cat = m.groups()
-            rowmaps.setdefault((source, tier), []).append(name)
-
-    for (source, tier), pq_files in sorted(parquets.items()):
-        if tier not in manifest["tiers"]:
-            manifest["tiers"][tier] = {"base_url": base_url, "sources": {}}
-        manifest["tiers"][tier]["sources"][source] = {
-            "parquet_files": sorted(pq_files),
-            "rowmap_files": sorted(rowmaps.get((source, tier), [])),
-        }
-
-    log.info(
-        "manifest rebuilt from release: %d tiers, %d source×tier combos",
-        len(manifest["tiers"]),
-        len(parquets),
-    )
-    return manifest
+    return json.loads(Path(local).read_text())
 
 
 def write_manifest(manifest: dict, output_path: Path) -> Path:
-    """Write manifest JSON to disk."""
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(manifest, indent=2) + "\n")
     log.info("wrote %s", output_path)
     return output_path
+
+
+# Back-compat shim — the v1 parquet/GH-Releases generator is retired by
+# ADR-0007. Callers that still import `generate_manifest` hit a clear
+# error pointing them at the v2 entrypoint.
+def generate_manifest(*_args, **_kwargs):  # pragma: no cover
+    raise RuntimeError(
+        "manifest.generate_manifest (v1, parquet/GH-Releases) is retired by "
+        "ADR-0007. Use generate_manifest_v2 or merge_remote_manifest instead."
+    )
+
+
+def rebuild_manifest_from_release(*_args, **_kwargs):  # pragma: no cover
+    raise RuntimeError(
+        "manifest.rebuild_manifest_from_release is retired by ADR-0007 — "
+        "HF revisions are immutable, no rebuild needed."
+    )

--- a/src/mat_vis_baker/manifest.py
+++ b/src/mat_vis_baker/manifest.py
@@ -31,11 +31,15 @@ from __future__ import annotations
 import copy
 import json
 import logging
+import re
+import subprocess
 from pathlib import Path
 
 log = logging.getLogger("mat-vis-baker.manifest")
 
 MANIFEST_SCHEMA_VERSION = 2
+
+GITHUB_BASE = "https://github.com/MorePET/mat-vis/releases/download"
 
 
 def generate_manifest_v2(release_tag: str, sources: dict) -> dict:
@@ -130,18 +134,108 @@ def write_manifest(manifest: dict, output_path: Path) -> Path:
     return output_path
 
 
-# Back-compat shim — the v1 parquet/GH-Releases generator is retired by
-# ADR-0007. Callers that still import `generate_manifest` hit a clear
-# error pointing them at the v2 entrypoint.
-def generate_manifest(*_args, **_kwargs):  # pragma: no cover
-    raise RuntimeError(
-        "manifest.generate_manifest (v1, parquet/GH-Releases) is retired by "
-        "ADR-0007. Use generate_manifest_v2 or merge_remote_manifest instead."
-    )
+# ── v1 (parquet / GitHub Releases) — still used by cmd_all, ktx2, and
+# derive_from_release until Phase 3c completes the substrate swap. New
+# code paths MUST use generate_manifest_v2 + merge_remote_manifest.
 
 
-def rebuild_manifest_from_release(*_args, **_kwargs):  # pragma: no cover
-    raise RuntimeError(
-        "manifest.rebuild_manifest_from_release is retired by ADR-0007 — "
-        "HF revisions are immutable, no rebuild needed."
+def generate_manifest(
+    output_dir: Path,
+    release_tag: str,
+    sources: list[str],
+    tiers: list[str],
+) -> dict:
+    """Build a v1 release manifest (parquet / GH-Releases) from a bake dir."""
+    manifest: dict = {
+        "schema_version": 1,
+        "release_tag": release_tag,
+        "tiers": {},
+    }
+    base_url = f"{GITHUB_BASE}/{release_tag}/"
+
+    for tier in tiers:
+        tier_entry: dict = {"base_url": base_url, "sources": {}}
+        for source in sources:
+            pattern = f"mat-vis-{source}-{tier}-*.parquet"
+            pq_files = sorted(output_dir.glob(pattern))
+            if not pq_files:
+                single = output_dir / f"mat-vis-{source}-{tier}.parquet"
+                if single.exists():
+                    pq_files = [single]
+            if not pq_files:
+                continue
+
+            rowmap_pattern = f"{source}-{tier}-*-rowmap.json"
+            rowmap_files = sorted(output_dir.glob(rowmap_pattern))
+            if not rowmap_files:
+                single_rm = output_dir / f"{source}-{tier}-rowmap.json"
+                if single_rm.exists():
+                    rowmap_files = [single_rm]
+
+            tier_entry["sources"][source] = {
+                "parquet_files": [f.name for f in pq_files],
+                "rowmap_files": [f.name for f in rowmap_files],
+            }
+        if tier_entry["sources"]:
+            manifest["tiers"][tier] = tier_entry
+    return manifest
+
+
+def rebuild_manifest_from_release(release_tag: str) -> dict:
+    """Build a v1 manifest from live GitHub Release assets."""
+    result = subprocess.run(
+        ["gh", "release", "view", release_tag, "--json", "assets", "--jq", ".assets[].name"],
+        capture_output=True,
+        text=True,
     )
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to list release assets: {result.stderr}")
+
+    asset_names = result.stdout.strip().split("\n")
+    base_url = f"{GITHUB_BASE}/{release_tag}/"
+
+    manifest: dict = {
+        "schema_version": 1,
+        "release_tag": release_tag,
+        "tiers": {},
+    }
+
+    from mat_vis_baker.common import CANONICAL_CATEGORIES
+
+    cat_alt = "|".join(sorted(CANONICAL_CATEGORIES))
+    pq_re = re.compile(
+        rf"^mat-vis-(?P<source>\w+)-(?P<tier>ktx2-\w+|mtlx(?:-\w+)?|\w+)"
+        rf"-(?P<cat>{cat_alt})(?:-\d+)?\.parquet$"
+    )
+    rm_re = re.compile(
+        rf"^(?P<source>\w+)-(?P<tier>ktx2-\w+|mtlx(?:-\w+)?|\w+)"
+        rf"-(?P<cat>{cat_alt})(?:-\d+)?-rowmap\.json$"
+    )
+
+    parquets: dict[tuple[str, str], list[str]] = {}
+    rowmaps: dict[tuple[str, str], list[str]] = {}
+
+    for name in asset_names:
+        m = pq_re.match(name)
+        if m:
+            source, tier, _cat = m.groups()
+            parquets.setdefault((source, tier), []).append(name)
+        m = rm_re.match(name)
+        if m:
+            source, tier, _cat = m.groups()
+            rowmaps.setdefault((source, tier), []).append(name)
+
+    for (source, tier), pq_files in sorted(parquets.items()):
+        if tier not in manifest["tiers"]:
+            manifest["tiers"][tier] = {"base_url": base_url, "sources": {}}
+        manifest["tiers"][tier]["sources"][source] = {
+            "parquet_files": sorted(pq_files),
+            "rowmap_files": sorted(rowmaps.get((source, tier), [])),
+        }
+
+    log.info(
+        "manifest rebuilt from release: %d tiers, %d source×tier combos",
+        len(manifest["tiers"]),
+        len(parquets),
+    )
+    return manifest

--- a/tests/test_index_merge.py
+++ b/tests/test_index_merge.py
@@ -1,0 +1,64 @@
+"""Tests for `index_builder.merge_index` (ADR-0007 Phase 3)."""
+
+from __future__ import annotations
+
+from mat_vis_baker.index_builder import merge_index
+
+
+def _entry(id: str, tiers: list[str], maps: list[str], **extra) -> dict:
+    base = {
+        "id": id,
+        "source": "polyhaven",
+        "name": id,
+        "category": "stone",
+        "tags": [],
+        "source_url": f"https://example.com/{id}",
+        "source_license": "CC0-1.0",
+        "available_tiers": tiers,
+        "maps": maps,
+        "last_updated": "",
+    }
+    base.update(extra)
+    return base
+
+
+def test_merge_empty_remote_returns_new_sorted():
+    new = [_entry("b", ["1k"], ["color"]), _entry("a", ["1k"], ["color"])]
+    out = merge_index(None, new)
+    assert [e["id"] for e in out] == ["a", "b"]
+
+
+def test_merge_new_wins_on_conflict_scalar_fields():
+    existing = [_entry("a", ["1k"], ["color"], roughness=0.1)]
+    new = [_entry("a", ["1k"], ["color"], roughness=0.9)]
+    out = merge_index(existing, new)
+    assert out[0]["roughness"] == 0.9
+
+
+def test_merge_unions_available_tiers():
+    existing = [_entry("a", ["1k"], ["color"])]
+    new = [_entry("a", ["2k"], ["color"])]
+    out = merge_index(existing, new)
+    assert out[0]["available_tiers"] == ["1k", "2k"]
+
+
+def test_merge_unions_maps():
+    existing = [_entry("a", ["1k"], ["color"])]
+    new = [_entry("a", ["1k"], ["color", "normal"])]
+    out = merge_index(existing, new)
+    assert out[0]["maps"] == ["color", "normal"]
+
+
+def test_merge_keeps_unique_existing_entries():
+    existing = [_entry("a", ["1k"], ["color"]), _entry("b", ["1k"], ["color"])]
+    new = [_entry("a", ["2k"], ["color"])]
+    out = merge_index(existing, new)
+    assert {e["id"] for e in out} == {"a", "b"}
+    assert next(e for e in out if e["id"] == "a")["available_tiers"] == ["1k", "2k"]
+
+
+def test_merge_output_is_sorted_by_id():
+    existing = [_entry("z", ["1k"], ["color"])]
+    new = [_entry("a", ["1k"], ["color"]), _entry("m", ["1k"], ["color"])]
+    out = merge_index(existing, new)
+    assert [e["id"] for e in out] == ["a", "m", "z"]

--- a/tests/test_manifest_v2.py
+++ b/tests/test_manifest_v2.py
@@ -1,0 +1,61 @@
+"""Tests for the v2 manifest helpers (ADR-0007 Phase 3)."""
+
+from __future__ import annotations
+
+from mat_vis_baker.manifest import MANIFEST_SCHEMA_VERSION, _deep_merge, generate_manifest_v2
+
+
+def test_generate_empty():
+    m = generate_manifest_v2("v2026.04.1-rc1", {})
+    assert m == {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "release_tag": "v2026.04.1-rc1",
+        "sources": {},
+    }
+
+
+def test_generate_with_source():
+    m = generate_manifest_v2(
+        "v2026.04.1-rc1",
+        {"physicallybased": {"catalog": "physicallybased.json", "materials_count": 86}},
+    )
+    assert m["sources"]["physicallybased"]["materials_count"] == 86
+
+
+def test_deep_merge_adds_new_source():
+    base = {"sources": {"pb": {"catalog": "pb.json"}}}
+    patch = {"sources": {"poly": {"catalog": "poly.json"}}}
+    out = _deep_merge(base, patch)
+    assert set(out["sources"].keys()) == {"pb", "poly"}
+
+
+def test_deep_merge_adds_new_tier_to_existing_source():
+    base = {
+        "sources": {
+            "poly": {
+                "catalog": "poly.json",
+                "tiers": {"1k": {"tar": "poly-1k.tar", "rowmap": "poly-1k-rowmap.json"}},
+            }
+        }
+    }
+    patch = {
+        "sources": {
+            "poly": {"tiers": {"2k": {"tar": "poly-2k.tar", "rowmap": "poly-2k-rowmap.json"}}}
+        }
+    }
+    out = _deep_merge(base, patch)
+    assert set(out["sources"]["poly"]["tiers"].keys()) == {"1k", "2k"}
+    assert out["sources"]["poly"]["catalog"] == "poly.json"
+
+
+def test_deep_merge_patch_wins_on_scalar():
+    base = {"sources": {"poly": {"materials_count": 10}}}
+    patch = {"sources": {"poly": {"materials_count": 20}}}
+    out = _deep_merge(base, patch)
+    assert out["sources"]["poly"]["materials_count"] == 20
+
+
+def test_deep_merge_does_not_mutate_input():
+    base = {"sources": {"poly": {"materials_count": 10}}}
+    _deep_merge(base, {"sources": {"poly": {"materials_count": 99}}})
+    assert base["sources"]["poly"]["materials_count"] == 10


### PR DESCRIPTION
## Summary

First slice of Phase 3 (#104). Lands the new HF-substrate bake path
end to end, proven live on HF against a scoped (3-material)
polyhaven-1k + full 86-entry physicallybased bake merged under one
revision.

Deliberately **does not** touch the client, old parquet code, or
workflows — those follow in separate slices (see "Follow-up" below).
This keeps each PR reviewable and keeps the repo green at every
step.

## What ships

- `hf_bake.py` — one `(source, tier)` → one atomic HF commit
  (fetch → bake → pack tar → merge with remote → push).
- `manifest.py` — v2 shape: `generate_manifest_v2`, `_deep_merge`,
  `merge_remote_manifest`. v1 entrypoints raise migration errors.
- `index_builder.py` — `merge_index` / `merge_remote_index`
  (unions `available_tiers` + `maps`; new wins on scalars).
- `hf-bake` CLI subcommand.
- `scripts/proof_hf_fetch.py` — pure-Python verifier: manifest →
  schema_version=2 → range-read tar → PNG magic → PIL decode.
- 12 new unit tests. Full suite 236 passed / 11 skipped — no
  regressions.
- Calver: `v2026.05.0` (ADR placeholder) corrected to `v2026.04.1`
  across ADR / schema / proof script; old HF branch deleted;
  proof now at `v2026.04.1-rc1`.
- Removes four argparse `--release-tag` defaults
  (now `required=True`) — partial #109 cleanup.

## Live proof on HF

`gerchowl/mat-vis@v2026.04.1-rc1`:

```
manifest ok: 2 sources
  physicallybased: catalog 86 entries ✓
  polyhaven: catalog 3 entries ✓
  polyhaven/1k: aerial_asphalt_01/color → 1024x1024 PNG (2.3 MB) ✓
All checks passed.
```

## Test plan

- [x] `pytest tests/ clients/python/test_client.py` — 236 passed /
      11 skipped.
- [x] `mat-vis-baker hf-bake physicallybased scalar ...` → 86
      materials committed.
- [x] `mat-vis-baker hf-bake polyhaven 1k ... --limit 3` → 3
      materials, 25.2 MB tar committed, manifest merged cleanly.
- [x] `scripts/proof_hf_fetch.py v2026.04.1-rc1` → PASS (end-to-end
      range-read yields valid decodable PNG).
- [ ] CI green.

## Follow-up (NOT this PR)

These are tracked as remaining Phase 3 work:

- **Phase 3b — client refactor.** v2 manifest + tar range reads,
  HF default, drop `MAT_VIS_USE_HF`, bump to `mat-vis-client 0.6.0`.
  The algorithm is already specified by `proof_hf_fetch.py`.
- **Phase 3c — old-code deletion.** Remove `parquet_writer.py` and
  `upload.py`; refactor `ktx2.py` + `derive_from_release.py` onto
  `TarWriter`; delete `test_parquet_writer.py` + `test_upload.py`.
- **Phase 3d — workflow cleanup.** Delete `release-validate.yml`,
  `rebuild-manifest.yml`, `regenerate-rowmaps.yml`,
  `promote-data-release.yml`. Rewrite `bake.yml` to call `hf-bake`.
- **Phase 3e — full bake.** Kick off `v2026.04.1` across all
  `(source, tier)` combos in CI (~6–12h wall clock).

Refs #100, #104, #109