### PR TITLE
feat(ci): derive.yml matrix fan-out + merge job (#138)

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -64,7 +64,9 @@ jobs:
   bake:
     name: hf-bake ${{ inputs.source }} ${{ inputs.tier }}
     runs-on: ubuntu-latest
-    timeout-minutes: 240
+    # GH-hosted runners hard-cap at 360 min; 350 leaves headroom for
+    # the post-step log upload and any slack in the scheduler.
+    timeout-minutes: 350
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:

--- a/.github/workflows/derive.yml
+++ b/.github/workflows/derive.yml
@@ -1,6 +1,21 @@
 ---
 # Derive workflow — resize a smaller PNG tier or KTX2-transcode an
-# existing PNG tar on HF. Atomic-commits via hf-derive / hf-derive-ktx2.
+# existing PNG tar on HF, sharded across N runners (#134, #138).
+#
+# Shape:
+#   setup   — precomputes the shard-index list + target-tier name
+#   derive  — matrix[shard-index] runs mat-vis-baker hf-derive{,-ktx2}
+#             with --shard-index N --shard-total K; each shard is an
+#             atomic HF commit for its own tar + rowmap
+#   merge   — single job that runs mat-vis-baker merge-shards to
+#             reassemble the shard tars into one canonical tar and
+#             delete the shard artifacts in one atomic commit
+#   report  — notify-on-failure if any earlier job failed
+#
+# When shard-total == 1 the matrix produces one job, shard args are
+# omitted (so the output is polyhaven-512.tar directly), and the
+# merge step is skipped — gives back the legacy unsharded path
+# without code duplication.
 
 name: Derive
 
@@ -52,20 +67,81 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: 'gerchowl/mat-vis'
         type: string
+      shard-total:
+        description: 'Number of shards (1 = no sharding; defaults: 4 for resize, 8 for ktx2)'
+        required: false
+        default: '0'   # 0 = auto (see setup job)
+        type: string
 
 permissions:
   contents: read
   issues: write          # needed by notify-on-failure composite action
 
 jobs:
+  setup:
+    name: setup (shards + target-tier)
+    runs-on: ubuntu-latest
+    outputs:
+      shard-total: ${{ steps.plan.outputs.shard-total }}
+      shards: ${{ steps.plan.outputs.shards }}
+      target-tier: ${{ steps.plan.outputs.target-tier }}
+    steps:
+      - id: plan
+        run: |
+          set -euo pipefail
+          kind="${{ inputs.kind }}"
+          req="${{ inputs.shard-total }}"
+          if [ "$req" = "0" ] || [ -z "$req" ]; then
+            if [ "$kind" = "ktx2" ]; then
+              K=8
+            else
+              K=4
+            fi
+          else
+            K="$req"
+          fi
+          if ! [[ "$K" =~ ^[0-9]+$ ]] || [ "$K" -lt 1 ]; then
+            echo "::error::shard-total must be a positive integer, got '$K'"
+            exit 1
+          fi
+
+          if [ "$kind" = "resize" ]; then
+            tier="${{ inputs.target-tier }}"
+          else
+            tier="ktx2-${{ inputs.source-tier }}"
+          fi
+
+          # Build JSON array [0, 1, …, K-1]
+          shards="[$(seq -s, 0 $((K-1)))]"
+
+          {
+            echo "shard-total=$K"
+            echo "shards=$shards"
+            echo "target-tier=$tier"
+          } >>"$GITHUB_OUTPUT"
+          echo "Plan: kind=$kind target-tier=$tier shard-total=$K shards=$shards"
+
   derive:
+    needs: setup
     name: >-
       ${{ inputs.kind }}
       ${{ inputs.source }}
       ${{ inputs.source-tier }}
-      → ${{ inputs.kind == 'resize' && inputs.target-tier || format('ktx2-{0}', inputs.source-tier) }}
+      → ${{ needs.setup.outputs.target-tier }}
+      (shard ${{ matrix.shard-index }}/${{ needs.setup.outputs.shard-total }})
     runs-on: ubuntu-latest
-    timeout-minutes: 240
+    # Shards of ktx2-2k can run ~3 h; 350 min gives headroom under
+    # the 360-min GH runner hard cap.
+    timeout-minutes: 350
+    strategy:
+      # Let all shards run to completion even if one fails — easier to
+      # triage which channels are broken than to bisect a cancelled set.
+      fail-fast: false
+      # 8 concurrent shards fits the org's 20-slot budget with room for
+      # other workflows. Users can pass shard-total > 8; excess queues.
+      max-parallel: 8
+      matrix:
+        shard-index: ${{ fromJson(needs.setup.outputs.shards) }}
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:
@@ -89,34 +165,84 @@ jobs:
       - name: Install baker
         run: uv sync --all-extras
 
-      - name: Derive
+      - name: Derive (shard ${{ matrix.shard-index }}/${{ needs.setup.outputs.shard-total }})
         run: |
           set -euxo pipefail
+          shard_flags=""
+          if [ "${{ needs.setup.outputs.shard-total }}" != "1" ]; then
+            shard_flags="--shard-index ${{ matrix.shard-index }} --shard-total ${{ needs.setup.outputs.shard-total }}"
+          fi
           if [ "${{ inputs.kind }}" = "resize" ]; then
+            # shellcheck disable=SC2086
             uv run mat-vis-baker hf-derive \
               "${{ inputs.source }}" \
               "${{ inputs.target-tier }}" \
               /tmp/derive \
               --source-tier "${{ inputs.source-tier }}" \
               --release-tag "${{ inputs.release-tag }}" \
-              --repo-id "${{ inputs.repo-id }}"
+              --repo-id "${{ inputs.repo-id }}" \
+              $shard_flags
           else
+            # shellcheck disable=SC2086
             uv run mat-vis-baker hf-derive-ktx2 \
               "${{ inputs.source }}" \
               /tmp/derive \
               --source-tier "${{ inputs.source-tier }}" \
               --release-tag "${{ inputs.release-tag }}" \
-              --repo-id "${{ inputs.repo-id }}"
+              --repo-id "${{ inputs.repo-id }}" \
+              $shard_flags
           fi
 
+  merge:
+    needs: [setup, derive]
+    # Skip merge when there's nothing to merge (shard-total=1 means the
+    # shard-aware flags weren't passed, so no shard-N-of-K artifacts
+    # exist on HF — the single-job output is already the final tar).
+    if: needs.setup.outputs.shard-total != '1'
+    name: merge-shards (${{ needs.setup.outputs.shard-total }} shards → ${{ needs.setup.outputs.target-tier }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install baker
+        run: uv sync --all-extras
+
+      - name: merge-shards
+        run: |
+          set -euxo pipefail
+          uv run mat-vis-baker merge-shards \
+            "${{ inputs.source }}" \
+            "${{ needs.setup.outputs.target-tier }}" \
+            /tmp/merge \
+            --release-tag "${{ inputs.release-tag }}" \
+            --repo-id "${{ inputs.repo-id }}"
+
+  report:
+    needs: [setup, derive, merge]
+    if: always() && (needs.derive.result == 'failure' || needs.merge.result == 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - name: Notify on failure
-        if: failure()
         uses: ./.github/actions/notify-on-failure
         with:
           label-prefix: "[derive-failed]"
           workflow-name: "derive"
-          target: "${{ inputs.kind }} ${{ inputs.source }}/${{ inputs.source-tier }} @ ${{ inputs.release-tag }}"
+          target: >-
+            ${{ inputs.kind }} ${{ inputs.source }}/${{ inputs.source-tier }}
+            → ${{ needs.setup.outputs.target-tier }}
+            @ ${{ inputs.release-tag }} (shard-total=${{ needs.setup.outputs.shard-total }})
           context: >-
-            Atomic HF commits mean a failed derive leaves the target
-            revision unchanged — safe to retry. Check the derive step
-            logs for the specific channel that errored.
+            Sharded derive — at least one shard failed, or the
+            merge-shards step failed. Each shard commit is atomic, so
+            partial progress is safely stored on HF. Re-run the failed
+            shard(s) by dispatching Derive with the same inputs — the
+            succeeded shards' tars are already in place (merge-shards
+            will pick them up once the last shard lands).

--- a/.github/workflows/derive.yml
+++ b/.github/workflows/derive.yml
@@ -77,6 +77,16 @@ permissions:
   contents: read
   issues: write          # needed by notify-on-failure composite action
 
+# Serialise dispatches on the same (release, source, source-tier, kind).
+# Without this, two parallel dispatches race on shard-N-of-K paths; because
+# tar member order is non-deterministic under ThreadPoolExecutor, producer
+# A's bytes could land with producer B's rowmap offsets — silent corruption.
+# cancel-in-progress=false because we want to queue retries, not preempt
+# the in-flight derive mid-shard.
+concurrency:
+  group: derive-${{ inputs.repo-id }}-${{ inputs.release-tag }}-${{ inputs.source }}-${{ inputs.source-tier }}-${{ inputs.kind }}
+  cancel-in-progress: false
+
 jobs:
   setup:
     name: setup (shards + target-tier)
@@ -144,6 +154,12 @@ jobs:
         shard-index: ${{ fromJson(needs.setup.outputs.shards) }}
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      # Python logging is line-buffered on a pipe by default, which can
+      # stall the 30 s progress heartbeat (mat_vis_baker.hf_derive) for
+      # minutes in the GH Actions log stream. Unbuffered stdio makes the
+      # heartbeat visible in real time — the difference between "stuck"
+      # and "slow" when triaging a running shard.
+      PYTHONUNBUFFERED: '1'
     steps:
       - uses: actions/checkout@v4
 
@@ -226,7 +242,14 @@ jobs:
 
   report:
     needs: [setup, derive, merge]
-    if: always() && (needs.derive.result == 'failure' || needs.merge.result == 'failure')
+    # Setup failure → downstream jobs are skipped (result != 'failure'),
+    # so check setup explicitly; otherwise a bad shard-total or tree
+    # listing fails silently with no issue filed.
+    if: >-
+      always() &&
+      (needs.setup.result == 'failure' ||
+       needs.derive.result == 'failure' ||
+       needs.merge.result == 'failure')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -240,9 +263,10 @@ jobs:
             → ${{ needs.setup.outputs.target-tier }}
             @ ${{ inputs.release-tag }} (shard-total=${{ needs.setup.outputs.shard-total }})
           context: >-
-            Sharded derive — at least one shard failed, or the
-            merge-shards step failed. Each shard commit is atomic, so
-            partial progress is safely stored on HF. Re-run the failed
-            shard(s) by dispatching Derive with the same inputs — the
-            succeeded shards' tars are already in place (merge-shards
-            will pick them up once the last shard lands).
+            Sharded derive — at least one shard or the merge step failed.
+            Each shard commit is atomic, so succeeded shards are already
+            on HF. Recovery: open the failed Actions run and click
+            "Re-run failed jobs" (top right). That re-runs only the red
+            shards + the merge job, skipping the succeeded shards —
+            much cheaper than a fresh workflow_dispatch, which re-runs
+            every shard from scratch.

--- a/docs/decisions/0010-sharded-pipeline-via-gh-matrix.md
+++ b/docs/decisions/0010-sharded-pipeline-via-gh-matrix.md
@@ -1,0 +1,137 @@
+# ADR-0010: Sharded derive pipeline via GH Actions matrix
+
+**Status:** Accepted (PR #148, /spike 148 consolidated 2026-04-20)
+**Supersedes parts of:** ADR-0009 (derive pipeline decisions — `fail-fast`
+logic and single-runner assumption)
+**Related:** #134 (shard CLI), #138 (workflow rewrite), epic #140 (Dagger
+migration), ADR-0007 (HF substrate), ADR-0008 (tree as SoT).
+
+## Context
+
+`ambientcg-ktx2-2k` needs ~22 h of single-runner work — far above
+GitHub's 6 h runner hard cap. Upgrading to larger runners doesn't help
+(the cap is per-job, not per-CPU). Two viable substrates:
+
+1. **GitHub Actions matrix fan-out** — every shard is a separate job,
+   each ≤ 6 h. Public repos have unlimited Actions minutes, so cost is
+   wall-clock and org concurrency (20-slot budget), not dollars.
+2. **HF Jobs** — near-data execution, no 6 h cap. Paid after free
+   tier, org quotas lower than GH's, dispatch UX immature. Interesting
+   for a follow-up but not the first move.
+
+We pick (1). Shape, defaults, and failure modes crystallised through a
+/spike 148 round with four adversarial reviewers (GH Actions mechanics,
+distributed systems, operator UX, cost).
+
+## Decision
+
+The derive pipeline runs as a four-job DAG on `workflow_dispatch`:
+
+```
+setup → derive (matrix[shard-index]) → merge → report
+                                           ↓
+                                    notify on failure
+```
+
+- **`setup`** precomputes the shard-index JSON array + target-tier
+  name, exposes them as job outputs. Validates `shard-total` is a
+  positive integer before the matrix evaluates `fromJson`.
+- **`derive`** matrix expands `shard-index: [0, 1, …, K-1]`. Each job
+  invokes `mat-vis-baker hf-derive` or `hf-derive-ktx2` with
+  `--shard-index N --shard-total K`. Each shard commits its own tar +
+  rowmap to HF atomically (ADR-0007's substrate-level guarantee).
+- **`merge`** runs `mat-vis-baker merge-shards` to reassemble shards
+  into one canonical tar + rowmap and delete shard leftovers in one
+  atomic commit. Skipped when `shard-total=1` (degenerate single-shard
+  case).
+- **`report`** runs `if: always() && (needs.{setup,derive,merge}.result
+  == 'failure')` and fires the `notify-on-failure` composite action.
+
+Defaults: `shard-total=4` (resize), `shard-total=8` (ktx2);
+`max-parallel=8`; `fail-fast=false`; `timeout-minutes=350` (10 min
+under the 360-min hard cap).
+
+## Consequences
+
+**Good:**
+- Removes the 6 h single-runner ceiling. ktx2-2k fits in ~3 h per
+  shard × 8 shards = ~3 h wall-clock total.
+- Each shard's HF commit is atomic, so partial progress is durably
+  stored on HF — a failed shard doesn't waste the others' work. GH's
+  "Re-run failed jobs" UI button is shard-selective, cheap, and the
+  recommended recovery path (per operator UX review).
+- Substrate-agnostic: the matrix shape survives a future swap to
+  `dagger call` (#140 epic) or HF Jobs — only the `run:` step changes.
+
+**Bad / accepted tradeoffs:**
+- **Non-deterministic tar bytes** (the old implementation). The
+  distributed-systems reviewer showed that
+  `ThreadPoolExecutor + as_completed` yielded results in completion
+  order, so tar member offsets varied between runs of the same shard.
+  Fixed in PR #148 by buffering transformed bytes in a dict keyed by
+  `(mid, ch)` and flushing to the tar in sorted order. Memory cost
+  ≤ ~600 MB for ktx2-2k, well under the 16 GB runner limit.
+- **Concurrent-dispatch race.** Without a `concurrency:` group, two
+  simultaneous dispatches could race on the same shard paths and
+  produce a tar whose bytes come from one producer but whose rowmap
+  came from another — silent corruption after merge. Fixed in PR #148
+  with `concurrency: derive-${repo-id}-${release-tag}-${source}-${source-tier}-${kind}`
+  and `cancel-in-progress=false` so retries queue rather than preempt.
+- **Post-merge dirty state.** After a successful merge, a re-dispatch
+  re-publishes shard artifacts alongside the canonical tar. Not fixed
+  in PR #148; tracked as #155 (guard `hf-derive` against overwriting an
+  existing canonical tar unless `--force`).
+- **Stale `-of-K'` artifacts after K change** hard-fails merge but
+  offers no cleanup path. Tracked as #156 (`--clean-stale`).
+- **HF CDN-lag 404s on freshly committed shards** have no retry in
+  `_range_read`. Tracked as #153.
+
+**Neutral / deferred:**
+- **Operator UX — error-class tagging, source URL logging, aggregated
+  failed-channel list** (#157). Noise today; structural fix later.
+- **Selective re-dispatch** via `shards-to-run` CSV input (#158). GH's
+  "Re-run failed jobs" UI button covers the interactive case; this
+  matters for headless/automated retry only.
+- **max-parallel=8 vs 4.** Cost reviewer argued 4 (frees team
+  throughput on the org's 20-slot budget). Kept at 8 because the
+  typical release fires one kind at a time; revisit if the team
+  finds other workflows queue-starved.
+
+## Alternatives considered
+
+**A. Keep single-runner + bigger runners.** Dead on arrival — the 6 h
+cap is per-job, not per-CPU. `ubuntu-latest-32gb` doesn't help.
+
+**B. Self-hosted runners.** Removes the cap but shifts the cost to
+host maintenance and trust boundaries. Not pursued; can be revisited
+if wall-clock becomes the bottleneck.
+
+**C. HF Jobs.** Genuinely interesting — runs near the data, no cap —
+but paid beyond the free tier, org quotas lower than GH's, dispatch
+UX immature. The matrix shape decided here swaps in as the `run:`
+step regardless, so this ADR doesn't close the door.
+
+**D. Dagger first (epic #140, issues #136/#137).** Would give local↔CI
+parity and OTel out of the box. Dagger engine bootstrap is 60–120 s on
+a cold runner — negligible relative to shard length — so the cost is
+implementation complexity, not runtime. Decision: Dagger is the
+*next* step, layered on top of this matrix. The matrix shape chosen
+here is Dagger-ready; swap `uv run mat-vis-baker …` for `dagger call
+…` in one PR.
+
+## Implementation notes
+
+- PR #148 lands the workflow + 4 blocker fixes from the spike.
+- PR #149 adds an `HF_INTEGRATION=1`-gated live test + cosmetic nits +
+  the bake→derive ordering doc note on ADR-0009.
+- Follow-up issues #153–#158 carry the non-blocker items to the
+  **v0.6.0 — sharded pipeline + Dagger** milestone.
+- Dagger migration tracked separately in epic #140.
+
+## Review trail
+
+- Independent review of #146 (shard CLI) — no blockers; 2 items patched
+  (empty-shard terminal gate, null-byte hash separator).
+- /spike 148 — four reviewers (GH Actions, distributed systems,
+  operator UX, cost). Findings consolidated into PR #148 blockers +
+  follow-up issues above.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -14,6 +14,7 @@ rejected, and what would trigger revisiting.
 7. [0007 — Substrate move to HF Datasets + tar container, drop per-category partitioning](0007-substrate-move-to-hf-datasets-and-tar-container.md) — supersedes 0001/0002/0003
 8. [0008 — Dataset tree is the source of truth; `release-manifest.json` is an optional convenience snapshot](0008-dataset-tree-as-source-of-truth.md) — partly supersedes 0007
 9. [0009 — Derive pipeline: HTTP-range streaming, parallel workers, ICC-strip, fail-fast](0009-derive-pipeline-processing.md)
+10. [0010 — Sharded derive pipeline via GH Actions matrix](0010-sharded-pipeline-via-gh-matrix.md) — partly supersedes 0009
 
 ## Template
 

--- a/src/mat_vis_baker/hf_derive.py
+++ b/src/mat_vis_baker/hf_derive.py
@@ -194,6 +194,15 @@ def _stream_transform_into_tar(
     if shard is not None:
         span_attrs["shard_index"] = shard[0]
         span_attrs["shard_total"] = shard[1]
+    # Buffer transformed bytes by (mid, ch) and flush to the tar in
+    # *sorted* order after the worker pool drains. Without this,
+    # ``as_completed`` yields in completion-arrival order → tar member
+    # offsets depend on worker scheduling → re-running the same shard
+    # produces different bytes. The buffer costs ~N × mean-channel-size
+    # of RAM per shard (for ktx2-2k at shard-total=8 that's ≤~600 MB,
+    # well under the 16 GB runner limit).
+    pending: dict[tuple[str, str], bytes] = {}
+
     with span("stream.transform", **span_attrs) as outer:
         with ThreadPoolExecutor(max_workers=max_workers) as pool, TarWriter(out_tar_path) as tw:
             futures = {pool.submit(_one, item): item for item in work}
@@ -201,7 +210,7 @@ def _stream_transform_into_tar(
                 mid, ch, spec = futures[fut]
                 try:
                     r_mid, r_ch, out_bytes = fut.result()
-                    tw.add_channel(r_mid, r_ch, out_bytes)
+                    pending[(r_mid, r_ch)] = out_bytes
                     n_ok += 1
                     recent.append(False)
                 except Exception as e:
@@ -247,6 +256,14 @@ def _stream_transform_into_tar(
                         {"n_ok": n_ok, "n_failed": n_failed, "rate_per_s": rate},
                     )
                     t_last = time.monotonic()
+
+            # Flush buffered results to the tar in deterministic order.
+            # Sorting by (mid, ch) guarantees that two runs of the same
+            # shard against the same source produce byte-identical tars.
+            for key in sorted(pending):
+                mid, ch = key
+                tw.add_channel(mid, ch, pending[key])
+            pending.clear()  # release peak memory before finalize
             new_materials = tw.finalize()
         outer.set_attribute("outcome", "ok")
         outer.set_attribute("n_ok", n_ok)

--- a/tests/test_shard_integration.py
+++ b/tests/test_shard_integration.py
@@ -158,11 +158,14 @@ def test_empty_shard_is_noop_not_error(tmp_path: Path) -> None:
 
 
 def test_shard_deterministic_bytes(tmp_path: Path) -> None:
-    """Same input + same shard index → identical output bytes (re-runnable)."""
-    src_tar, src_rowmap = _build_src(tmp_path, n_materials=8)
+    """Same input + same shard index → identical output bytes, even with
+    multiple workers. /spike 148 flagged that the old as_completed →
+    tw.add_channel path produced completion-order tars
+    (non-deterministic); the fix buffers + sorts before writing."""
+    src_tar, src_rowmap = _build_src(tmp_path, n_materials=16)
     src_bytes = src_tar.read_bytes()
 
-    def run(dest: Path) -> bytes:
+    def run(dest: Path, workers: int) -> bytes:
         with (
             patch("mat_vis_baker.hf_derive._pin_commit", return_value="deadbeef"),
             patch("mat_vis_baker.hf_derive._fetch_rowmap", return_value=src_rowmap),
@@ -176,14 +179,21 @@ def test_shard_deterministic_bytes(tmp_path: Path) -> None:
                 work_dir=dest,
                 hf_token="t",
                 dry_run=True,
-                workers=1,  # serial so tar member order is deterministic
+                workers=workers,
                 shard=(1, 4),
             )
         return (dest / "polyhaven-512.shard-1-of-4.tar").read_bytes()
 
-    a = run(tmp_path / "a")
-    b = run(tmp_path / "b")
+    # Two workers=8 runs — where completion order used to vary. Buffer +
+    # sort before write makes the tars byte-identical.
+    a = run(tmp_path / "a", workers=8)
+    b = run(tmp_path / "b", workers=8)
     assert a == b
+
+    # A serial run produces the same bytes — sort is the canonical
+    # order, not a concurrent-specific coincidence.
+    c = run(tmp_path / "c", workers=1)
+    assert a == c
 
 
 def test_validate_shards_happy_path() -> None:


### PR DESCRIPTION
Stacked: **dev ← this (#148) ← #149 (deferred nits)**.

## Summary

Rewrites `.github/workflows/derive.yml` to shard the channel work list across N GH-hosted runners via a matrix strategy, then merge the shards into one canonical tar. Bumps `bake.yml` timeout to 350 min. ADR-0010 captures the decision trail.

## Changes since first push (post-/spike 148 review round)

Four blocker fixes surfaced by four independent reviewers:

- **`concurrency:` group** (GH Actions + distributed reviewers) — keyed on `repo-id, release-tag, source, source-tier, kind`. `cancel-in-progress: false` so retries queue rather than preempt.
- **Deterministic tar writes** (distributed §6) — buffers transformed bytes by `(mid, ch)` and flushes sorted before finalize. The old `as_completed` → `tw.add_channel` yielded completion-order tars; bit-identity claim now actually holds. New test exercises `workers=8 → workers=8` and `workers=8 → workers=1`.
- **`report` job covers `setup` failure** (GH Actions) — added `needs.setup.result == 'failure'` to the `if:` so a bad `shard-total` input doesn't silently skip notification.
- **`PYTHONUNBUFFERED=1` + fixed context string** (operator UX) — heartbeat renders in real time; notify text directs operators to GH's "Re-run failed jobs" UI button (shard-selective) instead of a fresh dispatch (re-runs every shard).

Plus **ADR-0010** documenting the full decision trail.

## Why

Single-runner `ambientcg-ktx2-2k` needs ~22 h — doesn't fit the 6 h GH runner cap. Matrix fan-out with 8 shards brings each shard to ~3 h per #138's timeout math, all under the cap.

## Not in this PR (deferred to v0.6.0 milestone)

- #153 — retry-with-backoff in `merge_shards._range_read` (HF CDN-lag)
- #154 — rowmap metadata cross-check against filename in `merge-shards`
- #155 — guard `hf-derive` against rewriting over an existing canonical tar
- #156 — `merge-shards --clean-stale` + `--allow-missing-shards` flags
- #157 — error class tagging + source URL + aggregated failed-channel list
- #158 — `shards-to-run` CSV input for selective re-dispatch

## Test plan

- [x] `uv run pytest tests/test_shard_integration.py -q` — 11 pass, including workers=8 determinism test.
- [x] `yaml.safe_load` parses both workflows. Structure: `setup`, `derive`, `merge`, `report`.
- [ ] First live dispatch: `gh workflow run Derive -f kind=resize -f source=polyhaven -f source-tier=1k -f target-tier=512 -f release-tag=v0.0.1-smoke -f repo-id=gerchowl/mat-vis-tst -f shard-total=4` (do after merge).
- [ ] Full ktx2-2k matrix once #149 + follow-ups land.

Closes #138.
Refs #134, #140, ADR-0010, /spike 148.