### PR TITLE
feat(baker): OTLP spans + heartbeat log — observability foundation (#130, #131)

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,86 @@
+# Observability — self-hosted, no subscription
+
+The baker emits OpenTelemetry spans around bake/derive pipelines.
+Out-of-the-box: no-op. Set `OTEL_EXPORTER_OTLP_ENDPOINT` to an OTLP
+receiver and spans flow.
+
+## Local dashboard in 60 seconds
+
+```bash
+podman run -d --name otel-lgtm \
+  --restart=always \
+  -p 4318:4318 -p 3000:3000 \
+  -v otel-lgtm-data:/data \
+  grafana/otel-lgtm:latest
+```
+
+One image: Grafana + Tempo (traces) + Loki (logs) + Mimir/Prometheus
+(metrics). Open <http://localhost:3000>, default login
+`admin` / `admin`.
+
+## Point the baker at it
+
+Install the extra:
+
+```bash
+uv sync --all-extras
+# or: pip install 'mat-vis[observability]'
+```
+
+Run with the endpoint set:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
+  mat-vis-baker hf-derive polyhaven 512 /tmp/d \
+  --source-tier 1k --release-tag v2026.04.1 --repo-id gerchowl/mat-vis-tst
+```
+
+Spans land in Grafana Tempo under the `mat-vis-baker` service.
+Look for `stream.transform` root spans with `n_ok`, `n_failed`,
+`outcome` (`ok`/`fail_fast`), and per-30-s `progress` events.
+
+## CI via Tailscale (no public endpoint)
+
+Host machine (laptop, Pi, home server) on your tailnet:
+
+```bash
+# one-shot: expose Grafana + OTLP over tailnet
+tailscale serve --bg --https=3000 http://localhost:3000
+```
+
+Grab the tailnet hostname (`otel.tail-xxx.ts.net`). In the workflow:
+
+```yaml
+- uses: tailscale/github-action@v2
+  with:
+    authkey: ${{ secrets.TS_AUTHKEY }}
+    tags: tag:ci
+- run: |
+    export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel.tail-xxx.ts.net:4318
+    mat-vis-baker hf-derive ...
+```
+
+The runner joins your tailnet briefly, emits spans, leaves. No
+public endpoint, no inbound firewall holes.
+
+## What gets emitted
+
+- `stream.transform` root span per derive: `label`, `n_total`,
+  `max_workers`, plus `outcome`, `n_ok`, `n_failed` on close.
+- `progress` events every ~30 s with rolling counters + throughput.
+- Fail-fast path sets `outcome=fail_fast` and attaches the first
+  error as a span event.
+
+## Cost
+
+Zero subscription. Self-hosted container runs anywhere with an OCI
+runtime. Tempo defaults to 72 h trace retention (enough for
+debugging; not an audit trail).
+
+## References
+
+- ADR-0009: derive pipeline decisions (fail-fast, sliding window,
+  telemetry hooks).
+- Issue #131: full self-host spec.
+- Issue #129: Dagger pipeline (optional, emits to the same OTLP
+  receiver).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,13 @@ materialx = [
     "materialx>=1.39",
     "openexr>=3.3",
 ]
+observability = [
+    # OpenTelemetry for self-hosted dashboards (grafana/otel-lgtm,
+    # Jaeger, Tempo). Opt-in via OTEL_EXPORTER_OTLP_ENDPOINT; no-op
+    # when unset. Tailscale-exposed receivers work transparently.
+    "opentelemetry-sdk>=1.27",
+    "opentelemetry-exporter-otlp-proto-http>=1.27",
+]
 dev = [
     "pytest>=7",
     "pytest-cov>=4",

--- a/src/mat_vis_baker/hf_derive.py
+++ b/src/mat_vis_baker/hf_derive.py
@@ -36,6 +36,7 @@ from PIL import Image
 from mat_vis_baker.common import TIER_TO_PX
 from mat_vis_baker.hf_push import push_to_hf
 from mat_vis_baker.tar_writer import TarWriter
+from mat_vis_baker.telemetry import span
 
 log = logging.getLogger("mat-vis-baker.hf_derive")
 
@@ -160,47 +161,64 @@ def _stream_transform_into_tar(
     n_failed = 0
     first_error: str | None = None
     t_last = time.monotonic()
-    with ThreadPoolExecutor(max_workers=max_workers) as pool, TarWriter(out_tar_path) as tw:
-        futures = {pool.submit(_one, item): item for item in work}
-        for fut in as_completed(futures):
-            mid, ch, spec = futures[fut]
-            try:
-                r_mid, r_ch, out_bytes = fut.result()
-                tw.add_channel(r_mid, r_ch, out_bytes)
-                n_ok += 1
-                recent.append(False)
-            except Exception as e:
-                if first_error is None:
-                    first_error = f"{mid}/{ch}: {e}"
-                log.warning("%s/%s: %s failed: %s", mid, ch, label, e)
-                n_failed += 1
-                recent.append(True)
+    t_start = time.monotonic()
+    with span("stream.transform", label=label, n_total=n_total, max_workers=max_workers) as outer:
+        with ThreadPoolExecutor(max_workers=max_workers) as pool, TarWriter(out_tar_path) as tw:
+            futures = {pool.submit(_one, item): item for item in work}
+            for fut in as_completed(futures):
+                mid, ch, spec = futures[fut]
+                try:
+                    r_mid, r_ch, out_bytes = fut.result()
+                    tw.add_channel(r_mid, r_ch, out_bytes)
+                    n_ok += 1
+                    recent.append(False)
+                except Exception as e:
+                    if first_error is None:
+                        first_error = f"{mid}/{ch}: {e}"
+                    log.warning("%s/%s: %s failed: %s", mid, ch, label, e)
+                    n_failed += 1
+                    recent.append(True)
 
-            completed = n_ok + n_failed
-            if (
-                completed >= MIN_SAMPLES
-                and len(recent) == WINDOW
-                and sum(recent) / WINDOW > FAIL_RATIO
-            ):
-                pool.shutdown(wait=False, cancel_futures=True)
-                raise RuntimeError(
-                    f"{label}: fail-fast — last {WINDOW} completions had "
-                    f"{sum(recent)} failures (>{int(FAIL_RATIO * 100)}%) "
-                    f"after {completed}/{n_total} total. "
-                    f"First error: {first_error}"
-                )
+                completed = n_ok + n_failed
+                if (
+                    completed >= MIN_SAMPLES
+                    and len(recent) == WINDOW
+                    and sum(recent) / WINDOW > FAIL_RATIO
+                ):
+                    pool.shutdown(wait=False, cancel_futures=True)
+                    outer.set_attribute("outcome", "fail_fast")
+                    outer.set_attribute("n_ok", n_ok)
+                    outer.set_attribute("n_failed", n_failed)
+                    raise RuntimeError(
+                        f"{label}: fail-fast — last {WINDOW} completions had "
+                        f"{sum(recent)} failures (>{int(FAIL_RATIO * 100)}%) "
+                        f"after {completed}/{n_total} total. "
+                        f"First error: {first_error}"
+                    )
 
-            if time.monotonic() - t_last > 30:
-                log.info(
-                    "%s progress: %d/%d ok, %d failed (window=%d%%)",
-                    label,
-                    n_ok,
-                    n_total,
-                    n_failed,
-                    int(100 * sum(recent) / max(1, len(recent))),
-                )
-                t_last = time.monotonic()
-        new_materials = tw.finalize()
+                if time.monotonic() - t_last > 30:
+                    elapsed = time.monotonic() - t_start
+                    rate = completed / elapsed if elapsed else 0
+                    eta = (n_total - completed) / rate if rate > 0 else 0
+                    log.info(
+                        "%s progress: %d/%d ok, %d failed (window=%d%%, rate=%.1f/s, eta=%ds)",
+                        label,
+                        n_ok,
+                        n_total,
+                        n_failed,
+                        int(100 * sum(recent) / max(1, len(recent))),
+                        rate,
+                        int(eta),
+                    )
+                    outer.add_event(
+                        "progress",
+                        {"n_ok": n_ok, "n_failed": n_failed, "rate_per_s": rate},
+                    )
+                    t_last = time.monotonic()
+            new_materials = tw.finalize()
+        outer.set_attribute("outcome", "ok")
+        outer.set_attribute("n_ok", n_ok)
+        outer.set_attribute("n_failed", n_failed)
 
     # Terminal gate: refuse to ship a partial tar. A few dozen bad
     # textures in a 11k-channel bake is tolerable; sub-90% is not.

--- a/src/mat_vis_baker/telemetry.py
+++ b/src/mat_vis_baker/telemetry.py
@@ -1,0 +1,108 @@
+"""OpenTelemetry instrumentation for the baker (opt-in, self-hosted).
+
+Wires OpenTelemetry SDK + OTLP HTTP exporter around bake / derive
+operations. Active when ``OTEL_EXPORTER_OTLP_ENDPOINT`` is set
+(e.g. ``http://grafana.tail-xxx.ts.net:4318``); a complete no-op
+otherwise. Use with the free-tier stack documented in #131:
+
+    podman run -d --name otel-lgtm \\
+      -p 4318:4318 -p 3000:3000 \\
+      grafana/otel-lgtm:latest
+
+Emits:
+
+- one root span per high-level op (``hf-bake``, ``hf-derive``,
+  ``hf-derive-ktx2``) with source/tier/release attrs;
+- a ``stream.transform`` child span with the ok/failed counters
+  attached as attributes when the pool drains;
+- counter events every 30 s with a ``progress`` marker.
+
+The sdk / exporter deps live under the ``observability`` optional
+extra so non-observing consumers don't pay for them.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import contextmanager
+from typing import Iterator
+
+log = logging.getLogger("mat-vis-baker.telemetry")
+
+_tracer = None  # type: ignore[var-annotated]
+_initialised = False
+
+
+def _init_once() -> None:
+    """Initialise the OTLP tracer on first use. No-op if the endpoint
+    env var is unset or the SDK isn't installed."""
+    global _tracer, _initialised
+    if _initialised:
+        return
+    _initialised = True
+
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if not endpoint:
+        log.debug("OTEL_EXPORTER_OTLP_ENDPOINT not set — telemetry disabled")
+        return
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError:
+        log.warning(
+            "OTEL_EXPORTER_OTLP_ENDPOINT set but opentelemetry SDK missing — "
+            "install `mat-vis[observability]` to enable"
+        )
+        return
+
+    resource = Resource.create(
+        {
+            "service.name": "mat-vis-baker",
+            "service.version": os.environ.get("MAT_VIS_BAKER_VERSION", "dev"),
+            "deployment.environment": (
+                "ci" if os.environ.get("GITHUB_ACTIONS") == "true" else "local"
+            ),
+        }
+    )
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(provider)
+    _tracer = trace.get_tracer("mat_vis_baker")
+    log.info("telemetry enabled → %s", endpoint)
+
+
+@contextmanager
+def span(name: str, **attrs: object) -> Iterator[object]:
+    """Context manager that opens an OTel span (no-op if telemetry off).
+
+    Yields the span handle so callers can set additional attributes
+    mid-operation (e.g. final ok/failed counters)."""
+    _init_once()
+    if _tracer is None:
+        yield _NoopSpan()
+        return
+    with _tracer.start_as_current_span(name) as s:
+        for k, v in attrs.items():
+            s.set_attribute(k, _coerce(v))
+        yield s
+
+
+class _NoopSpan:
+    def set_attribute(self, *_args, **_kw) -> None: ...
+    def add_event(self, *_args, **_kw) -> None: ...
+
+
+def _coerce(v: object) -> object:
+    """OTel attrs want str/int/float/bool or sequences of same."""
+    if isinstance(v, (str, bool, int, float)):
+        return v
+    if isinstance(v, (list, tuple)):
+        return [_coerce(x) for x in v]
+    return str(v)


### PR DESCRIPTION
## Summary

Parallel track alongside the v2026.04.1 finish. Adds opt-in
OpenTelemetry spans + a richer heartbeat log line to the bake/derive
pipelines. Setting \`OTEL_EXPORTER_OTLP_ENDPOINT\` enables; unset is a
complete no-op.

Addresses the observability gap the /falsify review surfaced, without
any infra assumption — all OTel deps live under a new
\`[observability]\` optional extra.

## What changed

- \`mat_vis_baker/telemetry.py\` — tiny wrapper: \`span(name, **attrs)\`
  context manager. Initialises the SDK on first use, no-op if the
  env var isn't set or the extra isn't installed.
- \`hf_derive._stream_transform_into_tar\` — wraps the pool in a
  \`stream.transform\` root span with \`n_ok\`/\`n_failed\`/\`outcome\`
  attrs on close and a \`progress\` event every 30 s. Fail-fast path
  sets \`outcome=fail_fast\`.
- Heartbeat log line: adds rolling-window fail rate %, channels/s
  throughput, ETA seconds.
- \`docs/observability.md\` — podman one-liner for
  \`grafana/otel-lgtm\` (Grafana + Tempo + Loki + Mimir + Prometheus
  in one image). Tailscale serve recipe for CI.
- \`pyproject.toml\` — \`observability\` optional extra with
  \`opentelemetry-sdk\` + \`opentelemetry-exporter-otlp-proto-http\`.

## Test plan

- [x] \`pytest tests/ clients/python/test_client.py\` — 202 passed /
      11 skipped. All no-op paths covered.
- [x] \`uv sync --all-extras\` installs OTel deps cleanly (5 new).
- [ ] Live end-to-end with
      \`podman run -p 4318:4318 grafana/otel-lgtm\` — verify
      \`stream.transform\` spans appear in Tempo UI.
- [ ] CI green.

Explicit OTLP emission integration test deferred to #129 — Dagger
pipeline lands a reusable OTLP fixture there.

## Follow-ups

- #129 — Dagger pipeline emits spans to the same receiver.
- #130 closes with the heartbeat line lands.
- #131 closes with the podman recipe + docs.

Refs #129, #130, #131