### PR TITLE
ci: bump Derive workflow timeout 240 → 480 min

### DIFF
--- a/.github/workflows/derive.yml
+++ b/.github/workflows/derive.yml
@@ -65,7 +65,10 @@ jobs:
       ${{ inputs.source-tier }}
       → ${{ inputs.kind == 'resize' && inputs.target-tier || format('ktx2-{0}', inputs.source-tier) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 240
+    # 2k ktx2 transcodes with PIL re-encode + toktx per channel run
+    # ~3 h on free runners (2026-04-20 empirical). Headroom for
+    # ambientcg (largest source).
+    timeout-minutes: 480
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:


### PR DESCRIPTION
Empirical: ktx2-2k transcodes (ambientcg has ~2.5 k materials ×
5 channels = 11 k through PIL re-encode + toktx UASTC + \`--genmipmap\`)
take ~3 h on free ubuntu-latest runners. The 240-min default was
cutting them off mid-run; none of the 6 in-flight v2026.04.1 ktx2
jobs had committed by the 190-min mark.

Double to 480 with headroom. Doesn't help the in-flight runs
(\`timeout-minutes\` is frozen at dispatch), but next dispatch
won't hit the cliff.

Longer-term: #129's Dagger shard fan-out should bring per-job
runtime back under 90 min by parallelising shards across runners.

Refs #129