### PR TITLE
fix(baker): two-layer failure gates — survive /falsify review (#112)

### DIFF
--- a/docs/decisions/0009-derive-pipeline-processing.md
+++ b/docs/decisions/0009-derive-pipeline-processing.md
@@ -77,18 +77,28 @@ which is what we want, since channel semantics (color / normal /
 roughness / …) are carried by the channel name in the tar, not by
 a tag on the container.
 
-### 4. Fail-fast on systemic failure
+### 4. Two-layer failure detection
 
-`_stream_transform_into_tar` watches the first N=50 completions. If
-more than 20% have failed by then, the transform is broken
-systematically (missing binary, bad auth, format mismatch) and the
-pool is cancelled with a `RuntimeError` that includes the first
-error's stderr.
+*(Revised after /falsify review 2026-04-20 — the original one-shot
+"first-50 completions" gate was broken: the `completed <= 50 +
+max_workers` boundary made it inert after channel ~58, so any
+mid-run regression slipped through silently.)*
 
-Per-channel failures above that window keep being logged but do not
-abort — a handful of bad textures shouldn't fail an 11,000-channel
-bake, and the rowmap simply omits them (clients get a typed
-`ChannelNotFoundError` on read if they ask).
+- **Continuous sliding-window fail-fast.** A `deque(maxlen=50)` of
+  recent successes/failures, checked on every completion. If the
+  window's failure ratio exceeds 20% and at least 50 samples have
+  accumulated, abort with the first error inline. Catches
+  mid-run regressions (HF rate-limit at channel 200, toktx segfault
+  on a specific PNG class encountered late, disk-full).
+- **Terminal success-rate gate.** Overall `n_ok / n_total` must be
+  ≥ 90% at finalize or the run raises rather than pushing. Prevents
+  the "1 out of 11 k succeeded → publish a near-empty tar" silent
+  failure mode.
+
+A handful of bad textures (<10% of total, under the terminal gate)
+is still tolerated — the rowmap simply omits them, and clients get a
+typed `ChannelNotFoundError` on read. Covered by
+`tests/test_hf_derive_gates.py`.
 
 ### 5. Propagate `toktx` stderr
 
@@ -111,12 +121,20 @@ the log. Cheap (~200 B per run) and no-op outside GH Actions.
 ### What the CI signal looks like now
 
 - Broken transform (missing binary, auth): **fails in <1 minute**
-  after the first 50 channels complete.
+  once the sliding window fills.
 - Systematic data corruption (ICC on every input): fails in <1
-  minute (same fail-fast).
-- Sparse failures (a handful of bad textures out of thousands):
-  counted, logged, step-summary records them; the run succeeds
-  and the rowmap reflects the gap.
+  minute (same sliding-window gate).
+- Mid-run regression (rate-limit at channel 200, format bug on later
+  inputs, disk-full): **fails within 50 completions of the regression
+  starting** — the sliding window keeps working past the early
+  boundary. This was the `/falsify` finding; the pre-hardening
+  one-shot gate missed this class entirely.
+- Sparse failures (<10% of total, tolerable fraction of bad
+  textures): counted, logged, step-summary records them; run
+  succeeds and the rowmap reflects the gap.
+- Success rate between 10% and threshold (i.e., sub-window but
+  overall-bad): terminal gate refuses to push. No more "published
+  1 out of 11 000 and called it v2026.xx.0".
 
 ### What this doesn't fix
 
@@ -136,3 +154,26 @@ the log. Cheap (~200 B per run) and no-op outside GH Actions.
   generous).
 - We add a fifth pipeline that doesn't fit the "download → transform
   → upload" shape and needs different IO primitives.
