### PR TITLE
fix(baker): populate physicallybased tags from upstream (#151)

### DIFF
--- a/src/mat_vis_baker/sources/physicallybased.py
+++ b/src/mat_vis_baker/sources/physicallybased.py
@@ -33,6 +33,29 @@ def _rgb_to_hex(rgb: list[float] | None) -> str | None:
     )
 
 
+def _normalize_tags(raw: object) -> list[str]:
+    """Normalize upstream tags to lowercase, stripped, de-duplicated strings.
+
+    physicallybased.info's ``tags`` is a list of strings, but a handful of
+    entries contain a single empty string (``[""]``) and some values carry
+    stray whitespace or mixed case. Drop empties, collapse casing, and
+    preserve first-seen order so the output is stable across bakes.
+    """
+    if not isinstance(raw, list):
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for t in raw:
+        if not isinstance(t, str):
+            continue
+        norm = t.strip().lower()
+        if not norm or norm in seen:
+            continue
+        seen.add(norm)
+        out.append(norm)
+    return out
+
+
 def fetch(*, session: requests.Session | None = None) -> list[MaterialRecord]:
     """Fetch all physicallybased materials (scalar only, no tier needed)."""
     s = session or requests.Session()
@@ -54,6 +77,7 @@ def fetch(*, session: requests.Session | None = None) -> list[MaterialRecord]:
             source="physicallybased",
             name=name,
             category=cat,
+            tags=_normalize_tags(mat.get("tags")),
             source_url="https://physicallybased.info",
             source_license="CC0-1.0",
             color_hex=color_hex,

--- a/tests/test_physicallybased_extractor.py
+++ b/tests/test_physicallybased_extractor.py
@@ -1,0 +1,89 @@
+"""Tests for the physicallybased.info extractor (#151).
+
+v2026.04.0 shipped ``physicallybased.json`` with ``tags: []`` on every
+entry even though upstream (``https://api.physicallybased.info/materials``)
+provides a per-material ``tags`` list. The fetcher simply never passed
+``tags=`` through to ``MaterialRecord``. This test locks in the fix:
+
+- populated tags flow through, lowercased, stripped, de-duplicated
+- the upstream ``[""]`` sentinel that several entries carry collapses
+  to an empty list (not a list containing an empty string)
+- a missing/None/non-list ``tags`` field is tolerated
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from mat_vis_baker.sources.physicallybased import _normalize_tags, fetch
+
+
+def test_normalize_tags_populated() -> None:
+    assert _normalize_tags(["aluminium", "mirror"]) == ["aluminium", "mirror"]
+
+
+def test_normalize_tags_drops_empty_sentinel() -> None:
+    """Upstream uses ``[""]`` for ~3 entries (e.g. Banana, Brass). Drop it."""
+    assert _normalize_tags([""]) == []
+
+
+def test_normalize_tags_strips_lowercases_dedupes_preserves_order() -> None:
+    assert _normalize_tags(["  Car Paint ", "coat", "CAR PAINT", "Coat", ""]) == [
+        "car paint",
+        "coat",
+    ]
+
+
+def test_normalize_tags_rejects_non_list() -> None:
+    assert _normalize_tags(None) == []
+    assert _normalize_tags("not a list") == []
+    assert _normalize_tags(42) == []
+
+
+def test_normalize_tags_skips_non_string_elements() -> None:
+    assert _normalize_tags(["good", 7, None, "also good"]) == ["good", "also good"]
+
+
+def test_fetch_populates_tags_from_upstream() -> None:
+    """End-to-end: the API response shape upstream actually returns today
+    (list-of-dicts with ``tags`` as list-of-strings) produces MaterialRecords
+    whose ``tags`` field is populated + normalized."""
+    fake_api = [
+        {
+            "name": "Aluminum",
+            "category": "metal",
+            "color": [0.9, 0.9, 0.9],
+            "ior": 1.39,
+            "metalness": 1.0,
+            "roughness": 0.0,
+            "tags": ["aluminium", "mirror"],
+        },
+        {
+            "name": "Banana",
+            "category": "organic",
+            "color": [1.0, 0.8, 0.2],
+            "ior": 1.45,
+            "tags": [""],  # upstream sentinel for "no tags"
+        },
+        {
+            "name": "Car Paint",
+            "category": "plastic",
+            "color": [0.5, 0.0, 0.0],
+            "ior": 1.5,
+            "tags": ["acrylic", "Coat", "car paint", "LACQUER", "acrylic"],
+        },
+    ]
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = fake_api
+
+    with patch("mat_vis_baker.sources.physicallybased.retry_request", return_value=mock_resp):
+        records = fetch()
+
+    assert len(records) == 3
+    by_name = {r.name: r for r in records}
+
+    assert by_name["Aluminum"].tags == ["aluminium", "mirror"]
+    # [""] collapses to [] — not a singleton-empty-string list
+    assert by_name["Banana"].tags == []
+    # case-folded, de-duplicated, order preserved
+    assert by_name["Car Paint"].tags == ["acrylic", "coat", "car paint", "lacquer"]


### PR DESCRIPTION
## Summary

- Closes #151. v2026.04.0 shipped `physicallybased.json` with `tags: []` on every entry because `sources/physicallybased.py` never passed `tags=` through to `MaterialRecord`, even though upstream (`https://api.physicallybased.info/materials`) exposes a per-material `tags` list.
- Wire the upstream `tags` field through and normalize: lowercase, strip whitespace, drop empties, de-duplicate (order-preserving).
- Normalization is required because ~3/86 upstream entries carry a `[""]` sentinel (e.g. Banana, Brass, Blackboard) rather than `[]`, which would otherwise leak an empty-string element into the index.

## Upstream field wired up

Top-level `"tags"` on each object in the JSON array returned by `GET https://api.physicallybased.info/materials`. Probe (86 materials total): 83 populated, 3 `[""]`, 0 missing. Example: `{"name": "Aluminum", "tags": ["aluminium", "mirror"], ...}`.

## Out of scope

Per the issue: no synthesized tags from scalars/category/description, no #152 `upstream` block, no rebake.

## Test plan

- [x] `uv run --with pytest pytest tests/ -k physicallybased -v` — 6 passed
- [x] `uv run --with ruff ruff check` on touched files — clean
- [x] `uv run --with ruff ruff format --check` on touched files — clean
- [x] New `tests/test_physicallybased_extractor.py` covers: populated passthrough, `[""]` sentinel drop, strip/lowercase/dedupe with order preservation, non-list input rejection, non-string element skip, and an end-to-end `fetch()` with mocked upstream.