### PR TITLE
feat(client): phase 3b — HF substrate default, v2 manifest, tar range reads (#104)

### DIFF
--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -44,7 +44,7 @@ DEFAULT_CACHE_DIR = Path(os.environ.get("MAT_VIS_CACHE", Path.home() / ".cache" 
 # Version is kept in sync with clients/python/pyproject.toml by
 # scripts/sync-standalone-version.py (run via pre-commit). Do not
 # hand-edit — a drift test in tests/ fails CI if it disagrees.
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 # Same User-Agent as the installable package (issue #70). Standalone vs
 # pip-installed is an internal packaging detail; servers receiving the
 # request can't act on it and splitting UA populations fragments

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mat-vis-client"
-version = "0.5.0"
+version = "0.6.0"
 description = "Pure Python client for mat-vis PBR textures — HTTP range reads, zero deps"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -37,16 +37,13 @@ from importlib.metadata import version as _pkg_version
 from pathlib import Path
 
 REPO = "MorePET/mat-vis"
-GITHUB_RELEASES = f"https://github.com/{REPO}/releases"
-GITHUB_API = f"https://api.github.com/repos/{REPO}"
-GITHUB_RAW = f"https://raw.githubusercontent.com/{REPO}"
-LATEST_MANIFEST_URL = f"{GITHUB_RELEASES}/latest/download/release-manifest.json"
+GITHUB_API = f"https://api.github.com/repos/{REPO}"  # update-check only
 PYPI_API = "https://pypi.org/pypi/mat-vis-client/json"
 
-# v0.5.0 HF-substrate scaffolding — Phase 2 (ADR-0007). When
-# MAT_VIS_USE_HF=1, the client fetches manifest + per-source indexes
-# from the HF dataset revision instead of GitHub Releases. Phase 3
-# makes this the default and drops the env flag.
+# v0.6.0 (ADR-0007): HF Datasets is the canonical substrate. URLs are
+# built as ``{HF_BASE}/<tag>/<path>``. There is no "latest" alias on HF
+# — callers must pin a revision (tag or branch). `MAT_VIS_HF_BASE`
+# overrides the default for tests / private mirrors.
 HF_DATASET = "gerchowl/mat-vis"
 HF_BASE = os.environ.get(
     "MAT_VIS_HF_BASE",
@@ -378,7 +375,7 @@ def _in_range(value: float | None, lo: float, hi: float) -> bool:
 # Schema versions this client understands. Manifest declares its own
 # schema_version field; if the manifest version is outside this set,
 # the client refuses to operate rather than silently misreading data.
-COMPATIBLE_SCHEMA_VERSIONS = frozenset([1])
+COMPATIBLE_SCHEMA_VERSIONS = frozenset([2])
 
 
 class MatVisClient:
@@ -422,24 +419,15 @@ class MatVisClient:
         # Each shares this instance's cache_dir + cache flag so all tag
         # scopes resolve under one root.
         self._alt_clients: dict[str, MatVisClient] = {}
-        # In-memory cache of resolved redirect URLs (github.com -> signed CDN).
-        # GitHub's signed URLs expire ~5 min; we cache for 4 min to be safe.
-        # Avoids hitting the rate-limited github.com redirect on every
-        # range read to the same parquet.
-        self._redirect_cache: dict[str, tuple[str, float]] = {}
         self._tag = tag
 
         if manifest_url:
             self._manifest_url = manifest_url
-        elif _env_flag("MAT_VIS_USE_HF"):
-            # Phase-2 scaffolding: HF substrate needs an explicit tag —
-            # there is no "latest" branch convention yet.
+        else:
+            # v0.6.0: HF substrate only. No "latest" alias — tag required.
+            # Default `main` tracks the dataset's main branch (for dev).
             rev = tag or "main"
             self._manifest_url = f"{HF_BASE}/{rev}/release-manifest.json"
-        elif tag:
-            self._manifest_url = f"{GITHUB_RELEASES}/download/{tag}/release-manifest.json"
-        else:
-            self._manifest_url = LATEST_MANIFEST_URL
 
     @property
     def _cache_scope(self) -> Path:
@@ -673,91 +661,99 @@ class MatVisClient:
                 f"Upgrade with: pip install -U mat-vis-client"
             )
 
-    def sources(self, tier: str = "1k") -> list[str]:
-        """List available sources for a tier."""
-        tier_data = self.manifest.get("tiers", {}).get(tier, {})
-        return list(tier_data.get("sources", {}).keys())
+    def _revision(self) -> str:
+        """Pinned revision for HF resolve URLs.
 
-    def tiers(self) -> list[str]:
-        """List available tiers (discovered from the manifest)."""
-        return list(self.manifest.get("tiers", {}).keys())
+        v0.6.0 requires a tagged revision — there is no "latest" alias
+        on HF the way `releases/latest` worked on GitHub. Falls back to
+        `main` for dev-time clients constructed with no tag, but that
+        path only sees whatever is on the dataset's default branch.
+        """
+        return self._tag or self.manifest.get("release_tag", "main")
+
+    def _hf_url(self, path: str) -> str:
+        return f"{HF_BASE}/{self._revision()}/{path}"
+
+    def sources(self, tier: str | None = None) -> list[str]:
+        """List sources. With ``tier`` set, restricts to sources that
+        actually published that tier in this revision."""
+        sources = self.manifest.get("sources", {})
+        if tier is None:
+            return sorted(sources.keys())
+        return sorted(name for name, entry in sources.items() if tier in (entry.get("tiers") or {}))
+
+    def tiers(self, source: str | None = None) -> list[str]:
+        """List tiers published in this revision. With ``source``, just that source's."""
+        sources = self.manifest.get("sources", {})
+        if source is not None:
+            src_entry = _lookup(sources, source, kind="source")
+            return sorted((src_entry.get("tiers") or {}).keys())
+        found: set[str] = set()
+        for entry in sources.values():
+            found.update((entry.get("tiers") or {}).keys())
+        return sorted(found)
 
     def categories(self) -> tuple[str, ...]:
-        """Discover material categories from the current release manifest.
+        """Discover material categories from the current release's catalogs.
 
-        Derived from rowmap filenames (``{source}-{tier}-{category}-rowmap.json``).
-        Always reflects the actual release — no hardcoded list to drift.
+        v0.6.0 reads `category` from each source's catalog entry — the
+        old substrate encoded categories in parquet filenames; that
+        dimension no longer exists (ADR-0007 drops per-category
+        partitioning). Always reflects the actual release.
         """
-        import re
-
         global CATEGORIES
-        # Parse categories out of rowmap filenames across all tiers x sources.
-        # Single regex covers simple and chunked names: ...-{cat}[-N]-rowmap.json
-        pat = re.compile(r"-(?P<cat>[a-z]+)(?:-\d+)?-rowmap\.json$")
         found: set[str] = set()
-        for tier_data in self.manifest.get("tiers", {}).values():
-            for src_data in tier_data.get("sources", {}).values():
-                for rm in src_data.get("rowmap_files", []):
-                    m = pat.search(rm)
-                    if m:
-                        found.add(m.group("cat"))
-                single = src_data.get("rowmap_file")
-                if single:
-                    m = pat.search(single)
-                    if m:
-                        found.add(m.group("cat"))
+        for source in self.sources():
+            for entry in self.index(source):
+                cat = entry.get("category")
+                if cat:
+                    found.add(cat)
         result = tuple(sorted(found))
-        # Populate the module-level constant for back-compat
         CATEGORIES = frozenset(result)
         return result
 
     def rowmap(self, source: str, tier: str, category: str | None = None) -> dict:
-        """Fetch and cache rowmaps. Merges partitioned rowmaps into one."""
-        key = f"{source}-{tier}-{category or 'all'}"
-        if key not in self._rowmaps:
-            tiers = self.manifest.get("tiers", {})
-            tier_data = _lookup(tiers, tier, kind="tier")
-            base_url = tier_data["base_url"]
-            src_data = _lookup(
-                tier_data.get("sources", {}), source, kind="source", context=f"tier {tier!r}"
-            )
+        """Fetch and cache the rowmap for a (source, tier).
 
-            rowmap_files = src_data.get("rowmap_files", [])
-            if not rowmap_files:
-                rowmap_file = src_data.get("rowmap_file", f"{source}-{tier}-rowmap.json")
-                rowmap_files = [rowmap_file]
+        v0.6.0: exactly one rowmap per (source, tier) — no per-category
+        partitioning (ADR-0007). The ``category`` kwarg is accepted for
+        back-compat with 0.5.x callers but ignored: every material is
+        in the same tar, filtering by category is the caller's job
+        (typically via `search()` / `index()`).
+        """
+        del category  # accepted but no longer partitions the fetch
 
-            if category:
-                rowmap_files = [f for f in rowmap_files if category in f] or rowmap_files[:1]
+        key = f"{source}-{tier}"
+        if key in self._rowmaps:
+            return self._rowmaps[key]
 
-            # Fetch all partition rowmaps and merge materials
-            merged: dict = {"materials": {}}
-            for rmf in rowmap_files:
-                cache_path = self._cache_scope / ".rowmaps" / rmf
-                cached = self._cache_read_text(cache_path)
-                if cached is not None:
-                    rm = json.loads(cached)
-                else:
-                    url = base_url + rmf
-                    rm = _get_json(url)
-                    self._cache_write_text(cache_path, json.dumps(rm, indent=2))
+        sources = self.manifest.get("sources", {})
+        src_entry = _lookup(sources, source, kind="source")
+        tier_entry = _lookup(
+            src_entry.get("tiers") or {},
+            tier,
+            kind="tier",
+            context=f"source {source!r}",
+        )
+        rowmap_path = tier_entry["rowmap"]
 
-                # Each partitioned rowmap has its own parquet_file
-                pq_file = rm.get("parquet_file", "")
-                for mid, channels in rm.get("materials", {}).items():
-                    # Tag each channel with its parquet file for range reads
-                    for ch_data in channels.values():
-                        ch_data["parquet_file"] = pq_file
-                    merged["materials"][mid] = channels
+        cache_path = self._cache_scope / ".rowmaps" / rowmap_path
+        cached = self._cache_read_text(cache_path)
+        if cached is not None:
+            rm = json.loads(cached)
+        else:
+            rm = _get_json(self._hf_url(rowmap_path))
+            self._cache_write_text(cache_path, json.dumps(rm, indent=2))
 
-                # Keep metadata from last rowmap (they're all the same except materials)
-                for k in ("version", "release_tag", "source", "tier"):
-                    if k in rm:
-                        merged[k] = rm[k]
+        # Attach the tar path to every channel so fetch_texture can find
+        # the bytes without re-reading the manifest.
+        tar_path = tier_entry["tar"]
+        for channels in rm.get("materials", {}).values():
+            for ch_data in channels.values():
+                ch_data["tar_file"] = tar_path
 
-            self._rowmaps[key] = merged
-
-        return self._rowmaps[key]
+        self._rowmaps[key] = rm
+        return rm
 
     def materials(self, source: str, tier: str) -> list[str]:
         """List material IDs available for a source × tier."""
@@ -773,20 +769,22 @@ class MatVisClient:
     # ── Index & search ──────────────────────────────────────────
 
     def _index_url(self, source: str) -> str:
-        """Build the URL for a source's index JSON."""
-        ref = self._tag or "main"
-        if _env_flag("MAT_VIS_USE_HF"):
-            # Phase-2 scaffolding: the HF dataset root holds catalogs at
-            # <source>.json (no per-source index/ subtree — ADR-0007).
-            return f"{HF_BASE}/{ref}/{source}.json"
-        return f"{GITHUB_RAW}/{ref}/index/{source}.json"
+        """Build the URL for a source's catalog JSON on HF."""
+        # The manifest's per-source entry is the authoritative pointer;
+        # fall back to the convention for callers constructing a URL
+        # before loading the manifest.
+        try:
+            catalog = self.manifest["sources"][source]["catalog"]
+        except (KeyError, TypeError):
+            catalog = f"{source}.json"
+        return self._hf_url(catalog)
 
     def index(self, source: str) -> list[dict]:
-        """Fetch and cache the material index for a source.
+        """Fetch and cache the per-source catalog JSON.
 
-        Tries git (raw.githubusercontent.com) first, falls back to
-        release asset (some sources only ship the index on the release).
-        Returns a list of material entries per index-schema.json.
+        v0.6.0: resolves to ``<HF_BASE>/<revision>/<source>.json`` via
+        the manifest. No GH-Raw fallback — the catalog lives in the
+        same dataset revision as everything else (ADR-0007).
         """
         if source not in self._indexes:
             cache_path = self._cache_scope / ".indexes" / f"{source}.json"
@@ -794,21 +792,9 @@ class MatVisClient:
             if cached is not None:
                 self._indexes[source] = json.loads(cached)
             else:
-                # Try git first, then fall back to release asset
-                data = None
-                try:
-                    data = _get_json(self._index_url(source))
-                except Exception:
-                    tag = self.manifest.get("release_tag", self._tag or "")
-                    if tag:
-                        try:
-                            data = _get_json(f"{GITHUB_RELEASES}/download/{tag}/{source}.json")
-                        except Exception:
-                            pass
-                if data is None:
-                    raise FileNotFoundError(f"Index for {source!r} not found in git or release")
+                data = _get_json(self._index_url(source))
                 self._indexes[source] = data
-                self._cache_write_text(cache_path, json.dumps(self._indexes[source], indent=2))
+                self._cache_write_text(cache_path, json.dumps(data, indent=2))
         return self._indexes[source]
 
     _SCALAR_WIDEN = 0.2  # scalar shorthand → range half-width
@@ -1042,10 +1028,12 @@ class MatVisClient:
         if not hasattr(self, "_mtlx_originals"):
             self._mtlx_originals: dict[str, dict[str, str]] = {}
         if source not in self._mtlx_originals:
-            tag = self.manifest.get("release_tag", self._tag or "")
-            url = f"{GITHUB_RELEASES}/download/{tag}/{source}-mtlx.json"
+            mtlx_path = (
+                self.manifest.get("sources", {}).get(source, {}).get("mtlx")
+                or f"{source}-mtlx.json"
+            )
             try:
-                self._mtlx_originals[source] = _get_json(url)
+                self._mtlx_originals[source] = _get_json(self._hf_url(mtlx_path))
             except Exception:
                 self._mtlx_originals[source] = {}
         return self._mtlx_originals[source]
@@ -1060,7 +1048,7 @@ class MatVisClient:
     ) -> dict[str, dict]:
         """Get raw rowmap offsets for a material (for DIY consumers).
 
-        Returns a dict of channel -> {offset, length, parquet_file}.
+        Returns a dict of channel -> {offset, length, tar_file}.
         """
         rm = self.rowmap(source, tier)
         mat = _lookup(
@@ -1069,31 +1057,15 @@ class MatVisClient:
             kind="material",
             context=f"{source}/{tier}",
         )
-        fallback_pq = rm.get("parquet_file", "")
+        tar_file = rm.get("tar_file", "")
         return {
             ch: {
                 "offset": info["offset"],
                 "length": info["length"],
-                "parquet_file": info.get("parquet_file", fallback_pq),
+                "tar_file": info.get("tar_file", tar_file),
             }
             for ch, info in mat.items()
         }
-
-    def _resolved_url(self, url: str) -> tuple[str, bool]:
-        """Return (url_to_use, is_cached). Resolves github.com releases URL to
-        its signed CDN URL and caches for 4 min. Used to amortize the
-        rate-limited redirect across many range reads on the same parquet.
-        """
-        now = time.time()
-        cached = self._redirect_cache.get(url)
-        if cached and cached[1] > now:
-            return cached[0], True
-        return url, False
-
-    def _cache_resolved(self, original_url: str, resolved_url: str) -> None:
-        """Store a resolved CDN URL with a 4-minute TTL."""
-        if resolved_url and resolved_url != original_url:
-            self._redirect_cache[original_url] = (resolved_url, time.time() + 240)
 
     def fetch_texture(
         self,
@@ -1152,35 +1124,12 @@ class MatVisClient:
                 "Raise MAT_VIS_MAX_FETCH_SIZE to override."
             )
 
-        # Find parquet URL (per-partition from merged rowmap)
-        tier_data = self.manifest["tiers"][tier]
-        base_url = tier_data["base_url"]
-        parquet_file = rng.get("parquet_file") or rm.get("parquet_file", "")
-        original_url = base_url + parquet_file
-
-        # Use cached resolved (signed CDN) URL if available — avoids the
-        # rate-limited github.com redirect on repeat range reads.
-        url, is_cached = self._resolved_url(original_url)
+        # Range-read the tar on HF. HF's resolve URL is stable (no
+        # expiring signed-URL dance), so one GET per channel is fine.
+        tar_file = rng.get("tar_file") or rm.get("tar_file", f"{source}-{tier}.tar")
+        url = self._hf_url(tar_file)
         range_header = f"bytes={offset}-{offset + length - 1}"
-
-        try:
-            if is_cached:
-                data = _get(url, headers={"Range": range_header})
-            else:
-                data, resolved = _get(url, headers={"Range": range_header}, return_final_url=True)
-                self._cache_resolved(original_url, resolved)
-        except HTTPFetchError as e:
-            # Signed URL may have expired between cache and use — retry once with fresh.
-            if is_cached and e.code in (403, 404):
-                self._redirect_cache.pop(original_url, None)
-                data, resolved = _get(
-                    original_url,
-                    headers={"Range": range_header},
-                    return_final_url=True,
-                )
-                self._cache_resolved(original_url, resolved)
-            else:
-                raise
+        data = _get(url, headers={"Range": range_header})
 
         # Verify PNG
         if data[:4] != b"\x89PNG":

--- a/clients/python/test_client.py
+++ b/clients/python/test_client.py
@@ -50,60 +50,75 @@ def _mock_get(*args, **kwargs):
 
 
 MOCK_MANIFEST = {
-    "schema_version": 1,
-    "version": 1,  # retained for tests asserting on the legacy field
-    "release_tag": "v2026.04.0",
-    "tiers": {
-        "1k": {
-            "base_url": "https://example.com/releases/download/v2026.04.0/",
-            "sources": {
-                "ambientcg": {
-                    # Single rowmap — legacy shape. Search tests that need
-                    # broader category discovery override via mock_client_with_categories.
-                    "parquet_files": ["mat-vis-ambientcg-1k-stone.parquet"],
-                    "rowmap_files": ["ambientcg-1k-stone-rowmap.json"],
-                    "rowmap_file": "ambientcg-1k-stone-rowmap.json",
-                },
-                "polyhaven": {
-                    "parquet_files": ["mat-vis-polyhaven-1k-wood.parquet"],
-                    "rowmap_files": ["polyhaven-1k-wood-rowmap.json"],
-                    "rowmap_file": "polyhaven-1k-wood-rowmap.json",
-                },
-                "gpuopen": {
-                    "parquet_files": ["mat-vis-gpuopen-1k-other.parquet"],
-                    "rowmap_files": ["gpuopen-1k-other-rowmap.json"],
-                    "rowmap_file": "gpuopen-1k-other-rowmap.json",
+    "schema_version": 2,
+    "release_tag": "v2026.04.1",
+    "sources": {
+        "ambientcg": {
+            "catalog": "ambientcg.json",
+            "materials_count": 3,
+            "tiers": {
+                "1k": {
+                    "tar": "ambientcg-1k.tar",
+                    "rowmap": "ambientcg-1k-rowmap.json",
                 },
             },
-        }
+        },
+        "polyhaven": {
+            "catalog": "polyhaven.json",
+            "materials_count": 1,
+            "tiers": {
+                "1k": {
+                    "tar": "polyhaven-1k.tar",
+                    "rowmap": "polyhaven-1k-rowmap.json",
+                },
+            },
+        },
+        "gpuopen": {
+            "catalog": "gpuopen.json",
+            "materials_count": 1,
+            "tiers": {
+                "1k": {
+                    "tar": "gpuopen-1k.tar",
+                    "rowmap": "gpuopen-1k-rowmap.json",
+                },
+            },
+        },
     },
 }
 
-# Rowmap suitable for the gpuopen "test-uuid" material — mirrors the
-# ambientcg fixture's structure so MtlxSource.original.export() has
-# concrete channels to rewrite texture paths against.
+# Rowmap shape for the v0.6.0 tar substrate: no parquet_file, offsets
+# point at tar bytes. The client attaches `tar_file` on each channel at
+# read time from the manifest's tier entry.
 MOCK_ROWMAP_GPUOPEN = {
-    "parquet_file": "gpuopen-1k.parquet",
+    "version": 1,
+    "release_tag": "v2026.04.1",
+    "source": "gpuopen",
+    "tier": "1k",
+    "tar_file": "gpuopen-1k.tar",
     "materials": {
         "test-uuid": {
-            "color": {"offset": 0, "length": 1024},
-            "roughness": {"offset": 1024, "length": 512},
+            "color": {"offset": 512, "length": 1024},
+            "roughness": {"offset": 2048, "length": 512},
         },
     },
 }
 
 MOCK_ROWMAP = {
-    "parquet_file": "ambientcg-1k.parquet",
+    "version": 1,
+    "release_tag": "v2026.04.1",
+    "source": "ambientcg",
+    "tier": "1k",
+    "tar_file": "ambientcg-1k.tar",
     "materials": {
         "Rock064": {
-            "color": {"offset": 0, "length": 1024},
-            "normal": {"offset": 1024, "length": 2048},
-            "roughness": {"offset": 3072, "length": 512},
+            "color": {"offset": 512, "length": 1024},
+            "normal": {"offset": 2048, "length": 2048},
+            "roughness": {"offset": 4608, "length": 512},
         },
         "Metal032": {
-            "color": {"offset": 4000, "length": 800},
-            "metalness": {"offset": 4800, "length": 600},
-            "roughness": {"offset": 5400, "length": 500},
+            "color": {"offset": 5120, "length": 800},
+            "metalness": {"offset": 6144, "length": 600},
+            "roughness": {"offset": 7168, "length": 500},
         },
     },
 }
@@ -161,9 +176,9 @@ MOCK_INDEX_AMBIENTCG = [
 def mock_client():
     """Client with mocked HTTP and temp cache."""
     with tempfile.TemporaryDirectory() as tmp:
-        client = MatVisClient(tag="v2026.04.0", cache_dir=Path(tmp))
-        # Pre-populate manifest cache at the tag-scoped path (0.5.0+).
-        cache_path = Path(tmp) / "v2026.04.0" / ".manifest.json"
+        client = MatVisClient(tag="v2026.04.1", cache_dir=Path(tmp))
+        # Pre-populate manifest cache at the tag-scoped path.
+        cache_path = Path(tmp) / "v2026.04.1" / ".manifest.json"
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         cache_path.write_text(json.dumps(MOCK_MANIFEST))
         # Suppress the background update-check HTTP calls that would
@@ -177,22 +192,15 @@ def mock_search_client():
     """Client with a richer manifest (multiple rowmaps per source) so
     search() discovers the full category set. Used by search tests that
     reference categories not in the default single-rowmap fixture."""
+    # v0.6.0: no per-category partitioning (ADR-0007). The "rich"
+    # variant just raises the materials_count to match the full catalog
+    # used by search tests; category breadth comes from the catalog
+    # itself, not the manifest.
     rich_manifest = json.loads(json.dumps(MOCK_MANIFEST))  # deep copy
-    rich_manifest["tiers"]["1k"]["sources"]["ambientcg"].update(
-        parquet_files=[
-            "mat-vis-ambientcg-1k-stone.parquet",
-            "mat-vis-ambientcg-1k-metal.parquet",
-            "mat-vis-ambientcg-1k-wood.parquet",
-        ],
-        rowmap_files=[
-            "ambientcg-1k-stone-rowmap.json",
-            "ambientcg-1k-metal-rowmap.json",
-            "ambientcg-1k-wood-rowmap.json",
-        ],
-    )
+    rich_manifest["sources"]["ambientcg"]["materials_count"] = 3
     with tempfile.TemporaryDirectory() as tmp:
-        client = MatVisClient(tag="v2026.04.0", cache_dir=Path(tmp))
-        cache_path = Path(tmp) / "v2026.04.0" / ".manifest.json"
+        client = MatVisClient(tag="v2026.04.1", cache_dir=Path(tmp))
+        cache_path = Path(tmp) / "v2026.04.1" / ".manifest.json"
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         cache_path.write_text(json.dumps(rich_manifest))
         client._update_warned = True
@@ -223,8 +231,8 @@ class TestInRange:
 class TestClientManifest:
     def test_manifest_loads_from_cache(self, mock_client):
         m = mock_client.manifest
-        assert m["schema_version"] == 1
-        assert "tiers" in m
+        assert m["schema_version"] == 2
+        assert "sources" in m
 
     def test_tiers(self, mock_client):
         assert mock_client.tiers() == ["1k"]
@@ -242,8 +250,8 @@ def _fresh_client(cache_dir: Path) -> MatVisClient:
     """Client with MOCK_MANIFEST pre-cached but the update-check flag
     NOT suppressed — lets tests exercise the TTY / env-var gating path.
     """
-    client = MatVisClient(tag="v2026.04.0", cache_dir=cache_dir)
-    scoped = cache_dir / "v2026.04.0"
+    client = MatVisClient(tag="v2026.04.1", cache_dir=cache_dir)
+    scoped = cache_dir / "v2026.04.1"
     scoped.mkdir(parents=True, exist_ok=True)
     (scoped / ".manifest.json").write_text(json.dumps(MOCK_MANIFEST))
     return client
@@ -448,9 +456,9 @@ class TestClientRowmap:
     def test_rowmap_entry(self, mock_get, mock_client):
         entry = mock_client.rowmap_entry("ambientcg", "Rock064", "1k")
         assert "color" in entry
-        assert entry["color"]["offset"] == 0
+        assert entry["color"]["offset"] == 512
         assert entry["color"]["length"] == 1024
-        assert entry["color"]["parquet_file"] == "ambientcg-1k.parquet"
+        assert entry["color"]["tar_file"] == "ambientcg-1k.tar"
 
 
 class TestClientSearch:
@@ -500,7 +508,8 @@ class TestClientSearch:
         results = mock_search_client.search(source="ambientcg")
         assert len(results) == 3
 
-    def test_search_invalid_category_returns_empty(self, mock_client, caplog):
+    @patch("mat_vis_client.client._get_json")
+    def test_search_invalid_category_returns_empty(self, mock_get, mock_client, caplog):
         """Invalid category soft-warns and returns empty rather than raising.
 
         Raising would force consumers to validate against a moving-target
@@ -510,6 +519,9 @@ class TestClientSearch:
         """
         import logging
 
+        # v0.6.0 derives categories from per-source catalog entries; mock
+        # each `.index()` call with the fixture.
+        mock_get.return_value = MOCK_INDEX_AMBIENTCG
         with caplog.at_level(logging.WARNING, logger="mat-vis-client"):
             results = mock_client.search("invalid_category")
         assert results == []
@@ -716,7 +728,7 @@ class TestFriendlyNotFoundErrors:
     def test_unknown_source_suggests_available(self, mock_http, mock_json, mock_client):
         from mat_vis_client import MatVisError
 
-        with pytest.raises(MatVisError, match=r"source 'nope' not found in tier '1k'"):
+        with pytest.raises(MatVisError, match=r"source 'nope' not found"):
             mock_client.fetch_texture("nope", "Rock064", "color", "1k")
 
     @patch("mat_vis_client.client._get_json", return_value=MOCK_ROWMAP)
@@ -1196,87 +1208,88 @@ live = pytest.mark.skipif(
 )
 
 
+LIVE_TAG = "v2026.04.1-rc1"
+LIVE_SOURCE = "polyhaven"
+LIVE_TIER = "1k"
+
+
 @pytest.fixture
 def live_client():
-    """Client pointed at v2026.04.0 with temp cache."""
+    """Client pointed at the scoped-proof HF revision with a temp cache."""
     with tempfile.TemporaryDirectory() as tmp:
-        yield MatVisClient(tag="v2026.04.0", cache_dir=Path(tmp))
+        yield MatVisClient(tag=LIVE_TAG, cache_dir=Path(tmp))
 
 
 @live
 class TestLiveManifest:
     def test_fetch_manifest(self, live_client):
         m = live_client.manifest
-        assert m["schema_version"] == 1
-        assert "tiers" in m
+        assert m["schema_version"] == 2
+        assert "sources" in m
 
     def test_tiers(self, live_client):
         tiers = live_client.tiers()
-        assert "1k" in tiers
+        assert LIVE_TIER in tiers
 
     def test_sources(self, live_client):
-        sources = live_client.sources("1k")
-        assert "ambientcg" in sources
+        sources = live_client.sources(LIVE_TIER)
+        assert LIVE_SOURCE in sources
 
 
 @live
 class TestLiveRowmap:
     def test_fetch_rowmap(self, live_client):
-        rm = live_client.rowmap("ambientcg", "1k")
+        rm = live_client.rowmap(LIVE_SOURCE, LIVE_TIER)
         assert "materials" in rm
         assert len(rm["materials"]) > 0
 
     def test_materials_list(self, live_client):
-        mats = live_client.materials("ambientcg", "1k")
+        mats = live_client.materials(LIVE_SOURCE, LIVE_TIER)
         assert len(mats) > 0
         assert all(isinstance(m, str) for m in mats)
 
     def test_channels(self, live_client):
-        mats = live_client.materials("ambientcg", "1k")
-        channels = live_client.channels("ambientcg", mats[0], "1k")
+        mats = live_client.materials(LIVE_SOURCE, LIVE_TIER)
+        channels = live_client.channels(LIVE_SOURCE, mats[0], LIVE_TIER)
         assert "color" in channels
 
 
 @live
 class TestLiveFetchTexture:
     def test_fetch_returns_png(self, live_client):
-        mats = live_client.materials("ambientcg", "1k")
-        data = live_client.fetch_texture("ambientcg", mats[0], "color", "1k")
+        mats = live_client.materials(LIVE_SOURCE, LIVE_TIER)
+        data = live_client.fetch_texture(LIVE_SOURCE, mats[0], "color", LIVE_TIER)
         assert data[:4] == b"\x89PNG"
         assert len(data) > 1000
 
     def test_fetch_caches_locally(self, live_client):
-        mats = live_client.materials("ambientcg", "1k")
+        mats = live_client.materials(LIVE_SOURCE, LIVE_TIER)
         mid = mats[0]
-        data1 = live_client.fetch_texture("ambientcg", mid, "color", "1k")
-        data2 = live_client.fetch_texture("ambientcg", mid, "color", "1k")
+        data1 = live_client.fetch_texture(LIVE_SOURCE, mid, "color", LIVE_TIER)
+        data2 = live_client.fetch_texture(LIVE_SOURCE, mid, "color", LIVE_TIER)
         assert data1 == data2
 
     def test_fetch_multiple_channels(self, live_client):
-        mats = live_client.materials("ambientcg", "1k")
+        mats = live_client.materials(LIVE_SOURCE, LIVE_TIER)
         mid = mats[0]
-        channels = live_client.channels("ambientcg", mid, "1k")
+        channels = live_client.channels(LIVE_SOURCE, mid, LIVE_TIER)
         for ch in channels[:3]:
-            data = live_client.fetch_texture("ambientcg", mid, ch, "1k")
+            data = live_client.fetch_texture(LIVE_SOURCE, mid, ch, LIVE_TIER)
             assert data[:4] == b"\x89PNG", f"{mid}/{ch} is not PNG"
 
     def test_fetch_nonexistent_material_raises(self, live_client):
-        # 0.4.0: KeyError replaced by MatVisError carrying an Available list.
         from mat_vis_client import MatVisError
 
         with pytest.raises(MatVisError, match="material 'NONEXISTENT_XYZ' not found"):
-            live_client.fetch_texture("ambientcg", "NONEXISTENT_XYZ", "color", "1k")
+            live_client.fetch_texture(LIVE_SOURCE, "NONEXISTENT_XYZ", "color", LIVE_TIER)
 
 
-# ── Phase 2 proof: HF substrate fetch (ADR-0007, gated by MAT_VIS_USE_HF=1) ──
+# ── Phase 2 proof (physicallybased scalar catalog, live on HF) ──
 
 
-@pytest.mark.skipif(
-    os.environ.get("MAT_VIS_USE_HF") != "1",
-    reason="Phase-2 HF substrate proof; set MAT_VIS_USE_HF=1 to run",
-)
+@live
 def test_proof_phase_2_fetch_physicallybased_index_from_hf():
-    """Proof bake — physicallybased index fetchable from HF substrate."""
+    """Scalar catalog for physicallybased is fetchable from HF substrate."""
     with tempfile.TemporaryDirectory() as tmp:
         client = MatVisClient(tag="v2026.04.1-rc1", cache_dir=Path(tmp))
         idx = client.index("physicallybased")


### PR DESCRIPTION
## Summary

Phase 3b (#104). mat-vis-client speaks HF + tar natively. Version
bumps to **0.6.0** — reading v1 manifests (GH-Releases era) is
intentionally no longer supported; that substrate is frozen at
\`v2026.04.0\` and 0.5.x stays on PyPI for consumers still pinned
to it.

## Changes

- \`clients/python/pyproject.toml\` — 0.5.0 → **0.6.0** (standalone synced).
- \`COMPATIBLE_SCHEMA_VERSIONS = {2}\`.
- Drop all GH-Releases scaffolding:
  \`GITHUB_RELEASES\`, \`GITHUB_RAW\`, \`LATEST_MANIFEST_URL\`,
  \`_redirect_cache\`, \`_resolved_url\`, \`_cache_resolved\`,
  \`MAT_VIS_USE_HF\` env flag, signed-URL stale-retry branch.
- Manifest defaults to \`{HF_BASE}/<tag>/release-manifest.json\`.
  No "latest" — tag is effectively required.
- \`sources\`, \`tiers\`, \`categories\`, \`rowmap\`, \`materials\`,
  \`channels\`, \`index\`, \`rowmap_entry\`, \`fetch_texture\`,
  \`_fetch_mtlx_original_map\` rewritten against the v2 shape
  (\`manifest.sources[src].tiers[tier]{tar,rowmap}\`, one rowmap per
  source×tier).
- \`fetch_texture\` range-reads the tar directly — no parquet layer.
- \`categories()\` derives from per-source catalogs (no more category-
  tagged filenames since ADR-0007 dropped per-category partitioning).

## Live proof (real HF)

Target: \`gerchowl/mat-vis@v2026.04.1-rc1\` (Phase 3a scoped bake).

\`\`\`python
>>> c = MatVisClient(tag='v2026.04.1-rc1')
>>> c.sources('1k')
['polyhaven']
>>> data = c.fetch_texture('polyhaven', 'aerial_asphalt_01', 'color', '1k')
>>> data[:4] == b'\x89PNG'
True
>>> len(data)
2337475
\`\`\`

All 10 live tests pass against this revision.

## Test plan

- [x] \`pytest clients/python/test_client.py\` (mocked) — 78 pass / 11 skip.
- [x] \`pytest -k Live\` against real HF — 10 pass.
- [x] Full suite: \`pytest tests/ clients/python/test_client.py\` —
      236 passed / 11 skipped.
- [x] Standalone drift test green (symbol inventory unchanged).
- [ ] CI green.

## Follow-up

- **3c** — delete \`parquet_writer.py\` + \`upload.py\`; refactor
  \`ktx2.py\` + \`derive_from_release.py\` onto \`TarWriter\`.
- **3d** — delete four obsolete workflows; rewrite \`bake.yml\` to
  call \`hf-bake\`.
- **3e** — full \`v2026.04.1\` bake across every (source, tier) in CI.

Refs #100, #104