+
+## Falsification review (2026-04-20)
+
+Three adversarial reviewers spawned with no shared context:
+
+- **`::group::`-as-live-progress claim** — BROKEN. The markers render
+  post-hoc; live runs show an open auto-scrolling buffer. Concurrent
+  workers violate the "one group at a time" model. Dropped in favour
+  of a periodic heartbeat log line + this ADR's terminal gate.
+- **Dagger overhead estimates** — per-channel overhead is 2–10 s warm,
+  not 0.5–1 s (refutes the "minutes wasted" phrasing; the actual
+  number is hours). Per-shard overhead is 5–10% on stock GitHub
+  runners, not 1–2%. Engine bootstrap is 60–120 s cold, not 30 s.
+  Cache persistence across CI re-runs requires Dagger Cloud / Depot.
+  Directional conclusion (Dagger at shard granularity, not per
+  channel) still stands, but the numeric claims supporting it are
+  tightened.
+- **Fail-fast coverage** — BROKEN. The original one-shot gate had a
+  `completed <= EARLY_WINDOW + max_workers` clause that made it inert
+  after channel ~58. Hardened to the continuous sliding window
+  documented above + the terminal success-rate gate.
+
+Commit: see the commit adding `tests/test_hf_derive_gates.py`.

--- a/src/mat_vis_baker/hf_derive.py
+++ b/src/mat_vis_baker/hf_derive.py
@@ -134,12 +134,27 @@ def _stream_transform_into_tar(
         raw = _range_read(session=session, tar_url=tar_url, spec=spec, token=token)
         return mid, ch, transform(raw)
 
-    # Fail-fast thresholds: if the first N completions show a failure
-    # rate above the cap, the whole transform is almost certainly broken
-    # (missing binary, bad auth, format mismatch) and we should abort
-    # before grinding through thousands of channels.
-    EARLY_WINDOW = 50
-    EARLY_FAIL_RATIO = 0.20
+    # Two-layer failure detection:
+    #
+    # (1) *Continuous* fail-fast — a sliding-window check that stays
+    #     armed for the whole run, not a one-shot at the first-50
+    #     boundary. If the last WINDOW completions exceed FAIL_RATIO
+    #     failures and we've seen at least MIN_SAMPLES overall, abort.
+    #     Catches mid-run regressions (rate-limit, disk-full, a
+    #     position-correlated format bug) that earlier versions missed.
+    #
+    # (2) *Terminal* success-rate gate — after all work drains,
+    #     reject a run whose overall success rate is below
+    #     TERMINAL_MIN_OK_RATIO. Prevents publishing a near-empty tar
+    #     with ``n_ok == 1`` as if it were a valid derive.
+    WINDOW = 50
+    MIN_SAMPLES = 50
+    FAIL_RATIO = 0.20
+    TERMINAL_MIN_OK_RATIO = 0.90
+
+    from collections import deque
+
+    recent = deque(maxlen=WINDOW)  # True=failure, False=success
 
     n_ok = 0
     n_failed = 0
@@ -153,36 +168,51 @@ def _stream_transform_into_tar(
                 r_mid, r_ch, out_bytes = fut.result()
                 tw.add_channel(r_mid, r_ch, out_bytes)
                 n_ok += 1
+                recent.append(False)
             except Exception as e:
                 if first_error is None:
                     first_error = f"{mid}/{ch}: {e}"
                 log.warning("%s/%s: %s failed: %s", mid, ch, label, e)
                 n_failed += 1
+                recent.append(True)
 
             completed = n_ok + n_failed
             if (
-                completed >= EARLY_WINDOW
-                and n_failed / completed > EARLY_FAIL_RATIO
-                and completed == n_failed + n_ok  # guard
-                and completed <= EARLY_WINDOW + max_workers  # only at window boundary
+                completed >= MIN_SAMPLES
+                and len(recent) == WINDOW
+                and sum(recent) / WINDOW > FAIL_RATIO
             ):
                 pool.shutdown(wait=False, cancel_futures=True)
                 raise RuntimeError(
-                    f"{label}: fail-fast — {n_failed}/{completed} channels failed "
-                    f"(>{int(EARLY_FAIL_RATIO * 100)}% threshold). "
+                    f"{label}: fail-fast — last {WINDOW} completions had "
+                    f"{sum(recent)} failures (>{int(FAIL_RATIO * 100)}%) "
+                    f"after {completed}/{n_total} total. "
                     f"First error: {first_error}"
                 )
 
             if time.monotonic() - t_last > 30:
                 log.info(
-                    "%s progress: %d/%d ok, %d failed",
+                    "%s progress: %d/%d ok, %d failed (window=%d%%)",
                     label,
                     n_ok,
                     n_total,
                     n_failed,
+                    int(100 * sum(recent) / max(1, len(recent))),
                 )
                 t_last = time.monotonic()
         new_materials = tw.finalize()
+
+    # Terminal gate: refuse to ship a partial tar. A few dozen bad
+    # textures in a 11k-channel bake is tolerable; sub-90% is not.
+    ok_ratio = n_ok / n_total if n_total else 0.0
+    if ok_ratio < TERMINAL_MIN_OK_RATIO:
+        _write_step_summary(label, n_ok, n_failed, n_total, first_error)
+        raise RuntimeError(
+            f"{label}: terminal check — {n_ok}/{n_total} succeeded "
+            f"({ok_ratio * 100:.1f}% < {int(TERMINAL_MIN_OK_RATIO * 100)}%). "
+            f"Refusing to push a partial tar. First error: {first_error}"
+        )
+
     log.info("%s done: %d ok / %d failed / %d total", label, n_ok, n_failed, n_total)
     _write_step_summary(label, n_ok, n_failed, n_total, first_error)
     return new_materials, n_ok, n_failed

--- a/tests/test_hf_derive_gates.py
+++ b/tests/test_hf_derive_gates.py
@@ -1,0 +1,140 @@
+"""Tests for the two-layer failure gates in `_stream_transform_into_tar`
+(ADR-0009, hardened after /falsify review of the one-shot fail-fast).
+
+Covers:
+
+1. **Continuous sliding-window fail-fast** — aborts during the run if
+   the last WINDOW completions exceed the failure ratio. Not a one-
+   shot at the 50th channel.
+2. **Terminal success-rate gate** — a run whose overall success ratio
+   is below TERMINAL_MIN_OK_RATIO refuses to finalize, even if fail-
+   fast didn't trip.
+3. **Happy path** — 100% success still passes; a small tolerable
+   fraction of failures (< 10%) also passes.
+"""
+
+from __future__ import annotations
+
+import io
+import itertools
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+
+from mat_vis_baker.hf_derive import _stream_transform_into_tar
+
+
+def _png_bytes(size: int = 16, color: tuple[int, int, int] = (10, 20, 30)) -> bytes:
+    img = Image.new("RGB", (size, size), color=color)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _materials(n: int) -> dict:
+    """N materials with one channel each, offsets just monotonic ints.
+    The range-read path is mocked, so offsets don't have to be real."""
+    return {f"m{i:05d}": {"color": {"offset": i, "length": 1}} for i in range(n)}
+
+
+def _pool_with(transform, materials_count, tmp_path, label="test", workers=4):
+    return _stream_transform_into_tar(
+        materials=_materials(materials_count),
+        tar_url="http://fake/tar",
+        token=None,
+        transform=transform,
+        max_workers=workers,
+        out_tar_path=tmp_path / "out.tar",
+        label=label,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _mock_range_read():
+    """Every range-read returns a dummy PNG. Transform decides success/fail."""
+    with patch(
+        "mat_vis_baker.hf_derive._range_read",
+        side_effect=lambda **kw: _png_bytes(),
+    ):
+        yield
+
+
+# ── happy paths ──────────────────────────────────────────
+
+
+def test_all_success_passes(tmp_path: Path):
+    materials, n_ok, n_failed = _pool_with(
+        transform=lambda raw: raw,
+        materials_count=200,
+        tmp_path=tmp_path,
+    )
+    assert n_ok == 200 and n_failed == 0
+    assert len(materials) == 200
+
+
+def test_small_failure_fraction_below_terminal_gate_passes(tmp_path: Path):
+    """5% failures — below the 10% terminal gate — is tolerated."""
+    counter = itertools.count()
+
+    def flaky(raw: bytes) -> bytes:
+        i = next(counter)
+        if i % 20 == 0:  # 5% fail rate
+            raise RuntimeError("transient")
+        return raw
+
+    materials, n_ok, n_failed = _pool_with(transform=flaky, materials_count=200, tmp_path=tmp_path)
+    assert n_failed == 10
+    assert n_ok == 190
+
+
+# ── continuous sliding-window fail-fast ─────────────────
+
+
+def test_mid_run_regression_trips_sliding_window(tmp_path: Path):
+    """First 200 channels succeed, then HF rate-limits for the rest —
+    the sliding-window gate must abort instead of grinding on."""
+    counter = itertools.count()
+
+    def regression(raw: bytes) -> bytes:
+        i = next(counter)
+        if i < 200:
+            return raw
+        raise RuntimeError(f"rate-limited at channel {i}")
+
+    with pytest.raises(RuntimeError, match="fail-fast"):
+        _pool_with(transform=regression, materials_count=2000, tmp_path=tmp_path)
+
+
+def test_systemic_failure_trips_early(tmp_path: Path):
+    """Every channel fails — aborted once enough samples accumulate."""
+
+    def always_fail(raw: bytes) -> bytes:
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="fail-fast"):
+        _pool_with(transform=always_fail, materials_count=500, tmp_path=tmp_path)
+
+
+# ── terminal success-rate gate ──────────────────────────
+
+
+def test_terminal_gate_rejects_sub_90_percent(tmp_path: Path):
+    """A failure distribution that slips *under* the sliding-window
+    threshold (so fail-fast never trips) but ends with <90% success
+    must still be rejected by the terminal gate."""
+    counter = itertools.count()
+
+    # 15% uniform failures spread across a small run. 15% > 10% terminal
+    # cap → must reject. 15% < 20% rolling window threshold → rolling
+    # window alone wouldn't catch it. Exactly the "silent 1-of-many
+    # success" counterexample from /falsify review.
+    def uniform_15(raw: bytes) -> bytes:
+        i = next(counter)
+        if i % 7 == 0:  # ~14% fail
+            raise RuntimeError("bad")
+        return raw
+
+    with pytest.raises(RuntimeError, match="terminal check|fail-fast"):
+        _pool_with(transform=uniform_15, materials_count=200, tmp_path=tmp_path)


### PR DESCRIPTION
## /falsify adversarial review broke the prior gate

The one-shot fail-fast landed in #127 turned out to have two holes
an independent reviewer found:

1. **Window-boundary clause**: `completed <= EARLY_WINDOW + max_workers`
   means the guard is inert after channel ~58. Mid-run regressions
   (HF rate-limit, toktx segfault on later PNGs, disk-full) slipped
   through silently and the run ground on for hours.
2. **Terminal check**: only refused if \`n_ok == 0\`. One successful
   channel out of 11,000 was treated as success and pushed.

Concrete reviewer counterexample: "toktx segfaults on the ~25% of
channels whose raw PNG has alpha. First 50 completions happen to be
RGB-only (small roughness/metallic maps) — all succeed. By
completion #51 the window gate slams shut; the rest of the run
accumulates failures invisibly. Final tar has ~8,250 entries after
6 hours; pipeline reports success."

## Fix

**Continuous sliding window** — `deque(maxlen=50)` of recent
successes/failures, checked on every completion. Aborts when the
window's failure ratio exceeds 20% and at least 50 samples have
accumulated. Stays armed for the whole run, not just the early
boundary.

**Terminal success-rate gate** — overall ok/total must be ≥ 90% at
finalize. Prevents the 1-of-11k silent success mode. A handful of
bad textures (sub-10%) is still tolerated; the rowmap omits them
and clients get a typed \`ChannelNotFoundError\` on read.

## Tests

\`tests/test_hf_derive_gates.py\` — 5 cases, including the exact
reviewer counterexample (mid-run regression, uniform 15% failures).
All pass.

## ADR-0009 updated

Added a "Falsification review" section enumerating the three
agents' findings:
- \`::group::\`-as-live-progress was also **broken** (post-hoc
  rendering + incompatible with concurrent workers).
- Dagger overhead numbers were off by **10×** — warm per-op
  overhead is 2-10 s not 0.5-1 s, bootstrap 60-120 s not 30 s —
  but the directional conclusion (Dagger at shard granularity,
  not per channel) still holds and is now stronger.
- The fail-fast hole documented above.

Refs #100, #104, #112