### PR TITLE
chore(baker): deferred review items from PR #146 (#134)

### DIFF
--- a/docs/decisions/0009-derive-pipeline-processing.md
+++ b/docs/decisions/0009-derive-pipeline-processing.md
@@ -148,6 +148,16 @@ the log. Cheap (~200 B per run) and no-op outside GH Actions.
   every `fetch_texture`), but it would underperform against a
   rate-limiting origin.
 
+## Operator contract: bake → merge → derive ordering
+
+Derives MUST run against the already-merged `<source>-<tier>.tar` (+
+rowmap) for their source tier, not against `shard-N-of-K` bake
+artifacts. The code doesn't enforce this — `_fetch_rowmap` asks for
+`<source>-<source_tier>-rowmap.json` at a fixed path, so a missing
+merged rowmap yields a loud 404 rather than silent corruption, but
+workflow ordering is the operator's responsibility. CI's job graph
+gates derive jobs on the preceding `merge-shards` job for this reason.
+
 ## Upgrade triggers
 
 - HF CDN changes rate-limit semantics for range reads (currently

--- a/src/mat_vis_baker/__main__.py
+++ b/src/mat_vis_baker/__main__.py
@@ -206,7 +206,9 @@ def cmd_merge_shards(args: argparse.Namespace) -> int:
         keep_shards=args.keep_shards,
     )
     log.info("merge-shards result: %s", result)
-    return 0 if "error" not in result else 1
+    # merge_shards never puts "error" in its result — it raises on any
+    # fault (incomplete shard set, range-read mismatch). Always return 0.
+    return 0
 
 
 def cmd_hf_bake(args: argparse.Namespace) -> int:

