### PR TITLE
fix(baker): normalize_category handles plurals + extended keyword map (#150)

### DIFF
--- a/src/mat_vis_baker/common.py
+++ b/src/mat_vis_baker/common.py
@@ -137,6 +137,8 @@ for _cat, _keywords in {
         "mortar",
         "pavement",
         "sidewalk",
+        "paving",
+        "terrazzo",
     ],
     "ceramic": ["ceramic", "porcelain", "tile", "terracotta", "clay", "brick", "pottery"],
     "glass": ["glass", "mirror", "crystal", "window", "translucent", "transparent"],
@@ -169,18 +171,105 @@ for _cat, _keywords in {
         _CATEGORY_MAP[kw] = _cat
 
 
+def _tokenize_category(first: str) -> list[str]:
+    """Split a lower-case first segment into candidate match tokens.
+
+    Handles dashes, underscores, spaces, and CamelCase run-ons like
+    "WoodFloor" / "PaintedPlaster" / "BaseMaterials" (which arrive as
+    "woodfloor" after .lower(), so we split on the original casing
+    before lower-casing — see normalize_category).
+    """
+    # split on any non-alphanumeric delimiter
+    tokens: list[str] = []
+    buf = ""
+    for ch in first:
+        if ch.isalnum():
+            buf += ch
+        else:
+            if buf:
+                tokens.append(buf)
+            buf = ""
+    if buf:
+        tokens.append(buf)
+    return tokens
+
+
+def _split_camel(token: str) -> list[str]:
+    """Split a CamelCase/PascalCase token into lower-case sub-words.
+
+    "WoodFloor" -> ["wood", "floor"]; "SciFi" -> ["sci", "fi"];
+    "PaintedPlaster" -> ["painted", "plaster"]; a token with no upper
+    transitions returns itself (lower-cased) as a single element.
+    """
+    if not token:
+        return []
+    parts: list[str] = []
+    start = 0
+    for i in range(1, len(token)):
+        if token[i].isupper() and token[i - 1].islower():
+            parts.append(token[start:i])
+            start = i
+    parts.append(token[start:])
+    return [p.lower() for p in parts if p]
+
+
+def _lookup_token(word: str) -> str | None:
+    """Look up a single lower-case word in _CATEGORY_MAP with plural fallback.
+
+    Tries the word as-is, then strips a trailing "s" (bricks -> brick,
+    rocks -> rock, tiles -> tile, fabrics -> fabric, leaves unchanged
+    if <=2 chars so we don't match empty strings or single letters).
+    Deterministic: no fuzzy matching.
+    """
+    if not word:
+        return None
+    if word in _CATEGORY_MAP:
+        return _CATEGORY_MAP[word]
+    if len(word) > 2 and word.endswith("s"):
+        stem = word[:-1]
+        if stem in _CATEGORY_MAP:
+            return _CATEGORY_MAP[stem]
+    return None
+
+
 def normalize_category(raw: str) -> str:
-    """Map a freeform upstream category to one of the 10 canonical categories."""
+    """Map a freeform upstream category to one of the 10 canonical categories.
+
+    Handles:
+      - Hierarchical paths ("Metal/Steel" -> first segment)
+      - Plurals ("Bricks" -> brick -> ceramic; "Rocks" -> rock -> stone)
+      - Multi-word display strings ("Brick Wall", "Interior Flooring")
+      - CamelCase run-ons ("WoodFloor", "PaintedPlaster", "BaseMaterials")
+      - dash / underscore separators
+
+    Deterministic only — no fuzzy / Levenshtein matching (see mat-vis#150).
+    Unmatched inputs fall through to "other".
+    """
     if not raw:
         return "other"
-    # ambientcg uses hierarchical like "Metal/Steel" — take first segment
-    first = raw.split("/")[0].strip().lower()
-    if first in _CATEGORY_MAP:
-        return _CATEGORY_MAP[first]
-    # try individual words
-    for word in first.split():
-        if word in _CATEGORY_MAP:
-            return _CATEGORY_MAP[word]
+    # ambientcg uses hierarchical like "Metal/Steel" — take first segment.
+    # Preserve original casing so we can split CamelCase afterwards.
+    first_cased = raw.split("/")[0].strip()
+    first = first_cased.lower()
+    # Fast path: whole-segment match (covers legacy behavior).
+    hit = _lookup_token(first)
+    if hit is not None:
+        return hit
+    # Split on delimiters, then CamelCase-split each token. Try each
+    # resulting sub-word against the keyword map (with plural fallback).
+    # Known fall-throughs that intentionally stay "other":
+    #   - "Liquid", "Manmade" (physicallybased): too broad / not a PBR class
+    #   - "Human" (physicallybased): skin/hair isn't "organic" vegetation
+    #   - "Atlas", "Decal", "Sign", "OnlyPBR" (ambientcg): meta/format tags
+    #   - "SciFi" (gpuopen): stylistic, not a material
+    #   - "Facade", "Roofing", "Wallpaper", "Interior Flooring",
+    #     "Base Materials" (gpuopen/ambientcg): multi-material contexts
+    #     with no single canonical home — mapping them would be wrong.
+    for delim_token in _tokenize_category(first_cased):
+        for sub in _split_camel(delim_token):
+            hit = _lookup_token(sub)
+            if hit is not None:
+                return hit
     return "other"
 
 

--- a/tests/test_normalize_category.py
+++ b/tests/test_normalize_category.py
@@ -1,0 +1,172 @@
+"""Regression tests for mat_vis_baker.common.normalize_category.
+
+Covers the bug in mat-vis#150 where ~40% of real upstream categories
+collapsed to "other" because _CATEGORY_MAP only contained singular
+forms. Inputs below are sampled verbatim from the four upstream
+sources' live responses (audit in mat-vis#152).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mat_vis_baker.common import normalize_category
+
+
+# ── the exact reproducer from the issue ─────────────────────────
+
+
+class TestIssue150Reproducer:
+    def test_bricks_plural(self):
+        assert normalize_category("Bricks") == "ceramic"
+
+    def test_rocks_plural(self):
+        assert normalize_category("Rocks") == "stone"
+
+
+# ── plural stripping (core fix) ─────────────────────────────────
+
+
+class TestPluralStripping:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("Bricks", "ceramic"),
+            ("Tiles", "ceramic"),
+            ("Rocks", "stone"),
+            ("Fabrics", "fabric"),
+            ("Metals", "metal"),
+            ("Woods", "wood"),
+            ("Stones", "stone"),
+            ("Plastics", "plastic"),
+            ("Leaves", "organic"),  # already in map as plural, must still work
+        ],
+    )
+    def test_plural_forms_map_to_canonical(self, raw: str, expected: str) -> None:
+        assert normalize_category(raw) == expected
+
+    def test_short_words_not_over_stripped(self):
+        # 2-char words ending in "s" must not have "s" stripped (would
+        # produce empty / 1-char garbage lookups). "as" -> would strip
+        # to "a" which isn't in the map; must fall through to "other".
+        assert normalize_category("as") == "other"
+        assert normalize_category("is") == "other"
+
+
+# ── CamelCase + multi-word display strings ──────────────────────
+
+
+class TestCamelCaseAndMultiWord:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            # ambientcg real display categories
+            ("WoodFloor", "wood"),
+            ("PaintedPlaster", "concrete"),  # plaster is already canonical concrete
+            ("Terrazzo", "concrete"),
+            ("Paving", "concrete"),
+            # gpuopen real display categories
+            ("Brick Wall", "ceramic"),
+            ("Interior Wood", "wood"),  # synthetic but plausible — word-split still works
+            ("Stone Wall", "stone"),
+            ("Metal Plates", "metal"),
+        ],
+    )
+    def test_multi_word_and_camel(self, raw: str, expected: str) -> None:
+        assert normalize_category(raw) == expected
+
+
+# ── audit sweep: real strings from the four upstream sources ────
+
+
+class TestAuditSweep:
+    """Real inputs sampled from mat-vis#152's live audit.
+
+    Each case is tagged with its source in the parametrize id so a
+    failure message points straight at the offender.
+    """
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            # ── ambientcg browse taxonomy (23 entries; 10 were broken) ──
+            ("Atlas", "other"),  # meta/format tag — intentional other
+            ("Bricks", "ceramic"),  # was "other"
+            ("Concrete", "concrete"),
+            ("Decal", "other"),  # meta/format tag — intentional other
+            ("Fabric", "fabric"),
+            ("Facade", "other"),  # multi-material context — intentional other
+            ("Ground", "organic"),
+            ("Marble", "stone"),
+            ("Metal", "metal"),
+            ("OnlyPBR", "other"),  # meta/format tag — intentional other
+            ("PaintedPlaster", "concrete"),  # was "other"
+            ("Paving", "concrete"),  # was "other"
+            ("Plaster", "concrete"),
+            ("Rocks", "stone"),  # was "other"
+            ("Sign", "other"),  # meta/format tag — intentional other
+            ("Terrazzo", "concrete"),  # was "other"
+            ("Tiles", "ceramic"),  # was "other"
+            ("Wood", "wood"),
+            ("WoodFloor", "wood"),  # was "other"
+            # ── physicallybased (8 top-level cats; 3 intentionally other) ──
+            ("Liquid", "other"),  # not a PBR class — intentional other
+            ("Manmade", "other"),  # too broad — intentional other
+            ("Human", "other"),  # skin/hair isn't organic vegetation
+            ("Wood", "wood"),
+            ("Metal", "metal"),
+            # ── gpuopen real display categories (5 were broken) ──
+            ("Interior Flooring", "other"),  # multi-material — intentional other
+            ("SciFi", "other"),  # stylistic — intentional other
+            ("Wallpaper", "other"),  # multi-material — intentional other
+            ("Roofing", "other"),  # multi-material — intentional other
+            ("Base Materials", "other"),  # meta-collection — intentional other
+        ],
+    )
+    def test_audit_inputs(self, raw: str, expected: str) -> None:
+        assert normalize_category(raw) == expected, (
+            f"{raw!r} -> {normalize_category(raw)!r}, expected {expected!r}"
+        )
+
+
+# ── no regressions against the pre-existing test_common.py cases ─
+
+
+class TestNoRegressions:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("Metal/Steel", "metal"),  # hierarchical first segment
+            ("Wood", "wood"),
+            ("Stone/Marble/White", "stone"),
+            ("FooBarBaz", "other"),
+            ("", "other"),
+            ("CONCRETE", "concrete"),  # case insensitive
+            ("Soil", "organic"),
+            # lower-case plain
+            ("metal", "metal"),
+            ("ceramic", "ceramic"),
+            ("glass", "glass"),
+            ("fabric", "fabric"),
+            ("plastic", "plastic"),
+        ],
+    )
+    def test_no_regression(self, raw: str, expected: str) -> None:
+        assert normalize_category(raw) == expected
+
+
+# ── delimiters: dashes, underscores ─────────────────────────────
+
+
+class TestDelimiters:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("wood-floor", "wood"),
+            ("wood_floor", "wood"),
+            ("brick_wall", "ceramic"),
+            ("painted-plaster", "concrete"),
+        ],
+    )
+    def test_delimiters(self, raw: str, expected: str) -> None:
+        assert normalize_category(raw) == expected


### PR DESCRIPTION
## Summary

Fixes mat-vis#150. `normalize_category` collapsed ~40% of real upstream display categories to `"other"` because `_CATEGORY_MAP` only contained singular keywords. Upstream APIs routinely return plurals (`Bricks`, `Rocks`, `Tiles`, `Fabrics`), CamelCase run-ons (`WoodFloor`, `PaintedPlaster`), and multi-word display strings (`Brick Wall`, `Interior Flooring`).

- Extend `_CATEGORY_MAP` under `concrete` with `paving` and `terrazzo` (the only new keyword additions — every other fix comes from improved tokenization, not map growth).
- Harden `normalize_category` with deterministic token-splitting: delimiter split (dashes / underscores / spaces), CamelCase split, and a per-sub-word trailing-`s` plural fallback. No fuzzy / Levenshtein matching (per the issue: "Keep it deterministic").
- Add `tests/test_normalize_category.py` with 65 cases: the exact issue reproducer, plural/CamelCase/delimiter coverage, a ~30-input audit sweep quoted verbatim from the four upstream sources (mat-vis#152), and no-regression assertions against the pre-existing `tests/test_common.py` cases.

### Intentional `"other"` fall-throughs

Documented inline in both `common.py` and the test file — these are not bugs:

| input | source | why |
|---|---|---|
| `Liquid`, `Manmade` | physicallybased | too broad / not a PBR material class |
| `Human` | physicallybased | skin/hair isn't vegetation-style `"organic"` |
| `Atlas`, `Decal`, `Sign`, `OnlyPBR` | ambientcg | meta/format tags, not materials |
| `SciFi` | gpuopen | stylistic, not a material |
| `Facade`, `Roofing`, `Wallpaper`, `Interior Flooring`, `Base Materials` | gpuopen/ambientcg | span multiple materials — forcing a canonical home would be wrong |

## Test plan

- [x] `uv run --with pytest pytest tests/test_normalize_category.py -v` → 65 passed
- [x] `uv run --with pytest pytest tests/test_common.py -v` → no regressions
- [x] `uv run --with pytest pytest tests/` → 214 passed
- [x] `uv run --with ruff ruff check src/mat_vis_baker/common.py tests/test_normalize_category.py` → clean
- [x] `uv run --with ruff ruff format --check ...` → clean
- [x] Issue reproducer: `normalize_category("Bricks") == "ceramic"` and `normalize_category("Rocks") == "stone"`

Refs mat-vis#150, mat-vis#152 (audit).