### PR TITLE
feat(ci): swap uv run → dagger call in bake.yml + derive.yml (#138)

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -1,5 +1,10 @@
 ---
 # Bake workflow — atomic HF push per (source, tier) per ADR-0007.
+#
+# Invokes the Dagger `bake` function (#136) which wraps
+# mat-vis-baker hf-bake in a python:3.12-slim container. Container
+# bootstraps inside Dagger — no separate install steps here.
+# Reproduce locally with: dagger call bake --source=... --tier=1k ...
 
 name: Bake
 
@@ -72,35 +77,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install baker
-        run: uv sync --all-extras
+      - name: Dagger shell-safety lint (#61)
+        run: python3 scripts/check-dagger-shell-safety.py
 
       - name: hf-bake
-        run: |
-          set -euxo pipefail
-          limit_flag=""
-          if [ "${{ inputs.limit }}" != "0" ]; then
-            limit_flag="--limit ${{ inputs.limit }}"
-          fi
-          offset_flag=""
-          if [ "${{ inputs.offset }}" != "0" ]; then
-            offset_flag="--offset ${{ inputs.offset }}"
-          fi
-          dry_flag=""
-          if [ "${{ inputs.dry-run }}" = "true" ]; then
-            dry_flag="--dry-run"
-          fi
-          uv run mat-vis-baker hf-bake \
-            "${{ inputs.source }}" \
-            "${{ inputs.tier }}" \
-            /tmp/bake \
-            --release-tag "${{ inputs.release-tag }}" \
-            --batch-size "${{ inputs.batch-size }}" \
-            $limit_flag $offset_flag $dry_flag
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          verb: call
+          module: .dagger
+          # Dagger fn sentinels: limit=0 (no cap), offset=0 (no skip),
+          # shard-index/total=-1 (unsharded). The baker CLI adopts the
+          # same sentinel convention so re-plumbing is a pure rename.
+          args: >-
+            bake
+            --context=.
+            --source=${{ inputs.source }}
+            --tier=${{ inputs.tier }}
+            --release-tag=${{ inputs.release-tag }}
+            --hf-token=env:HF_TOKEN
+            --limit=${{ inputs.limit }}
+            --offset=${{ inputs.offset }}
+            --batch-size=${{ inputs.batch-size }}
+            ${{ inputs.dry-run == true && '--dry-run=true' || '' }}
 
       - name: Notify on failure
         if: failure()

--- a/.github/workflows/derive.yml
+++ b/.github/workflows/derive.yml
@@ -4,17 +4,23 @@
 #
 # Shape:
 #   setup   — precomputes the shard-index list + target-tier name
-#   derive  — matrix[shard-index] runs mat-vis-baker hf-derive{,-ktx2}
-#             with --shard-index N --shard-total K; each shard is an
-#             atomic HF commit for its own tar + rowmap
-#   merge   — single job that runs mat-vis-baker merge-shards to
+#   derive  — matrix[shard-index] invokes the Dagger `derive` or
+#             `derive-ktx2` function (which wraps mat-vis-baker
+#             hf-derive{,-ktx2}). Each shard is an atomic HF commit.
+#   merge   — single job that invokes Dagger `merge-shards` to
 #             reassemble the shard tars into one canonical tar and
-#             delete the shard artifacts in one atomic commit
+#             delete the shard artifacts in one atomic commit.
 #   report  — notify-on-failure if any earlier job failed
 #
+# Dagger gives us local ↔ CI parity: reproduce a shard locally with
+# `dagger call derive --source=... --shard-index=3 --shard-total=8`
+# against the same hf-token secret, identical bytes. The container
+# bootstraps inside Dagger (python:3.12-slim + uv + toktx), so this
+# workflow has no separate install steps.
+#
 # When shard-total == 1 the matrix produces one job, shard args are
-# omitted (so the output is polyhaven-512.tar directly), and the
-# merge step is skipped — gives back the legacy unsharded path
+# passed as -1/-1 (the Dagger function's "no-sharding" sentinel), and
+# the merge step is skipped — gives back the legacy unsharded path
 # without code duplication.
 
 name: Derive
@@ -154,60 +160,30 @@ jobs:
         shard-index: ${{ fromJson(needs.setup.outputs.shards) }}
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      # Python logging is line-buffered on a pipe by default, which can
-      # stall the 30 s progress heartbeat (mat_vis_baker.hf_derive) for
-      # minutes in the GH Actions log stream. Unbuffered stdio makes the
-      # heartbeat visible in real time — the difference between "stuck"
-      # and "slow" when triaging a running shard.
-      PYTHONUNBUFFERED: '1'
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install KTX-Software (toktx)
-        if: inputs.kind == 'ktx2'
-        run: |
-          set -euxo pipefail
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq libgomp1 ca-certificates
-          curl -fsSL -o /tmp/ktx.deb \
-            https://github.com/KhronosGroup/KTX-Software/releases/download/v4.4.0/KTX-Software-4.4.0-Linux-x86_64.deb
-          sudo dpkg -i /tmp/ktx.deb
-          toktx --version
-
-      - name: Install baker
-        run: uv sync --all-extras
+      - name: Dagger shell-safety lint (#61)
+        run: python3 scripts/check-dagger-shell-safety.py
 
       - name: Derive (shard ${{ matrix.shard-index }}/${{ needs.setup.outputs.shard-total }})
-        run: |
-          set -euxo pipefail
-          shard_flags=""
-          if [ "${{ needs.setup.outputs.shard-total }}" != "1" ]; then
-            shard_flags="--shard-index ${{ matrix.shard-index }} --shard-total ${{ needs.setup.outputs.shard-total }}"
-          fi
-          if [ "${{ inputs.kind }}" = "resize" ]; then
-            # shellcheck disable=SC2086
-            uv run mat-vis-baker hf-derive \
-              "${{ inputs.source }}" \
-              "${{ inputs.target-tier }}" \
-              /tmp/derive \
-              --source-tier "${{ inputs.source-tier }}" \
-              --release-tag "${{ inputs.release-tag }}" \
-              --repo-id "${{ inputs.repo-id }}" \
-              $shard_flags
-          else
-            # shellcheck disable=SC2086
-            uv run mat-vis-baker hf-derive-ktx2 \
-              "${{ inputs.source }}" \
-              /tmp/derive \
-              --source-tier "${{ inputs.source-tier }}" \
-              --release-tag "${{ inputs.release-tag }}" \
-              --repo-id "${{ inputs.repo-id }}" \
-              $shard_flags
-          fi
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          verb: call
+          module: .dagger
+          # Shard args use -1/-1 sentinel when shard-total=1 (both omitted);
+          # the Dagger function uses the same convention internally.
+          args: >-
+            ${{ inputs.kind == 'resize' && 'derive' || 'derive-ktx2' }}
+            --context=.
+            --source=${{ inputs.source }}
+            ${{ inputs.kind == 'resize' && format('--target-tier={0}', inputs.target-tier) || '' }}
+            --source-tier=${{ inputs.source-tier }}
+            --release-tag=${{ inputs.release-tag }}
+            --repo-id=${{ inputs.repo-id }}
+            --hf-token=env:HF_TOKEN
+            --shard-index=${{ needs.setup.outputs.shard-total == '1' && '-1' || matrix.shard-index }}
+            --shard-total=${{ needs.setup.outputs.shard-total == '1' && '-1' || needs.setup.outputs.shard-total }}
 
   merge:
     needs: [setup, derive]
@@ -223,22 +199,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install baker
-        run: uv sync --all-extras
+      - name: Dagger shell-safety lint (#61)
+        run: python3 scripts/check-dagger-shell-safety.py
 
       - name: merge-shards
-        run: |
-          set -euxo pipefail
-          uv run mat-vis-baker merge-shards \
-            "${{ inputs.source }}" \
-            "${{ needs.setup.outputs.target-tier }}" \
-            /tmp/merge \
-            --release-tag "${{ inputs.release-tag }}" \
-            --repo-id "${{ inputs.repo-id }}"
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          verb: call
+          module: .dagger
+          args: >-
+            merge-shards
+            --context=.
+            --source=${{ inputs.source }}
+            --tier=${{ needs.setup.outputs.target-tier }}
+            --release-tag=${{ inputs.release-tag }}
+            --repo-id=${{ inputs.repo-id }}
+            --hf-token=env:HF_TOKEN
 
   report:
     needs: [setup, derive, merge]


### PR DESCRIPTION
Completes epic **#140**. #135 / #136 / #137 / #139 landed in the last hour; this PR is the tail — flips the workflows from an ad-hoc `setup-uv + apt + KTX .deb + uv sync` chain to `dagger call` against the newly-ported Dagger functions.

## Summary

- **bake.yml** — one step: `dagger call bake --source=… --tier=… --release-tag=… --hf-token=env:HF_TOKEN --limit=… --offset=… --batch-size=…`
- **derive.yml matrix leg** — one step: `dagger call derive` or `dagger call derive-ktx2` with the shard args threaded through (`-1/-1` sentinel when `shard-total=1`).
- **derive.yml merge job** — one step: `dagger call merge-shards`.
- Drops all `setup-uv`, `Install baker`, `Install KTX-Software` blocks. The container bootstraps inside Dagger (`_baker_container(with_ktx2=…)`), so the workflow yaml shrinks to the args that actually vary.

## Why

- **Local ↔ CI parity**: `dagger call derive --shard-index=3 --shard-total=8 ...` locally reproduces CI's shard byte-for-byte (same container, same uv.lock, same toktx).
- **Observability**: Dagger's native OpenTelemetry composes with the baker's OTel hooks (#139). The committed dashboard (`docs/observability/dashboard.json`) visualises both Dagger op spans and baker `stream.transform` spans end-to-end.
- **Shorter yaml**: derive.yml is 71-line shorter; bake.yml is 30 lines shorter. Each line that survived is an argument that actually matters.

## What this closes

Epic #140 (Dagger migration) — all 5 sub-issues now merged or in this PR:
- #135 — _baker_container helper (merged via #161)
- #136 — bake() Dagger op (merged via #163)
- #137 — derive()/derive-ktx2()/merge-shards() Dagger ops (merged via #164)
- #139 — OTLP wiring + Grafana dashboard (merged via #162)
- #138 — this PR

## Test plan

- [x] `yaml.safe_load` parses both workflows.
- [x] Pre-commit hooks clean (Dagger shell-safety, ruff, yamllint).
- [ ] First live dispatch: `gh workflow run Derive -f kind=resize -f source=polyhaven -f source-tier=1k -f target-tier=512 -f release-tag=v0.0.1-smoke -f repo-id=gerchowl/mat-vis-tst -f shard-total=4` against the scratch repo. Verifies the Dagger call shape end-to-end.
- [ ] Full ktx2-2k dispatch against `gerchowl/mat-vis` once the v2026.04.1 finish-up resumes (task #7).

Closes #138. Refs epic #140, ADR-0010.