### PR TITLE
ci: derive.yml — resize + KTX2 workflows (#112)

### DIFF
--- a/.github/workflows/derive.yml
+++ b/.github/workflows/derive.yml
@@ -1,0 +1,122 @@
+---
+# Derive workflow — resize a smaller PNG tier or KTX2-transcode an
+# existing PNG tar on HF. Atomic-commits via hf-derive / hf-derive-ktx2.
+
+name: Derive
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+    inputs:
+      kind:
+        description: 'Derivation kind'
+        required: true
+        default: 'resize'
+        type: choice
+        options:
+          - resize
+          - ktx2
+      source:
+        description: 'Source (upstream)'
+        required: true
+        default: 'polyhaven'
+        type: choice
+        options:
+          - ambientcg
+          - polyhaven
+          - gpuopen
+      source-tier:
+        description: 'Source tier to derive from (existing PNG tar on HF)'
+        required: true
+        default: '1k'
+        type: choice
+        options:
+          - 128
+          - 256
+          - 512
+          - 1k
+          - 2k
+          - 4k
+          - 8k
+      target-tier:
+        description: 'Target tier (resize only; e.g. 512). Ignored for ktx2.'
+        required: false
+        default: '512'
+        type: string
+      release-tag:
+        description: 'Calver data release tag (e.g. v2026.04.1)'
+        required: true
+        default: 'v2026.04.1'
+        type: string
+      repo-id:
+        description: 'HF dataset repo'
+        required: false
+        default: 'gerchowl/mat-vis'
+        type: string
+
+permissions:
+  contents: read
+  issues: write          # needed by notify-on-failure composite action
+
+jobs:
+  derive:
+    name: >-
+      ${{ inputs.kind }}
+      ${{ inputs.source }}
+      ${{ inputs.source-tier }}
+      → ${{ inputs.kind == 'resize' && inputs.target-tier || format('ktx2-{0}', inputs.source-tier) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    env:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install KTX-Software (toktx)
+        if: inputs.kind == 'ktx2'
+        run: |
+          set -euxo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq libgomp1 ca-certificates
+          curl -fsSL -o /tmp/ktx.deb \
+            https://github.com/KhronosGroup/KTX-Software/releases/download/v4.4.0/KTX-Software-4.4.0-Linux-x86_64.deb
+          sudo dpkg -i /tmp/ktx.deb
+          toktx --version
+
+      - name: Install baker
+        run: uv sync --all-extras
+
+      - name: Derive
+        run: |
+          set -euxo pipefail
+          if [ "${{ inputs.kind }}" = "resize" ]; then
+            uv run mat-vis-baker hf-derive \
+              "${{ inputs.source }}" \
+              "${{ inputs.target-tier }}" \
+              /tmp/derive \
+              --source-tier "${{ inputs.source-tier }}" \
+              --release-tag "${{ inputs.release-tag }}" \
+              --repo-id "${{ inputs.repo-id }}"
+          else
+            uv run mat-vis-baker hf-derive-ktx2 \
+              "${{ inputs.source }}" \
+              /tmp/derive \
+              --source-tier "${{ inputs.source-tier }}" \
+              --release-tag "${{ inputs.release-tag }}" \
+              --repo-id "${{ inputs.repo-id }}"
+          fi
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-on-failure
+        with:
+          label-prefix: "[derive-failed]"
+          workflow-name: "derive"
+          target: "${{ inputs.kind }} ${{ inputs.source }}/${{ inputs.source-tier }} @ ${{ inputs.release-tag }}"
+          context: >-
+            Atomic HF commits mean a failed derive leaves the target
+            revision unchanged — safe to retry. Check the derive step
+            logs for the specific channel that errored.

--- a/scripts/check-calver-defaults.py
+++ b/scripts/check-calver-defaults.py
@@ -27,7 +27,7 @@ SCAN_DIRS = ("src", "scripts", ".dagger/src")
 # calver string. Everything else under .github/workflows/ is scanned.
 WORKFLOW_DEFAULT_ALLOWED = {
     Path(".github/workflows/bake.yml"),
-    Path(".github/workflows/derive-ktx2.yml"),
+    Path(".github/workflows/derive.yml"),
 }
 
 CALVER_RE = re.compile(r"v20\d{2}\.\d{2}\.\d+(-[A-Za-z0-9.]+)?")


### PR DESCRIPTION
## Summary

Wires \`hf-derive\` and \`hf-derive-ktx2\` (landed in #118) into a
workflow_dispatch-triggered GH Actions job, so we can fire derived
tiers at \`v2026.04.1\` before re-tagging.

- \`kind=resize\`: calls \`mat-vis-baker hf-derive\`; requires
  \`source-tier\` + \`target-tier\`.
- \`kind=ktx2\`: calls \`mat-vis-baker hf-derive-ktx2\`; installs
  KTX-Software v4.4.0 (\`toktx\`) via the upstream .deb first.
- Atomic HF commits mean a failed derive leaves the revision
  unchanged — safe to retry.

Smoke-tested live on \`gerchowl/mat-vis-tst@v0.0.1-smoke\`: both
paths committed; client fetches the derived bytes (the ktx2 magic
fix in #119 is what closes this loop).

Allow-list update: \`derive.yml\` replaces the deleted
\`derive-ktx2.yml\` entry in \`scripts/check-calver-defaults.py\`
(issue #109).

## Test plan

- [x] Local live smoke (see #119 PR body).
- [ ] CI green.
- After merge: fire 15 workflow runs (3 sources × {128, 256, 512,
  ktx2-1k, ktx2-2k}) at \`v2026.04.1\`, verify via
  \`proof_hf_fetch.py\`, then tag.

Refs #104, #112