### PR TITLE
chore(ci): calver SSoT — drop hardcoded release-tag defaults (#109)

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -968,7 +968,7 @@ class MatVisCi:
     async def regenerate_rowmaps(
         self,
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
-        release_tag: Annotated[str, Doc("Release tag")] = "v2026.04.0",
+        release_tag: Annotated[str, Doc("Release tag")] = "v0000.00.0",
         registry_pass: Annotated[dagger.Secret | None, Doc("GH token")] = None,
     ) -> str:
         """Regenerate all rowmap JSONs for a release using the legacy scanner.
@@ -1048,7 +1048,7 @@ class MatVisCi:
     async def rebuild_manifest(
         self,
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
-        release_tag: Annotated[str, Doc("Release tag")] = "v2026.04.0",
+        release_tag: Annotated[str, Doc("Release tag")] = "v0000.00.0",
         registry_pass: Annotated[dagger.Secret | None, Doc("GH token")] = None,
     ) -> str:
         """Rebuild manifest only (no rowmap regeneration). Fast — just re-reads

--- a/.github/workflows/rebuild-manifest.yml
+++ b/.github/workflows/rebuild-manifest.yml
@@ -7,7 +7,7 @@ on:  # yamllint disable-line rule:truthy
       release-tag:
         description: 'Release tag'
         required: true
-        default: 'v2026.04.0'
+        default: 'v0000.00.0'
         type: string
 
 permissions:

--- a/.github/workflows/regenerate-rowmaps.yml
+++ b/.github/workflows/regenerate-rowmaps.yml
@@ -7,7 +7,7 @@ on:  # yamllint disable-line rule:truthy
       release-tag:
         description: 'Release tag to regenerate rowmaps for'
         required: true
-        default: 'v2026.04.0'
+        default: 'v0000.00.0'
         type: string
 
 permissions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,13 @@ repos:
         files: ^\.dagger/src/.*\.py$
         pass_filenames: false
 
+      - id: check-calver-defaults
+        name: no hardcoded calver defaults in source (#109)
+        entry: python3 scripts/check-calver-defaults.py
+        language: system
+        files: ^(src/|scripts/|\.dagger/src/|\.github/workflows/)
+        pass_filenames: false
+
       - id: sync-spec
         name: sync docs/specs to baker's packaged _spec dir
         entry: python3 scripts/sync-spec.py

--- a/clients/python/test_client.py
+++ b/clients/python/test_client.py
@@ -1208,7 +1208,7 @@ live = pytest.mark.skipif(
 )
 
 
-LIVE_TAG = "v2026.04.1-rc1"
+LIVE_TAG = "v2026.04.1"
 LIVE_SOURCE = "polyhaven"
 LIVE_TIER = "1k"
 
@@ -1291,7 +1291,7 @@ class TestLiveFetchTexture:
 def test_proof_phase_2_fetch_physicallybased_index_from_hf():
     """Scalar catalog for physicallybased is fetchable from HF substrate."""
     with tempfile.TemporaryDirectory() as tmp:
-        client = MatVisClient(tag="v2026.04.1-rc1", cache_dir=Path(tmp))
+        client = MatVisClient(tag="v2026.04.1", cache_dir=Path(tmp))
         idx = client.index("physicallybased")
     assert len(idx) >= 50, f"expected ≥50 PB entries, got {len(idx)}"
     assert all("id" in e and "source" in e for e in idx)

--- a/scripts/check-calver-defaults.py
+++ b/scripts/check-calver-defaults.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Block hardcoded calver defaults in source (issue #109).
+
+The only legitimate place for a calver default is a workflow input on
+`bake.yml` / `derive-ktx2.yml` — the string a human bumps per release.
+Argparse defaults, module constants, and dataclass defaults that stamp
+a calver into source will silently re-ship last month's tag the next
+time somebody forgets the `--release-tag` flag.
+
+Python files are parsed with ``ast`` so docstrings and comments are
+not scanned (documentation is not SSoT). YAML / TOML / workflow files
+fall back to line-based regex.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+SCAN_DIRS = ("src", "scripts", ".dagger/src")
+
+# Workflows where an input default is the one legitimate place for a
+# calver string. Everything else under .github/workflows/ is scanned.
+WORKFLOW_DEFAULT_ALLOWED = {
+    Path(".github/workflows/bake.yml"),
+    Path(".github/workflows/derive-ktx2.yml"),
+}
+
+CALVER_RE = re.compile(r"v20\d{2}\.\d{2}\.\d+(-[A-Za-z0-9.]+)?")
+
+
+def _is_calver(value: object) -> bool:
+    return isinstance(value, str) and CALVER_RE.fullmatch(value) is not None
+
+
+def _python_hits(path: Path) -> list[tuple[int, str]]:
+    """Use AST so docstrings/comments are ignored — only real code counts."""
+    hits: list[tuple[int, str]] = []
+    try:
+        tree = ast.parse(path.read_text())
+    except SyntaxError:
+        return hits
+
+    lines = path.read_text().splitlines()
+
+    def _hit(lineno: int, note: str) -> None:
+        line = lines[lineno - 1].rstrip() if 1 <= lineno <= len(lines) else ""
+        hits.append((lineno, f"{note}: {line}"))
+
+    for node in ast.walk(tree):
+        # `release_tag = "v2026..."` or `release_tag: str = "v2026..."`
+        if isinstance(node, ast.Assign):
+            if not any(
+                isinstance(t, ast.Name) and "release_tag" in t.id.lower() for t in node.targets
+            ):
+                continue
+            if isinstance(node.value, ast.Constant) and _is_calver(node.value.value):
+                _hit(node.lineno, "release_tag = <calver>")
+        elif isinstance(node, ast.AnnAssign):
+            if not (isinstance(node.target, ast.Name) and "release_tag" in node.target.id.lower()):
+                continue
+            if node.value and isinstance(node.value, ast.Constant) and _is_calver(node.value.value):
+                _hit(node.lineno, "release_tag: ... = <calver>")
+        # Function signature defaults for params named `release_tag`
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            args = node.args
+            defaults = list(args.defaults)
+            positional = args.args[-len(defaults) :] if defaults else []
+            for arg, default in zip(positional, defaults):
+                if (
+                    "release_tag" in arg.arg.lower()
+                    and isinstance(default, ast.Constant)
+                    and _is_calver(default.value)
+                ):
+                    _hit(default.lineno, f"default {arg.arg}=<calver>")
+            kw_only = args.kwonlyargs
+            kw_defaults = args.kw_defaults
+            for arg, default in zip(kw_only, kw_defaults):
+                if (
+                    "release_tag" in arg.arg.lower()
+                    and isinstance(default, ast.Constant)
+                    and _is_calver(default.value)
+                ):
+                    _hit(default.lineno, f"kw default {arg.arg}=<calver>")
+        # argparse add_argument('--release-tag', default='v...')
+        elif isinstance(node, ast.Call):
+            func_name = ""
+            if isinstance(node.func, ast.Attribute):
+                func_name = node.func.attr
+            elif isinstance(node.func, ast.Name):
+                func_name = node.func.id
+            if func_name != "add_argument":
+                continue
+            positional_targets = " ".join(
+                a.value
+                for a in node.args
+                if isinstance(a, ast.Constant) and isinstance(a.value, str)
+            )
+            if "release" not in positional_targets.lower():
+                continue
+            for kw in node.keywords:
+                if (
+                    kw.arg == "default"
+                    and isinstance(kw.value, ast.Constant)
+                    and _is_calver(kw.value.value)
+                ):
+                    _hit(kw.value.lineno, "add_argument(default=<calver>)")
+
+    return hits
+
+
+def _yaml_hits(path: Path) -> list[tuple[int, str]]:
+    """Line-based for YAML: flag `default: v...` where a calver appears."""
+    hits: list[tuple[int, str]] = []
+    try:
+        text = path.read_text()
+    except (OSError, UnicodeDecodeError):
+        return hits
+    for lineno, line in enumerate(text.splitlines(), 1):
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        if "default" not in stripped:
+            continue
+        if CALVER_RE.search(stripped):
+            hits.append((lineno, f"yaml default: {line.rstrip()}"))
+    return hits
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for sub in SCAN_DIRS:
+        base = REPO / sub
+        if not base.exists():
+            continue
+        for path in base.rglob("*.py"):
+            for lineno, note in _python_hits(path):
+                failures.append(f"{path.relative_to(REPO)}:{lineno}: {note}")
+
+    wf_dir = REPO / ".github" / "workflows"
+    if wf_dir.exists():
+        for path in wf_dir.glob("*.yml"):
+            rel = path.relative_to(REPO)
+            if rel in WORKFLOW_DEFAULT_ALLOWED:
+                continue
+            for lineno, note in _yaml_hits(path):
+                failures.append(f"{rel}:{lineno}: {note}")
+
+    if failures:
+        sys.stderr.write(
+            "hardcoded calver default detected — use a required "
+            "--release-tag arg instead. See issue #109 for context.\n\n"
+        )
+        for f in failures:
+            sys.stderr.write(f"  {f}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Fix #109. Adds a pre-commit + CI guard that blocks hardcoded calver
defaults in source so stale defaults can't silently re-ship last
month's tag the next time someone forgets \`--release-tag\`.

## Changes

- \`scripts/check-calver-defaults.py\` — AST-based scanner for Python
  (skips docstrings/comments); regex for YAML. Flags
  \`release_tag = "v20…"\`, function-signature defaults whose param
  name contains \`release_tag\`, and \`add_argument(..., default="v20…")\`.
- Pre-commit hook \`check-calver-defaults\` (local) — runs on every
  commit touching \`src/\`, \`scripts/\`, \`.dagger/src/\`, or
  \`.github/workflows/\`. Two legitimate input-default files
  (\`bake.yml\`, \`derive-ktx2.yml\`) are allow-listed — those are
  the one place a human is expected to bump.
- Fixed existing violations:
  - \`bake.yml\` + \`derive-ktx2.yml\` input defaults: \`v2026.04.0\`
    → \`v2026.04.1\` (next release per #100).
  - \`rebuild-manifest.yml\` + \`regenerate-rowmaps.yml\` defaults →
    \`v0000.00.0\` sentinel. (These workflows are retired by ADR-0007
    and scheduled for deletion in Phase 3d of #104; the sentinel
    makes them hook-clean in the meantime.)
  - \`.dagger\` functions \`regenerate_rowmaps\` + \`rebuild_manifest\`
    — same sentinel swap for parity.

## Test plan

- [x] \`python scripts/check-calver-defaults.py\` on current tree → exit 0.
- [x] Added a bogus \`default="v2026.04.1"\` to a source file
      temporarily and confirmed the hook fails with a pointer to #109.
- [x] Full suite: 236 passed / 11 skipped.
- [ ] CI green.

Closes #109
Refs #100, #104