### PR TITLE
feat(ci): OTLP spans from Dagger + baker → grafana/otel-lgtm (#139)

### DIFF
--- a/.github/actions/otlp-tailnet/action.yml
+++ b/.github/actions/otlp-tailnet/action.yml
@@ -1,0 +1,89 @@
+---
+# Join the operator's tailnet and export OTEL_EXPORTER_OTLP_ENDPOINT so
+# every subsequent step in the job (including Dagger engine + baker
+# Python process) emits OTLP spans to the operator's self-hosted
+# grafana/otel-lgtm without a public endpoint.
+#
+# NOT wired into derive.yml / bake.yml by default — per
+# docs/observability.md, the OTLP collector + Tailscale tailnet are
+# operator-provided; enabling this action is opt-in.
+#
+# Usage (add as the first step before `uv run mat-vis-baker …` /
+# `dagger call …`):
+#
+#   - name: Join tailnet + export OTLP endpoint
+#     uses: ./.github/actions/otlp-tailnet
+#     with:
+#       hostname: otel.tail-abc123.ts.net
+#       port: "4318"
+#     env:
+#       TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
+#
+# After this step, `OTEL_EXPORTER_OTLP_ENDPOINT` is set on
+# `$GITHUB_ENV` for the rest of the job. Dagger's engine reads it
+# natively (emitting one span per `dagger call` + per container op)
+# and the baker's OTel SDK picks it up via
+# src/mat_vis_baker/telemetry.py (opt-in, no-op otherwise).
+#
+# Teardown: the tailscale/github-action handles disconnection when the
+# job ends — nothing to clean up here.
+
+name: Join tailnet + export OTLP endpoint
+description: >-
+  Authenticate to the operator's tailnet via TS_AUTHKEY and export
+  OTEL_EXPORTER_OTLP_ENDPOINT so Dagger + baker spans flow to the
+  self-hosted grafana/otel-lgtm collector on that tailnet host.
+
+inputs:
+  hostname:
+    description: >-
+      Tailnet hostname of the OTLP collector, e.g.
+      `otel.tail-abc123.ts.net`. Operator-specific; no default.
+    required: true
+  port:
+    description: OTLP/HTTP port on the collector. grafana/otel-lgtm defaults to 4318.
+    required: false
+    default: "4318"
+  scheme:
+    description: >-
+      `http` (default — tailnet traffic is already WireGuard-encrypted
+      end-to-end) or `https` if the operator put TLS in front of the
+      collector (tailscale serve, reverse proxy).
+    required: false
+    default: "http"
+  tags:
+    description: >-
+      Comma-separated tailscale ACL tags applied to the ephemeral
+      runner node. Keep narrow (e.g. `tag:ci`) so ACLs can restrict
+      CI-originated traffic.
+    required: false
+    default: "tag:ci"
+
+runs:
+  using: composite
+  steps:
+    - name: Join tailnet
+      uses: tailscale/github-action@v2
+      with:
+        authkey: ${{ env.TS_AUTHKEY }}
+        tags: ${{ inputs.tags }}
+
+    - name: Export OTEL_EXPORTER_OTLP_ENDPOINT
+      shell: bash
+      env:
+        HOSTNAME: ${{ inputs.hostname }}
+        PORT: ${{ inputs.port }}
+        SCHEME: ${{ inputs.scheme }}
+      run: |
+        set -euo pipefail
+        endpoint="${SCHEME}://${HOSTNAME}:${PORT}"
+        echo "OTEL_EXPORTER_OTLP_ENDPOINT=${endpoint}" >> "${GITHUB_ENV}"
+        # Diagnostic: confirm reachability before workload runs. A
+        # failure here is almost always "tailnet ACL blocks runner"
+        # or "collector down" — fail fast with a clear signal.
+        if ! curl -fsS --max-time 5 -o /dev/null -w '%{http_code}\n' \
+             "${endpoint}/v1/traces" -X POST \
+             -H 'content-type: application/json' -d '{"resourceSpans":[]}'; then
+          echo "::warning::OTLP endpoint ${endpoint} not reachable from runner — spans will be dropped. Check tailnet ACLs + collector health."
+        fi
+        echo "OTLP endpoint wired: ${endpoint}"

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -18,6 +18,41 @@ One image: Grafana + Tempo (traces) + Loki (logs) + Mimir/Prometheus
 (metrics). Open <http://localhost:3000>, default login
 `admin` / `admin`.
 
+### Import the committed dashboard
+
+The canonical pipeline dashboard ships with the repo:
+
+- [`docs/observability/dashboard.json`](./observability/dashboard.json)
+
+Import via **Dashboards → New → Import → Upload JSON file**, or via
+the API:
+
+```bash
+curl -s -u admin:admin -H 'Content-Type: application/json' \
+  -X POST http://localhost:3000/api/dashboards/import \
+  -d "$(jq '{dashboard: ., overwrite: true, inputs: [], folderUid: ""}' \
+        docs/observability/dashboard.json)"
+```
+
+Panels:
+
+- **Shard pipeline** — `stream.transform` root spans from
+  `service.name=mat-vis-baker` with `label`, `n_total`, `max_workers`,
+  `shard_index`, `shard_total`, `outcome`, `n_ok`, `n_failed` as
+  columns; `n_failed` colour-coded, `outcome` mapped
+  `ok`/`fail_fast`.
+- **Progress events** — 30-s rolling `progress` span events
+  (`n_ok` / `n_failed` / `rate_per_s`) as a table. Narrow the time
+  picker to one trace window to watch a single run.
+- **Dagger pipeline** — spans from `service.name~="dagger.*"` (Dagger
+  engine emits these natively when `OTEL_EXPORTER_OTLP_ENDPOINT` is
+  set). Shows container builds + function invocations surrounding
+  the baker spans.
+
+Tested against `grafana/otel-lgtm:latest` (Grafana 12.4, Tempo
+default datasource `uid=tempo`). Dashboard pinned to schemaVersion
+39 for backwards compatibility with Grafana 10.4+/11.x/12.x.
+
 ## Point the baker at it
 
 Install the extra:
@@ -48,17 +83,35 @@ Host machine (laptop, Pi, home server) on your tailnet:
 tailscale serve --bg --https=3000 http://localhost:3000
 ```
 
-Grab the tailnet hostname (`otel.tail-xxx.ts.net`). In the workflow:
+Grab the tailnet hostname (`otel.tail-xxx.ts.net`). Use the
+repo-local composite action
+[`./.github/actions/otlp-tailnet`](../.github/actions/otlp-tailnet/action.yml)
+which wraps the tailnet join + endpoint export:
 
 ```yaml
-- uses: tailscale/github-action@v2
+- name: Join tailnet + export OTLP endpoint
+  uses: ./.github/actions/otlp-tailnet
   with:
-    authkey: ${{ secrets.TS_AUTHKEY }}
-    tags: tag:ci
-- run: |
-    export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel.tail-xxx.ts.net:4318
-    mat-vis-baker hf-derive ...
+    hostname: otel.tail-xxx.ts.net
+    port: "4318"
+  env:
+    TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
+
+- run: uv run mat-vis-baker hf-derive ...   # spans flow automatically
+- run: dagger call integration-test ...     # Dagger engine spans too
 ```
+
+After the step runs, `OTEL_EXPORTER_OTLP_ENDPOINT` is exported to
+`$GITHUB_ENV` for the rest of the job — Dagger's engine picks it up
+natively (one span per `dagger call` + per container op) and the
+baker's OTel SDK picks it up via `src/mat_vis_baker/telemetry.py`.
+The action also probes `/v1/traces` so a blocked tailnet ACL or
+down collector surfaces as a step warning instead of silently
+dropped spans.
+
+The action is **not** wired into `derive.yml` / `bake.yml` — those
+workflows stay operator-agnostic. Drop the step into a fork /
+override workflow if you want CI spans.
 
 The runner joins your tailnet briefly, emits spans, leaves. No
 public endpoint, no inbound firewall holes.
@@ -81,6 +134,10 @@ debugging; not an audit trail).
 
 - ADR-0009: derive pipeline decisions (fail-fast, sliding window,
   telemetry hooks).
+- ADR-0010: full-pipeline observability (Dagger + baker → same
+  OTLP collector).
 - Issue #131: full self-host spec.
 - Issue #129: Dagger pipeline (optional, emits to the same OTLP
   receiver).
+- Issue #139: this wiring — committed Grafana dashboard + reusable
+  Tailscale composite action.

--- a/docs/observability/dashboard.json
+++ b/docs/observability/dashboard.json
@@ -1,0 +1,269 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "End-to-end OTLP view of the mat-vis pipeline: Dagger engine spans around baker stream.transform spans, with a progress-event log. Imports into grafana/otel-lgtm out of the box (Tempo datasource uid=tempo).",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "docs/observability.md",
+      "tooltip": "Operator runbook for this dashboard",
+      "type": "link",
+      "url": "https://github.com/MorePET/mat-vis/blob/dev/docs/observability.md"
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 100,
+      "panels": [],
+      "title": "Shard pipeline — baker stream.transform roots",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "tempo", "uid": "tempo"},
+      "description": "Root `stream.transform` spans emitted by mat-vis-baker, one per derive run (or one per shard when sharded). Columns surface the shard + ok/failed attrs so operators can scan runs at a glance.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "custom": {
+            "align": "auto",
+            "cellOptions": {"type": "auto"},
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 1}
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {"id": "byName", "options": "outcome"},
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {"type": "value", "options": {"ok": {"color": "green", "index": 0, "text": "ok"}}},
+                  {"type": "value", "options": {"fail_fast": {"color": "red", "index": 1, "text": "fail_fast"}}}
+                ]
+              },
+              {"id": "custom.cellOptions", "value": {"type": "color-text"}}
+            ]
+          },
+          {
+            "matcher": {"id": "byName", "options": "n_failed"},
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {"color": "green", "value": null},
+                    {"color": "orange", "value": 1},
+                    {"color": "red", "value": 10}
+                  ]
+                }
+              },
+              {"id": "custom.cellOptions", "value": {"type": "color-background"}}
+            ]
+          }
+        ]
+      },
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 1},
+      "id": 1,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {"type": "tempo", "uid": "tempo"},
+          "filters": [
+            {
+              "id": "service-name",
+              "operator": "=",
+              "scope": "resource",
+              "tag": "service.name",
+              "value": "mat-vis-baker",
+              "valueType": "string"
+            },
+            {
+              "id": "span-name",
+              "operator": "=",
+              "scope": "span",
+              "tag": "name",
+              "value": "stream.transform",
+              "valueType": "string"
+            }
+          ],
+          "groupBy": [],
+          "limit": 50,
+          "query": "{ resource.service.name=\"mat-vis-baker\" && name=\"stream.transform\" } | select(span.label, span.n_total, span.max_workers, span.shard_index, span.shard_total, span.outcome, span.n_ok, span.n_failed)",
+          "queryType": "traceql",
+          "refId": "A",
+          "tableType": "traces"
+        }
+      ],
+      "title": "stream.transform roots (service.name=mat-vis-baker)",
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 11},
+      "id": 200,
+      "panels": [],
+      "title": "Progress events — 30s rolling counters",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "tempo", "uid": "tempo"},
+      "description": "Span events named `progress` attached to `stream.transform` spans — emitted every ~30s with rolling n_ok, n_failed, rate_per_s. Use the time filter to narrow to a single run.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "align": "auto",
+            "cellOptions": {"type": "auto"},
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{"color": "green", "value": null}]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 12},
+      "id": 2,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {"type": "tempo", "uid": "tempo"},
+          "filters": [],
+          "groupBy": [],
+          "limit": 200,
+          "query": "{ resource.service.name=\"mat-vis-baker\" && event:name=\"progress\" } | select(span.label, event:name, event:n_ok, event:n_failed, event:rate_per_s)",
+          "queryType": "traceql",
+          "refId": "A",
+          "tableType": "spans"
+        }
+      ],
+      "title": "progress events (n_ok / n_failed / rate_per_s)",
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 22},
+      "id": 300,
+      "panels": [],
+      "title": "Dagger pipeline — container builds + function invocations",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "tempo", "uid": "tempo"},
+      "description": "Dagger engine spans around the baker — one span per `dagger call` function + per container op. service.name is `dagger-cli` in recent Dagger releases; falls back to `dagger` for older engines.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "custom": {
+            "align": "auto",
+            "cellOptions": {"type": "auto"},
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{"color": "green", "value": null}]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 23},
+      "id": 3,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {"type": "tempo", "uid": "tempo"},
+          "filters": [],
+          "groupBy": [],
+          "limit": 100,
+          "query": "{ resource.service.name=~\"dagger.*\" }",
+          "queryType": "traceql",
+          "refId": "A",
+          "tableType": "traces"
+        }
+      ],
+      "title": "Dagger engine spans (service.name ~= dagger*)",
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["mat-vis", "otlp", "baker", "dagger"],
+  "templating": {"list": []},
+  "time": {"from": "now-24h", "to": "now"},
+  "timepicker": {
+    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"]
+  },
+  "timezone": "browser",
+  "title": "mat-vis — Dagger + baker OTLP",
+  "uid": "mat-vis-otlp",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
Closes #139. Picks up where #132 left off (baker-only OpenTelemetry) and completes the full-pipeline observability called out in ADR-0010.

## Summary

- **`docs/observability/dashboard.json`** — committed Grafana dashboard (schemaVersion 39, tested against `grafana/otel-lgtm:latest` = Grafana 12.4). Three rows:
  - **Shard pipeline** — `stream.transform` root spans from `service.name=mat-vis-baker` with `label`, `n_total`, `max_workers`, `shard_index`, `shard_total`, `outcome`, `n_ok`, `n_failed` as columns. `n_failed` colour-coded (green → orange at 1 → red at 10); `outcome` value-mapped (`ok` green, `fail_fast` red).
  - **Progress events** — 30-s rolling `progress` span events (`n_ok` / `n_failed` / `rate_per_s`) as a table.
  - **Dagger pipeline** — spans from `service.name~="dagger.*"` so container builds + function invocations surround the baker spans.
  - 24h default range, 30s refresh, uid `mat-vis-otlp`.
- **`.github/actions/otlp-tailnet/action.yml`** — reusable composite action. Joins the operator's tailnet via `tailscale/github-action@v2` with `TS_AUTHKEY`, then exports `OTEL_EXPORTER_OTLP_ENDPOINT` to `$GITHUB_ENV` for every subsequent step. Dagger's engine picks it up natively; the baker's SDK picks it up via `src/mat_vis_baker/telemetry.py`. Probes `/v1/traces` so a blocked ACL / down collector surfaces as a step warning instead of silently dropped spans.
- **`docs/observability.md`** — links the dashboard JSON, the composite action, ADR-0010, #139.

## What's NOT in this PR

- **`derive.yml` / `bake.yml` are untouched.** Per `docs/observability.md`, the Tailscale path is operator opt-in — the repo doesn't own `TS_AUTHKEY` or the collector host. Operators drop the step into a fork / override workflow.

## Test plan

- [x] Dashboard JSON imports cleanly into `grafana/otel-lgtm:latest` via the `/api/dashboards/import` endpoint (verified locally — all 6 panels present post-migration, queries intact, no warnings).
- [x] `yamllint --strict` + full `pre-commit run` passes on changed files.
- [x] Panel TraceQL queries match the attrs emitted by `hf_derive.py` (`stream.transform` span attrs + `progress` events) — confirmed against `src/mat_vis_baker/hf_derive.py:195-253`.
- [ ] Tailscale action verified end-to-end on a real tailnet (NOT done — action is YAML skeleton + embedded reachability probe; no live `TS_AUTHKEY` available in this environment).
- [ ] Follow-up: operator smoke-test with `TS_AUTHKEY` + a real `grafana/otel-lgtm` host on tailnet to confirm the CI path before advertising it in release notes.

## Notes

- Dashboard pinned to **schemaVersion 39** — safe for Grafana 10.4+ through 12.x. Tested against 12.4.2 which kept the version unchanged through its migrator. Future Grafana majors may bump the schema; if so, re-export and commit the migrated JSON rather than cherry-picking new fields.
- ADR-0010 lives in PR #148 (not yet merged to `dev`); the docs reference is forward-looking but will resolve once #148 lands.