--- a/src/mat_vis_baker/merge_shards.py
+++ b/src/mat_vis_baker/merge_shards.py
@@ -154,7 +154,7 @@ def merge_shards(
     out_rowmap_in_repo = f"{subdir}{out_rowmap_name}"
     # Merged files must be staged locally under the same relative path
     # that they land in the repo — HF push takes (local, repo_path) pairs.
-    out_local_parent = work_dir / subdir.rstrip("/") if is_ktx2 else work_dir
+    out_local_parent = (work_dir / subdir.rstrip("/")) if is_ktx2 else work_dir
     out_local_parent.mkdir(parents=True, exist_ok=True)
     out_tar_path = out_local_parent / out_tar_name
     out_rowmap_path = out_local_parent / out_rowmap_name
@@ -171,6 +171,12 @@ def merge_shards(
     shards = _discover_shards(tree, source, tier, is_ktx2)
     shard_total = _validate_shards(shards)
     log.info("found %d shards (complete set)", shard_total)
+
+    # Build one set of all tree paths up front — the per-shard catalog
+    # existence check was O(len(tree)) per shard, O(K·len(tree)) total.
+    # K ≤ 16 today so the saving is tiny, but `in` against a set is
+    # both clearer and fixes the asymptotic wart called out in review.
+    tree_paths: set[str] = {e["path"] for e in tree if e.get("type") == "file"}
 
     session = requests.Session()
     resolve_base = f"{HF_RESOLVE}/{repo_id}/resolve/{release_tag}"
@@ -209,7 +215,7 @@ def merge_shards(
 
             # Partial catalog (bake shards only — derive shards don't write one).
             partial_catalog_repo_path = f"{source}-{tier}.shard-{idx}-of-{total}.catalog.json"
-            if any(e.get("path") == partial_catalog_repo_path for e in tree):
+            if partial_catalog_repo_path in tree_paths:
                 cat = _fetch_json(f"{resolve_base}/{partial_catalog_repo_path}", hf_token)
                 if isinstance(cat, list):
                     partial_catalog_data.append(cat)

--- a/tests/test_shard_live.py
+++ b/tests/test_shard_live.py
@@ -1,0 +1,196 @@
+"""Live HF-gated smoke test for the shard derive → merge loop (#134).
+
+PR #146 made the claim that the sharded derive + merge path works
+end-to-end against a real HF dataset revision. The unit suite in
+``tests/test_shard_integration.py`` mocks every HTTP call, so that
+claim only lived in prose. This module encodes it as an actually-
+runnable test against ``gerchowl/mat-vis-tst@v0.0.1-smoke``.
+
+Gated behind ``HF_INTEGRATION=1`` (+ a usable token from ``HF_TOKEN``
+or ``~/.cache/huggingface/token``) so the regular suite stays offline.
+
+Pattern: 4-shard resize 1k→256 on a 2-material / 10-channel smoke
+dataset. Each shard owns 2–3 channels (empirically verified against
+the current ``shard_utils`` hash). After 4 shard pushes + 1 merge,
+we assert:
+
+- the merged ``polyhaven-256.tar`` is live on the tag,
+- no ``shard-N-of-4`` artifacts remain,
+- every rowmap entry points at a valid PNG via HTTP Range reads.
+
+Cleanup: one final atomic commit deletes the merged tar + rowmap so
+the tag ends up in the same state it started in, and a second
+identical run will find nothing to clean up.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+from mat_vis_baker.hf_derive import derive_smaller_tier
+from mat_vis_baker.hf_push import push_to_hf
+from mat_vis_baker.merge_shards import merge_shards
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("HF_INTEGRATION"),
+    reason="requires HF_INTEGRATION=1 + a usable HF_TOKEN",
+)
+
+
+REPO_ID = "gerchowl/mat-vis-tst"
+REVISION = "v0.0.1-smoke"
+SOURCE = "polyhaven"
+SOURCE_TIER = "1k"
+TARGET_TIER = "256"
+K = 4
+
+
+def _resolve_token() -> str:
+    """HF_TOKEN wins; otherwise fall back to the CLI cache file."""
+    tok = os.environ.get("HF_TOKEN")
+    if tok:
+        return tok.strip()
+    cache = Path.home() / ".cache" / "huggingface" / "token"
+    if cache.exists():
+        return cache.read_text().strip()
+    pytest.skip("no HF token available (set HF_TOKEN or run `hf auth login`)")
+
+
+def _tree_paths(token: str) -> set[str]:
+    r = requests.get(
+        f"https://huggingface.co/api/datasets/{REPO_ID}/tree/{REVISION}?recursive=true",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=30,
+    )
+    r.raise_for_status()
+    return {e["path"] for e in r.json() if e.get("type") == "file"}
+
+
+def _range_head_bytes(url: str, offset: int, length: int, token: str) -> bytes:
+    r = requests.get(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Range": f"bytes={offset}-{offset + length - 1}",
+        },
+        timeout=30,
+    )
+    r.raise_for_status()
+    assert len(r.content) == length, f"range read short: {len(r.content)} != {length}"
+    return r.content
+
+
+def test_shard_derive_merge_live_roundtrip(tmp_path: Path) -> None:
+    token = _resolve_token()
+    t0 = time.monotonic()
+
+    merged_tar = f"{SOURCE}-{TARGET_TIER}.tar"
+    merged_rowmap = f"{SOURCE}-{TARGET_TIER}-rowmap.json"
+
+    # Pre-clean: if an earlier (possibly failed) run left a merged tar
+    # on the tag, delete it so we're testing the derive→merge path,
+    # not cached state. Shard artifacts (if any) are swept by the merge
+    # step itself via delete_paths.
+    existing = _tree_paths(token)
+    pre_deletes = [p for p in (merged_tar, merged_rowmap) if p in existing]
+    # Stale shard artifacts from a previous aborted run would cause the
+    # next merge to see 2K shards instead of K, so sweep those too.
+    pre_deletes += [p for p in existing if f"{SOURCE}-{TARGET_TIER}.shard-" in p]
+    if pre_deletes:
+        push_to_hf(
+            repo_id=REPO_ID,
+            files=[],
+            revision=REVISION,
+            commit_message=f"test: pre-clean {TARGET_TIER} artifacts for live roundtrip",
+            token=token,
+            delete_paths=pre_deletes,
+        )
+
+    # 1. Four shard derives — each pushes its own shard-N-of-K tar.
+    for i in range(K):
+        result = derive_smaller_tier(
+            source=SOURCE,
+            target_tier=TARGET_TIER,
+            source_tier=SOURCE_TIER,
+            release_tag=REVISION,
+            work_dir=tmp_path / f"shard-{i}",
+            repo_id=REPO_ID,
+            hf_token=token,
+            dry_run=False,
+            workers=2,
+            shard=(i, K),
+        )
+        assert result.get("ok", 0) > 0, f"shard {i}/{K} produced no channels: {result}"
+        assert result.get("failed", 0) == 0, f"shard {i}/{K} had failures: {result}"
+
+    # Confirm all K shard tars are on HF before we merge.
+    post_derive = _tree_paths(token)
+    for i in range(K):
+        assert f"{SOURCE}-{TARGET_TIER}.shard-{i}-of-{K}.tar" in post_derive
+        assert f"{SOURCE}-{TARGET_TIER}.shard-{i}-of-{K}-rowmap.json" in post_derive
+
+    # 2. Merge.
+    merge_result = merge_shards(
+        source=SOURCE,
+        tier=TARGET_TIER,
+        release_tag=REVISION,
+        work_dir=tmp_path / "merge",
+        repo_id=REPO_ID,
+        hf_token=token,
+        dry_run=False,
+        keep_shards=False,
+    )
+    assert merge_result["shards"] == K
+    assert merge_result["channels"] == 10, merge_result
+
+    # 3. Post-merge tree: merged artifacts present, shard artifacts gone.
+    post_merge = _tree_paths(token)
+    assert merged_tar in post_merge
+    assert merged_rowmap in post_merge
+    leftover_shards = [p for p in post_merge if f"{SOURCE}-{TARGET_TIER}.shard-" in p]
+    assert not leftover_shards, f"shard artifacts not swept: {leftover_shards}"
+
+    # 4. Rowmap offsets point at valid PNG bytes — verify via HTTP Range.
+    resolve_base = f"https://huggingface.co/datasets/{REPO_ID}/resolve/{REVISION}"
+    rowmap = requests.get(
+        f"{resolve_base}/{merged_rowmap}",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=30,
+    ).json()
+    merged_tar_url = f"{resolve_base}/{merged_tar}"
+    materials = rowmap["materials"]
+    assert set(materials) == {"aerial_beach_01", "aerial_asphalt_01"}
+    # Spot-check one channel per material (two Range reads is enough —
+    # full coverage would inflate runtime past the 60 s target).
+    for mid in materials:
+        ch, spec = next(iter(materials[mid].items()))
+        head = _range_head_bytes(
+            merged_tar_url, int(spec["offset"]), min(8, int(spec["length"])), token
+        )
+        assert head[:4] == b"\x89PNG", f"{mid}/{ch} is not a PNG: {head!r}"
+
+    # 5. Cleanup — one atomic commit to remove the merged artifacts so
+    # the tag ends up exactly as it started. Wrapped in a try/finally
+    # at the caller level isn't appropriate: if earlier assertions fail
+    # we *want* the artifacts to linger for post-mortem. Explicit
+    # cleanup runs only on the success path.
+    push_to_hf(
+        repo_id=REPO_ID,
+        files=[],
+        revision=REVISION,
+        commit_message=f"test: cleanup {TARGET_TIER} merged artifacts after live roundtrip",
+        token=token,
+        delete_paths=[merged_tar, merged_rowmap],
+    )
+    final = _tree_paths(token)
+    assert merged_tar not in final
+    assert merged_rowmap not in final
+
+    elapsed = time.monotonic() - t0
+    # Soft budget — not a hard assert; logged so we notice drift.
+    print(f"\nlive roundtrip took {elapsed:.1f}s (budget: ~60 s)")


### PR DESCRIPTION
## Summary

Addresses the three deferred items from the PR #146 independent review.

**Stack position**: `dev` ← #146 ← #148 ← this. Base this PR on `feature/138-derive-matrix`; expect to rebase once earlier PRs in the stack merge.

### What changed

- **Live-HF-gated integration test** (`tests/test_shard_live.py`) — exercises the 4-shard derive 1k→256 + merge roundtrip against `gerchowl/mat-vis-tst@v0.0.1-smoke`. Gated behind `HF_INTEGRATION=1` + `HF_TOKEN`; skipped by default. Cleans up after itself (deletes the merged `polyhaven-256.tar` + rowmap in a final atomic commit). Local runtime ~22 s.
- **Cosmetic nits in `merge_shards.py`** —
  - Build a single `set` of tree paths up front; use `in` for the partial-catalog existence probe instead of `any(e.get("path") == …)` per shard.
  - Parenthesise the `out_local_parent` ternary for precedence clarity.
  - Drop dead `return 0 if "error" not in result else 1` in `cmd_merge_shards` — `merge_shards` raises on fault rather than returning an `"error"` dict.
- **ADR-0009 operator contract** — six-line section making the bake → merge → derive ordering explicit. The code doesn't enforce it; bad ordering yields a loud 404 from `_fetch_rowmap`, and CI gates derive jobs on the merge job.

### What wasn't changed

- No behaviour changes to `merge_shards()` or `derive_smaller_tier()` beyond what's described above — same outputs, same commits, same error semantics.
- No CI workflow edits. The derive → merge ordering gate is already expressed in `derive.yml`'s `needs:`, and the ADR now points at that as the enforcement mechanism.
- No dependency bumps; no packaging changes.

## Test plan

- [x] `uv run pytest -q` — 143 pass, 1 skipped (the new live test)
- [x] `HF_INTEGRATION=1 HF_TOKEN=… uv run pytest tests/test_shard_live.py -x -v` — passes, cleanup verified (tag state pre/post is identical)
- [x] Pre-commit hooks (ruff, ruff-format, pymarkdown) all green
- [ ] CI green on the PR