### PR TITLE
feat: Phase B — populate mat_vis curated fields from upstreams (#152)

### DIFF
--- a/src/mat_vis_baker/sources/ambientcg.py
+++ b/src/mat_vis_baker/sources/ambientcg.py
@@ -16,10 +16,12 @@ from pathlib import Path
 import requests
 
 from mat_vis_baker.common import (
+    TIER_TO_PX,
     AttributionBlock,
     DatesBlock,
     MaterialRecord,
     MatVisBlock,
+    PhysicalBlock,
     check_zip_safety,
     normalize_category,
     normalize_channel,
@@ -163,6 +165,43 @@ def _extract_maps_from_zip(
     return result
 
 
+# ── curated-field extraction (Phase B, mat-vis#152) ─────────────
+
+
+def _dimensions_m(entry: dict) -> list[float | None] | None:
+    """Extract ``[x, y, z]`` in metres from upstream mm values.
+
+    ambientcg exposes ``dimensionX / dimensionY / dimensionZ`` in millimetres.
+    Convert to metres; treat ``0`` as "unknown" (not a real zero-thickness
+    material). If all three are missing entirely, return ``None`` so the
+    whole ``physical.dimensions_m`` field is null rather than ``[None, None, None]``.
+    """
+    keys = ("dimensionX", "dimensionY", "dimensionZ")
+    if not any(k in entry for k in keys):
+        return None
+    out: list[float | None] = []
+    for k in keys:
+        raw = entry.get(k)
+        if raw is None:
+            out.append(None)
+            continue
+        try:
+            v = float(raw)
+        except (TypeError, ValueError):
+            out.append(None)
+            continue
+        out.append(None if v == 0 else v / 1000.0)
+    return out
+
+
+def _max_resolution_px(tier: str) -> list[int] | None:
+    """Derive ``[w, h]`` in pixels from the baked tier."""
+    px = TIER_TO_PX.get(tier)
+    if px is None:
+        return None
+    return [px, px]
+
+
 # ── main fetch ──────────────────────────────────────────────────
 
 
@@ -201,6 +240,7 @@ def _fetch_one(entry: dict, tier: str, output_dir: Path, mtlx_dir: Path | None) 
         cat = normalize_category(entry.get("displayCategory", entry.get("category", "")))
         tags = entry.get("tags", [])
         release_date = (entry.get("releaseDate") or "")[:10] or None
+        description = entry.get("description") or None
 
         return MaterialRecord(
             id=mid,
@@ -209,7 +249,12 @@ def _fetch_one(entry: dict, tier: str, output_dir: Path, mtlx_dir: Path | None) 
                 name=name,
                 category=cat,
                 tags=tags,
+                description=description,
                 upstream_id=mid,
+                physical=PhysicalBlock(
+                    dimensions_m=_dimensions_m(entry),
+                    max_resolution_px=_max_resolution_px(tier),
+                ),
                 attribution=AttributionBlock(
                     license_spdx="CC0-1.0",
                     source_url=f"https://ambientcg.com/a/{mid}",

--- a/src/mat_vis_baker/sources/gpuopen.py
+++ b/src/mat_vis_baker/sources/gpuopen.py
@@ -30,10 +30,12 @@ from pathlib import Path
 import requests
 
 from mat_vis_baker.common import (
+    TIER_TO_PX,
     AttributionBlock,
     DatesBlock,
     MaterialRecord,
     MatVisBlock,
+    PhysicalBlock,
     check_zip_safety,
     normalize_category,
     normalize_channel,
@@ -206,6 +208,35 @@ def _extract_from_zip(
 # ── per-material worker ───────────────────────────────────────
 
 
+def _authors(mat: dict) -> list[str]:
+    """gpuopen exposes a single ``author`` string (typically ``"AMD"``).
+
+    Wrap in a list to match the ``attribution.authors`` contract. Empty
+    / missing → ``[]``.
+    """
+    raw = mat.get("author")
+    if not isinstance(raw, str) or not raw.strip():
+        return []
+    return [raw.strip()]
+
+
+def _iso_date(raw: object) -> str | None:
+    """gpuopen dates are ISO datetimes; truncate to ``YYYY-MM-DD``."""
+    if not isinstance(raw, str) or not raw:
+        return None
+    return raw[:10]
+
+
+def _max_resolution_px(tier: str) -> list[int] | None:
+    """Derive ``[w, h]`` in pixels from the baked tier (gpuopen packages
+    are labeled ``"1k 8b"``, ``"2k 8b"``, ...; the tier prefix is the px
+    we extract)."""
+    px = TIER_TO_PX.get(tier)
+    if px is None:
+        return None
+    return [px, px]
+
+
 def _fetch_one(
     mat: dict,
     tier: str,
@@ -223,6 +254,7 @@ def _fetch_one(
     name = mat.get("title") or mid
     category = normalize_category(mat.get("_category_title", ""))
     tags = list(mat.get("_tag_titles", []))
+    description = mat.get("description") or None
     source_url = f"https://matlib.gpuopen.com/main/materials/all?material={mid}"
 
     def _mat_vis(maps: list[str] | None = None) -> MatVisBlock:
@@ -230,12 +262,18 @@ def _fetch_one(
             name=name,
             category=category,
             tags=tags,
+            description=description,
             upstream_id=mid,
+            physical=PhysicalBlock(max_resolution_px=_max_resolution_px(tier)),
             attribution=AttributionBlock(
+                authors=_authors(mat),
                 license_spdx="MIT",
                 source_url=source_url,
             ),
-            dates=DatesBlock(updated=mat.get("updated_date") or None),
+            dates=DatesBlock(
+                published=_iso_date(mat.get("published_date")),
+                updated=_iso_date(mat.get("updated_date")),
+            ),
         )
 
     failed = lambda: MaterialRecord(  # noqa: E731 — local shorthand

--- a/src/mat_vis_baker/sources/physicallybased.py
+++ b/src/mat_vis_baker/sources/physicallybased.py
@@ -36,6 +36,52 @@ def _color_rgb(rgb: object) -> list[float] | None:
         return None
 
 
+def _specular_f0(raw: object) -> list[float] | None:
+    """Extract ``[r, g, b]`` from upstream ``specularColor`` if valid.
+
+    physicallybased.info exposes ``specularColor`` as a float triple on
+    dielectrics (absent on most metals — ``None`` passthrough). Same shape
+    contract as ``_color_rgb``; decoupled so future per-field validation
+    can diverge without churn.
+    """
+    if not isinstance(raw, list) or len(raw) < 3:
+        return None
+    try:
+        return [float(raw[0]), float(raw[1]), float(raw[2])]
+    except (TypeError, ValueError):
+        return None
+
+
+def _transmission(raw: object) -> float | None:
+    """Upstream ``transmission`` is a single float (0..1) or missing."""
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _complex_ior(raw: object) -> list[float] | None:
+    """Passthrough ``complexIor`` verbatim as a list of floats.
+
+    physicallybased.info publishes 6-element wavelength-resolved complex
+    IOR triples for metals (``[n_r, k_r, n_g, k_g, n_b, k_b]``). Some
+    entries upstream diverge in length; we coerce to list and keep all
+    data in Phase B — stripping / length validation is Phase C's
+    allowlist + schema-diff gate.
+    """
+    if not isinstance(raw, list) or not raw:
+        return None
+    out: list[float] = []
+    for v in raw:
+        try:
+            out.append(float(v))
+        except (TypeError, ValueError):
+            return None
+    return out
+
+
 def _normalize_tags(raw: object) -> list[str]:
     """Normalize upstream tags to lowercase, stripped, de-duplicated strings.
 
@@ -82,12 +128,16 @@ def fetch(*, session: requests.Session | None = None) -> list[MaterialRecord]:
                 name=name,
                 category=cat,
                 tags=_normalize_tags(mat.get("tags")),
+                description=mat.get("description") or None,
                 upstream_id=mid,
                 pbr=PBRBlock(
                     color_rgb=_color_rgb(mat.get("color")),
                     roughness=mat.get("roughness"),
                     metalness=mat.get("metalness"),
                     ior=mat.get("ior"),
+                    specular_f0=_specular_f0(mat.get("specularColor")),
+                    transmission=_transmission(mat.get("transmission")),
+                    complex_ior=_complex_ior(mat.get("complexIor")),
                 ),
                 attribution=AttributionBlock(
                     license_spdx="CC0-1.0",

--- a/src/mat_vis_baker/sources/polyhaven.py
+++ b/src/mat_vis_baker/sources/polyhaven.py
@@ -8,14 +8,17 @@ Format: Individual PNG downloads per map per resolution (no ZIP).
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 from pathlib import Path
 
 import requests
 
 from mat_vis_baker.common import (
     AttributionBlock,
+    DatesBlock,
     MaterialRecord,
     MatVisBlock,
+    PhysicalBlock,
     normalize_category,
     normalize_channel,
     retry_request,
@@ -108,6 +111,72 @@ def _download_maps(
             log.warning("%s/%s: download failed from %s", material_id, channel, url)
 
     return result
+
+
+# ── curated-field extraction (Phase B, mat-vis#152) ─────────────
+
+
+def _dimensions_m(raw: object) -> list[float | None] | None:
+    """Extract ``[x, y, None]`` in metres from polyhaven's mm 2-tuple.
+
+    polyhaven's ``dimensions`` is a 2-element list in millimetres (no
+    Z-axis upstream). Convert to metres, add ``None`` for the Z slot so
+    callers see a consistent ``[x, y, z]`` shape. Handles list / dict /
+    missing / zero defensively; returns ``None`` when upstream has
+    nothing usable.
+    """
+    if raw is None:
+        return None
+    # Some entries upstream have dict-shaped dimensions in edge cases;
+    # be permissive here — take numeric-keyed values if present.
+    if isinstance(raw, dict):
+        raw = [raw.get("x"), raw.get("y")]
+    if not isinstance(raw, list) or len(raw) < 2:
+        return None
+
+    def _one(v: object) -> float | None:
+        if v is None:
+            return None
+        try:
+            f = float(v)
+        except (TypeError, ValueError):
+            return None
+        return None if f == 0 else f / 1000.0
+
+    x, y = _one(raw[0]), _one(raw[1])
+    if x is None and y is None:
+        return None
+    return [x, y, None]
+
+
+def _max_resolution_px(raw: object) -> list[int] | None:
+    """Normalize polyhaven's ``max_resolution`` (already px) to ``[w, h]``."""
+    if not isinstance(raw, list) or len(raw) < 2:
+        return None
+    try:
+        return [int(raw[0]), int(raw[1])]
+    except (TypeError, ValueError):
+        return None
+
+
+def _authors(meta: dict) -> list[str]:
+    """polyhaven's ``authors`` is ``{name: role}``; we want the name list."""
+    raw = meta.get("authors")
+    if not isinstance(raw, dict):
+        return []
+    return list(raw.keys())
+
+
+def _published_date(meta: dict) -> str | None:
+    """polyhaven's ``date_published`` is a Unix epoch (int); return ISO date (UTC)."""
+    raw = meta.get("date_published")
+    if raw is None:
+        return None
+    try:
+        ts = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d")
 
 
 # ── main fetch ──────────────────────────────────────────────────
@@ -209,6 +278,7 @@ def _fetch_one(
             cat_str = ""
         cat = normalize_category(cat_str)
         tags = meta.get("tags", [])
+        description = meta.get("description") or None
 
         return MaterialRecord(
             id=slug,
@@ -217,11 +287,18 @@ def _fetch_one(
                 name=name,
                 category=cat,
                 tags=tags,
+                description=description,
                 upstream_id=slug,
+                physical=PhysicalBlock(
+                    dimensions_m=_dimensions_m(meta.get("dimensions")),
+                    max_resolution_px=_max_resolution_px(meta.get("max_resolution")),
+                ),
                 attribution=AttributionBlock(
+                    authors=_authors(meta),
                     license_spdx="CC0-1.0",
                     source_url=f"https://polyhaven.com/a/{slug}",
                 ),
+                dates=DatesBlock(published=_published_date(meta)),
             ),
             available_tiers=[tier],
             maps=sorted(textures.keys()),

--- a/tests/test_ambientcg_extractor.py
+++ b/tests/test_ambientcg_extractor.py
@@ -1,0 +1,189 @@
+"""Tests for the ambientcg extractor — Phase B curated fields (#152).
+
+Phase B populates every ``mat_vis.*`` curated field the upstream API can
+provide, with deterministic fallback to ``None`` when a field is missing
+or carries the "unknown" sentinel (``dimension* = 0``).
+
+These tests lock the extraction in by driving the real upstream payload
+shape from ``ambientcg.com/api/v2/full_json`` against a mocked ZIP
+download, and asserting every Phase B field shows up on the resulting
+``MaterialRecord.mat_vis``.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from mat_vis_baker.sources.ambientcg import (
+    _dimensions_m,
+    _fetch_one,
+    _max_resolution_px,
+)
+
+
+# ── helpers ─────────────────────────────────────────────────────
+
+
+def _fake_zip_bytes() -> bytes:
+    """One-PNG ZIP with an ambientcg-shaped ``*_Color.png`` member."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("Bricks097_1K-PNG/Bricks097_1K-PNG_Color.png", b"\x89PNG\r\n\x1a\nfake")
+    return buf.getvalue()
+
+
+def _entry(**overrides: object) -> dict:
+    """Baseline ambientcg API entry; overrides mutate individual fields."""
+    base: dict = {
+        "assetId": "Bricks097",
+        "displayName": "Bricks 097",
+        "displayCategory": "Ceramic/Brick",
+        "tags": ["brick", "red"],
+        "description": "A red brick wall texture.",
+        "dimensionX": 500,  # mm
+        "dimensionY": 500,
+        "dimensionZ": 20,
+        "releaseDate": "2024-11-22T00:00:00Z",
+        "downloadFolders": {
+            "default": {
+                "downloadFiletypeCategories": {
+                    "zip": {
+                        "downloads": [
+                            {
+                                "attribute": "1K-PNG",
+                                "fullDownloadPath": "https://example.com/Bricks097_1K-PNG.zip",
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+# ── _dimensions_m ───────────────────────────────────────────────
+
+
+def test_dimensions_m_converts_mm_to_m() -> None:
+    assert _dimensions_m({"dimensionX": 500, "dimensionY": 250, "dimensionZ": 20}) == [
+        0.5,
+        0.25,
+        0.02,
+    ]
+
+
+def test_dimensions_m_zero_becomes_none_per_axis() -> None:
+    assert _dimensions_m({"dimensionX": 0, "dimensionY": 500, "dimensionZ": 0}) == [
+        None,
+        0.5,
+        None,
+    ]
+
+
+def test_dimensions_m_all_zero_still_emits_triple() -> None:
+    """All-zero upstream is ambiguous: emit [None, None, None] so callers
+    see the axis slot; absent-entirely maps to None (handled separately)."""
+    assert _dimensions_m({"dimensionX": 0, "dimensionY": 0, "dimensionZ": 0}) == [
+        None,
+        None,
+        None,
+    ]
+
+
+def test_dimensions_m_all_missing_returns_none() -> None:
+    assert _dimensions_m({"assetId": "x"}) is None
+
+
+def test_dimensions_m_tolerates_bad_values() -> None:
+    assert _dimensions_m({"dimensionX": "nope", "dimensionY": None, "dimensionZ": 100}) == [
+        None,
+        None,
+        0.1,
+    ]
+
+
+# ── _max_resolution_px ──────────────────────────────────────────
+
+
+def test_max_resolution_px_derived_from_tier() -> None:
+    assert _max_resolution_px("1k") == [1024, 1024]
+    assert _max_resolution_px("4k") == [4096, 4096]
+    assert _max_resolution_px("128") == [128, 128]
+
+
+def test_max_resolution_px_unknown_tier_is_none() -> None:
+    assert _max_resolution_px("99k") is None
+
+
+# ── _fetch_one end-to-end ───────────────────────────────────────
+
+
+def test_fetch_one_populates_phase_b_fields(tmp_path: Path) -> None:
+    entry = _entry()
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.ambientcg.retry_request", return_value=mock_resp):
+        rec = _fetch_one(entry, "1k", tmp_path, mtlx_dir=None)
+
+    assert rec.status == "ok"
+    mv = rec.mat_vis
+    assert mv.name == "Bricks 097"
+    assert mv.category == "ceramic"
+    assert mv.tags == ["brick", "red"]
+    assert mv.description == "A red brick wall texture."
+    assert mv.physical.dimensions_m == [0.5, 0.5, 0.02]
+    assert mv.physical.max_resolution_px == [1024, 1024]
+    assert mv.attribution.license_spdx == "CC0-1.0"
+    assert mv.attribution.source_url == "https://ambientcg.com/a/Bricks097"
+    assert mv.dates.published == "2024-11-22"
+    assert mv.dates.updated == "2024-11-22"
+    assert mv.upstream_id == "Bricks097"
+
+
+def test_fetch_one_handles_missing_description(tmp_path: Path) -> None:
+    entry = _entry(description=None)
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.ambientcg.retry_request", return_value=mock_resp):
+        rec = _fetch_one(entry, "1k", tmp_path, mtlx_dir=None)
+    assert rec.mat_vis.description is None
+
+
+def test_fetch_one_handles_missing_dimensions(tmp_path: Path) -> None:
+    entry = _entry()
+    for k in ("dimensionX", "dimensionY", "dimensionZ"):
+        entry.pop(k, None)
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.ambientcg.retry_request", return_value=mock_resp):
+        rec = _fetch_one(entry, "2k", tmp_path, mtlx_dir=None)
+    assert rec.mat_vis.physical.dimensions_m is None
+    assert rec.mat_vis.physical.max_resolution_px == [2048, 2048]
+
+
+def test_fetch_one_handles_zero_dimensions(tmp_path: Path) -> None:
+    """Upstream leaves 0 for "not measured" on synthetic / abstract textures."""
+    entry = _entry(dimensionX=0, dimensionY=0, dimensionZ=0)
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.ambientcg.retry_request", return_value=mock_resp):
+        rec = _fetch_one(entry, "1k", tmp_path, mtlx_dir=None)
+    assert rec.mat_vis.physical.dimensions_m == [None, None, None]
+
+
+def test_fetch_one_builds_stable_mat_vis_shape(tmp_path: Path) -> None:
+    """Even a minimal entry flows through with all nested blocks present."""
+    entry = _entry(description=None, tags=[])
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.ambientcg.retry_request", return_value=mock_resp):
+        rec = _fetch_one(entry, "1k", tmp_path, mtlx_dir=None)
+
+    # every sub-block is a real dataclass instance, not None
+    assert rec.mat_vis.physical is not None
+    assert rec.mat_vis.pbr is not None
+    assert rec.mat_vis.attribution is not None
+    assert rec.mat_vis.dates is not None
+    # pbr stays empty — ambientcg doesn't expose scalar PBR properties
+    assert rec.mat_vis.pbr.color_rgb is None
+    assert rec.mat_vis.pbr.roughness is None

--- a/tests/test_gpuopen_extractor.py
+++ b/tests/test_gpuopen_extractor.py
@@ -1,0 +1,166 @@
+"""Tests for the gpuopen extractor — Phase B curated fields (#152).
+
+gpuopen's /api/materials/<uuid>/ response carries ``description``
+(often null), a single ``author`` string (usually ``"AMD"``),
+``published_date`` / ``updated_date`` ISO datetimes, and a package
+label like ``"1k 8b"`` — we derive ``max_resolution_px`` from the tier
+the bake is running (not from the label, since a single bake is tied
+to one tier).
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from mat_vis_baker.sources.gpuopen import (
+    _authors,
+    _fetch_one,
+    _iso_date,
+    _max_resolution_px,
+)
+
+
+# ── helpers ─────────────────────────────────────────────────────
+
+
+def _fake_zip_bytes() -> bytes:
+    """Tiny ZIP with a ``.mtlx`` + one basecolor PNG — enough to flow through."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("oak/material.mtlx", b"<materialx/>")
+        zf.writestr("oak/oak_basecolor.png", b"\x89PNG\r\n\x1a\nfake")
+    return buf.getvalue()
+
+
+def _mat(**overrides: object) -> dict:
+    base: dict = {
+        "id": "abcd-1234",
+        "title": "Oak Planks",
+        "description": "Warm oak planks.",
+        "author": "AMD",
+        "published_date": "2022-08-01T12:00:00Z",
+        "updated_date": "2023-03-15T09:30:00Z",
+        "_category_title": "Wood",
+        "_tag_titles": ["wood", "planks"],
+        "_packages_detail": [
+            {
+                "id": "pkg-1k-8b",
+                "label": "1k 8b",
+                "file_url": "https://example.com/oak_1k_8b.zip",
+            }
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+# ── _authors ────────────────────────────────────────────────────
+
+
+def test_authors_wraps_single_string() -> None:
+    assert _authors({"author": "AMD"}) == ["AMD"]
+
+
+def test_authors_strips_whitespace() -> None:
+    assert _authors({"author": "  AMD  "}) == ["AMD"]
+
+
+def test_authors_missing_is_empty() -> None:
+    assert _authors({}) == []
+    assert _authors({"author": None}) == []
+    assert _authors({"author": ""}) == []
+    assert _authors({"author": "   "}) == []
+
+
+# ── _iso_date ───────────────────────────────────────────────────
+
+
+def test_iso_date_truncates_datetime_to_date() -> None:
+    assert _iso_date("2022-08-01T12:00:00Z") == "2022-08-01"
+
+
+def test_iso_date_preserves_date_only() -> None:
+    assert _iso_date("2022-08-01") == "2022-08-01"
+
+
+def test_iso_date_missing_is_none() -> None:
+    assert _iso_date(None) is None
+    assert _iso_date("") is None
+    assert _iso_date(42) is None
+
+
+# ── _max_resolution_px ──────────────────────────────────────────
+
+
+def test_max_resolution_px_from_tier() -> None:
+    assert _max_resolution_px("1k") == [1024, 1024]
+    assert _max_resolution_px("4k") == [4096, 4096]
+
+
+def test_max_resolution_px_unknown_tier_is_none() -> None:
+    assert _max_resolution_px("huge") is None
+
+
+# ── _fetch_one end-to-end ───────────────────────────────────────
+
+
+def test_fetch_one_populates_phase_b_fields(tmp_path: Path) -> None:
+    mat = _mat()
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
+        rec = _fetch_one(mat, "1k", tmp_path, mtlx_dir=None)
+
+    assert rec.status == "ok"
+    mv = rec.mat_vis
+    assert mv.name == "Oak Planks"
+    assert mv.category == "wood"
+    assert mv.tags == ["wood", "planks"]
+    assert mv.description == "Warm oak planks."
+    assert mv.physical.max_resolution_px == [1024, 1024]
+    # upstream doesn't provide physical dimensions; stays null
+    assert mv.physical.dimensions_m is None
+    assert mv.attribution.authors == ["AMD"]
+    assert mv.attribution.license_spdx == "MIT"
+    assert mv.attribution.source_url == (
+        "https://matlib.gpuopen.com/main/materials/all?material=abcd-1234"
+    )
+    assert mv.dates.published == "2022-08-01"
+    assert mv.dates.updated == "2023-03-15"
+    assert mv.upstream_id == "abcd-1234"
+
+
+def test_fetch_one_handles_null_description(tmp_path: Path) -> None:
+    """gpuopen frequently returns description: null upstream."""
+    mat = _mat(description=None)
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
+        rec = _fetch_one(mat, "1k", tmp_path, mtlx_dir=None)
+    assert rec.mat_vis.description is None
+
+
+def test_fetch_one_handles_missing_dates(tmp_path: Path) -> None:
+    mat = _mat(published_date=None, updated_date=None)
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
+        rec = _fetch_one(mat, "1k", tmp_path, mtlx_dir=None)
+    assert rec.mat_vis.dates.published is None
+    assert rec.mat_vis.dates.updated is None
+
+
+def test_fetch_one_failed_record_still_has_stable_shape(tmp_path: Path) -> None:
+    """A material with no matching package returns a failed record whose
+    mat_vis block still carries every Phase B field we CAN derive from
+    the material dict (resolution still falls out of the tier)."""
+    mat = _mat(_packages_detail=[])  # no packages → immediate failure
+    rec = _fetch_one(mat, "2k", tmp_path, mtlx_dir=None)
+    assert rec.status == "failed"
+    mv = rec.mat_vis
+    # metadata we know from the /materials/ endpoint still populates
+    assert mv.name == "Oak Planks"
+    assert mv.description == "Warm oak planks."
+    assert mv.attribution.authors == ["AMD"]
+    assert mv.physical.max_resolution_px == [2048, 2048]
+    assert mv.dates.published == "2022-08-01"

--- a/tests/test_physicallybased_extractor.py
+++ b/tests/test_physicallybased_extractor.py
@@ -15,7 +15,13 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from mat_vis_baker.sources.physicallybased import _normalize_tags, fetch
+from mat_vis_baker.sources.physicallybased import (
+    _complex_ior,
+    _normalize_tags,
+    _specular_f0,
+    _transmission,
+    fetch,
+)
 
 
 def test_normalize_tags_populated() -> None:
@@ -87,3 +93,112 @@ def test_fetch_populates_tags_from_upstream() -> None:
     assert by_name["Banana"].mat_vis.tags == []
     # case-folded, de-duplicated, order preserved
     assert by_name["Car Paint"].mat_vis.tags == ["acrylic", "coat", "car paint", "lacquer"]
+
+
+# ── Phase B helpers (#152) ──────────────────────────────────────
+
+
+def test_specular_f0_extracts_rgb_triple() -> None:
+    assert _specular_f0([0.04, 0.04, 0.04]) == [0.04, 0.04, 0.04]
+
+
+def test_specular_f0_rejects_garbage() -> None:
+    assert _specular_f0(None) is None
+    assert _specular_f0([0.04, 0.04]) is None  # under-length
+    assert _specular_f0(["bad", "worse", "meh"]) is None
+
+
+def test_transmission_float_passthrough() -> None:
+    assert _transmission(0.95) == 0.95
+    assert _transmission(0) == 0.0
+    assert _transmission(None) is None
+    assert _transmission("not-a-float") is None
+
+
+def test_complex_ior_passes_six_float_through() -> None:
+    raw = [1.39, 7.61, 0.96, 6.55, 0.62, 5.25]
+    assert _complex_ior(raw) == raw
+
+
+def test_complex_ior_passes_arbitrary_length_in_phase_b() -> None:
+    """Phase B doesn't strip — Phase C's allowlist can debate that later."""
+    assert _complex_ior([1.0, 2.0]) == [1.0, 2.0]
+
+
+def test_complex_ior_missing_is_none() -> None:
+    assert _complex_ior(None) is None
+    assert _complex_ior([]) is None
+
+
+def test_complex_ior_rejects_non_floats() -> None:
+    assert _complex_ior([1.0, "bad", 3.0]) is None
+
+
+# ── end-to-end Phase B fields on the record ─────────────────────
+
+
+def test_fetch_populates_phase_b_pbr_fields() -> None:
+    """Every Phase B pbr.* field flows through from realistic upstream."""
+    fake_api = [
+        {
+            "name": "Aluminum",
+            "category": "metal",
+            "description": "Polished aluminum with characteristic blueish sheen.",
+            "color": [0.912, 0.914, 0.920],
+            "ior": 1.39,
+            "metalness": 1.0,
+            "roughness": 0.0,
+            "specularColor": [0.912, 0.914, 0.920],
+            "transmission": 0.0,
+            "complexIor": [1.39, 7.61, 0.96, 6.55, 0.62, 5.25],
+            "tags": ["aluminium", "mirror"],
+        },
+        {
+            "name": "Glass",
+            "category": "glass",
+            "description": "Crown optical glass.",
+            "color": [1.0, 1.0, 1.0],
+            "ior": 1.52,
+            "metalness": 0.0,
+            "roughness": 0.0,
+            "specularColor": [0.04, 0.04, 0.04],
+            "transmission": 1.0,
+            "tags": ["glass", "transparent"],
+            # no complexIor upstream on dielectrics
+        },
+        {
+            "name": "Plaster",
+            "category": "plaster",
+            "color": [0.93, 0.93, 0.93],
+            "ior": 1.5,
+            # no description, no specularColor, no transmission, no complexIor
+            "tags": [],
+        },
+    ]
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = fake_api
+
+    with patch("mat_vis_baker.sources.physicallybased.retry_request", return_value=mock_resp):
+        records = fetch()
+
+    by_name = {r.mat_vis.name: r for r in records}
+
+    al = by_name["Aluminum"].mat_vis
+    assert al.description == "Polished aluminum with characteristic blueish sheen."
+    assert al.pbr.specular_f0 == [0.912, 0.914, 0.920]
+    assert al.pbr.transmission == 0.0
+    assert al.pbr.complex_ior == [1.39, 7.61, 0.96, 6.55, 0.62, 5.25]
+
+    glass = by_name["Glass"].mat_vis
+    assert glass.pbr.specular_f0 == [0.04, 0.04, 0.04]
+    assert glass.pbr.transmission == 1.0
+    # absent upstream → None (not KeyError, not default-to-0)
+    assert glass.pbr.complex_ior is None
+
+    plaster = by_name["Plaster"].mat_vis
+    assert plaster.description is None
+    assert plaster.pbr.specular_f0 is None
+    assert plaster.pbr.transmission is None
+    assert plaster.pbr.complex_ior is None
+    # existing fields still populated
+    assert plaster.pbr.ior == 1.5

--- a/tests/test_polyhaven_extractor.py
+++ b/tests/test_polyhaven_extractor.py
@@ -1,0 +1,174 @@
+"""Tests for the polyhaven extractor — Phase B curated fields (#152).
+
+Polyhaven's ``/info/<slug>`` payload is the richest of the four sources:
+description, physical dimensions (mm 2-tuple), max resolution (px),
+per-author attribution dict, and a Unix-epoch publish date. Phase B
+wires all of them into ``mat_vis.*``.
+
+These tests drive each helper in isolation + an end-to-end ``_fetch_one``
+against a realistic mocked upstream payload.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from mat_vis_baker.sources.polyhaven import (
+    _authors,
+    _dimensions_m,
+    _fetch_one,
+    _max_resolution_px,
+    _published_date,
+)
+
+
+# ── _dimensions_m ───────────────────────────────────────────────
+
+
+def test_dimensions_m_converts_mm_two_tuple_to_m_triple() -> None:
+    assert _dimensions_m([1000, 2000]) == [1.0, 2.0, None]
+
+
+def test_dimensions_m_zero_axis_becomes_none() -> None:
+    assert _dimensions_m([0, 1500]) == [None, 1.5, None]
+
+
+def test_dimensions_m_both_zero_returns_none() -> None:
+    assert _dimensions_m([0, 0]) is None
+
+
+def test_dimensions_m_none_or_missing() -> None:
+    assert _dimensions_m(None) is None
+    assert _dimensions_m([]) is None
+    assert _dimensions_m([500]) is None  # under-length
+
+
+def test_dimensions_m_dict_shape_is_tolerated() -> None:
+    """Some polyhaven entries upstream carry dict-shaped dimensions."""
+    assert _dimensions_m({"x": 1000, "y": 500}) == [1.0, 0.5, None]
+
+
+def test_dimensions_m_tolerates_bad_values() -> None:
+    assert _dimensions_m(["bad", 1000]) == [None, 1.0, None]
+
+
+# ── _max_resolution_px ──────────────────────────────────────────
+
+
+def test_max_resolution_px_passes_through() -> None:
+    assert _max_resolution_px([8192, 8192]) == [8192, 8192]
+
+
+def test_max_resolution_px_rejects_garbage() -> None:
+    assert _max_resolution_px(None) is None
+    assert _max_resolution_px([1024]) is None
+    assert _max_resolution_px(["bad", "worse"]) is None
+
+
+# ── _authors ────────────────────────────────────────────────────
+
+
+def test_authors_extracts_keys_from_dict() -> None:
+    assert _authors({"authors": {"Rob Tuytel": "All", "Jarod Guest": "Scan"}}) == [
+        "Rob Tuytel",
+        "Jarod Guest",
+    ]
+
+
+def test_authors_missing_is_empty_list() -> None:
+    assert _authors({}) == []
+    assert _authors({"authors": None}) == []
+    assert _authors({"authors": ["not-a-dict"]}) == []
+
+
+# ── _published_date ─────────────────────────────────────────────
+
+
+def test_published_date_converts_unix_epoch_to_iso_date() -> None:
+    # 2023-06-15 00:00:00 UTC = 1686787200
+    assert _published_date({"date_published": 1686787200}) == "2023-06-15"
+
+
+def test_published_date_missing_is_none() -> None:
+    assert _published_date({}) is None
+    assert _published_date({"date_published": None}) is None
+
+
+def test_published_date_bad_value_is_none() -> None:
+    assert _published_date({"date_published": "not-a-timestamp"}) is None
+
+
+# ── _fetch_one end-to-end ───────────────────────────────────────
+
+
+def _meta(**overrides: object) -> dict:
+    base: dict = {
+        "name": "Wood Floor",
+        "categories": ["wood"],
+        "tags": ["wood", "floor", "planks"],
+        "description": "Seamless wood floor texture.",
+        "dimensions": [2000, 2000],
+        "max_resolution": [8192, 8192],
+        "authors": {"Rob Tuytel": "All"},
+        "date_published": 1686787200,
+    }
+    base.update(overrides)
+    return base
+
+
+def _file_info(tier_key: str = "1k") -> dict:
+    """Shape matching polyhaven ``/files/<slug>``."""
+    return {
+        "Diffuse": {tier_key: {"png": {"url": "https://example.com/diff.png"}}},
+    }
+
+
+def test_fetch_one_populates_phase_b_fields(tmp_path: Path) -> None:
+    meta = _meta()
+    file_info = _file_info()
+    png_resp = MagicMock(content=b"\x89PNG\r\n\x1a\nfake")
+
+    with (
+        patch("mat_vis_baker.sources.polyhaven._fetch_files", return_value=file_info),
+        patch("mat_vis_baker.sources.polyhaven.retry_request", return_value=png_resp),
+    ):
+        rec = _fetch_one("wood_floor", meta, "1k", tmp_path)
+
+    assert rec.status == "ok"
+    mv = rec.mat_vis
+    assert mv.name == "Wood Floor"
+    assert mv.category == "wood"
+    assert mv.tags == ["wood", "floor", "planks"]
+    assert mv.description == "Seamless wood floor texture."
+    assert mv.physical.dimensions_m == [2.0, 2.0, None]
+    assert mv.physical.max_resolution_px == [8192, 8192]
+    assert mv.attribution.authors == ["Rob Tuytel"]
+    assert mv.attribution.license_spdx == "CC0-1.0"
+    assert mv.attribution.source_url == "https://polyhaven.com/a/wood_floor"
+    assert mv.dates.published == "2023-06-15"
+    assert mv.upstream_id == "wood_floor"
+
+
+def test_fetch_one_tolerates_missing_optional_fields(tmp_path: Path) -> None:
+    """polyhaven entries with sparse metadata still flow through cleanly."""
+    meta = _meta(
+        description=None,
+        dimensions=None,
+        max_resolution=None,
+        authors=None,
+        date_published=None,
+    )
+    png_resp = MagicMock(content=b"\x89PNG\r\n\x1a\nfake")
+    with (
+        patch("mat_vis_baker.sources.polyhaven._fetch_files", return_value=_file_info()),
+        patch("mat_vis_baker.sources.polyhaven.retry_request", return_value=png_resp),
+    ):
+        rec = _fetch_one("wood_floor", meta, "1k", tmp_path)
+
+    mv = rec.mat_vis
+    assert mv.description is None
+    assert mv.physical.dimensions_m is None
+    assert mv.physical.max_resolution_px is None
+    assert mv.attribution.authors == []
+    assert mv.dates.published is None


### PR DESCRIPTION
Phase B of the ADR-0011 roll-out for #152. Stacked on #166 (Phase A). Target branch is the Phase A branch; **do not merge until the full stack is approved**.

## Summary

Phase A shipped the ``mat_vis`` block dataclasses + v3 index envelope but left the new curated fields empty. Phase B populates every Layer-1 curated field from the upstream API of each source, per the coverage table in #152.

## Per-source coverage

| Field | ambientcg | polyhaven | physicallybased | gpuopen |
|---|---|---|---|---|
| ``description`` | done | done | done | done (often null upstream) |
| ``physical.dimensions_m`` | done (mm → m, 0 = unknown) | done (2-tuple + null Z) | n/a | n/a |
| ``physical.max_resolution_px`` | derived from tier | upstream ``max_resolution`` | n/a | derived from tier |
| ``pbr.color_rgb`` | n/a | n/a | done (Phase A) | n/a |
| ``pbr.roughness / metalness / ior`` | n/a | n/a | done (Phase A) | n/a |
| ``pbr.specular_f0`` | n/a | n/a | **new** | n/a |
| ``pbr.transmission`` | n/a | n/a | **new** | n/a |
| ``pbr.complex_ior`` | n/a | n/a | **new** (verbatim passthrough) | n/a |
| ``attribution.authors`` | n/a | done (dict keys) | n/a | done (wrap single string) |
| ``attribution.license_spdx`` | CC0-1.0 | CC0-1.0 | CC0-1.0 | MIT |
| ``attribution.source_url`` | done | done | done | done |
| ``dates.published`` | done (Phase A) | **new** (epoch → ISO) | n/a | **new** (ISO truncation) |
| ``dates.updated`` | done (Phase A) | n/a | n/a | done (Phase A, normalized) |
| ``upstream_id`` | done | done | done | done |

Fields marked n/a stay ``null`` — the Layer-1 stable key set means they're always present, just empty. No contract change vs. Phase A shape.

## Explicitly deferred to Phase C

- ``upstream.raw`` verbatim mirror layer
- ``UPSTREAM_ALLOWLIST`` per-source constant
- ``client.upstream(source, id)`` accessor
- CI schema-diff gate (``scripts/check_upstream_schema_drift.py``)
- Strip policy in ``client.search()`` / ``client.index()``

``pbr.complex_ior`` length validation is also deferred to Phase C — Phase B keeps all data (the point of the layer-1 mirror pattern) and lets Phase C's per-source allowlist + schema-diff gate debate whether to normalize length.

## Test plan

- [x] ``tests/test_ambientcg_extractor.py`` — new, 12 tests. Covers ``_dimensions_m`` (mm → m, zero-axis sentinel, all-missing → None, bad values), ``_max_resolution_px`` (tier → px), plus end-to-end ``_fetch_one`` populating every Phase B field and the stable ``mat_vis`` block shape on sparse upstream.
- [x] ``tests/test_polyhaven_extractor.py`` — new, 15 tests. Helper unit tests for ``_dimensions_m`` / ``_max_resolution_px`` / ``_authors`` / ``_published_date`` including dict-shape fallback, epoch → ISO date, missing-field → None. End-to-end ``_fetch_one`` against realistic ``/info/<slug>`` + ``/files/<slug>`` mocks.
- [x] ``tests/test_physicallybased_extractor.py`` — extended, +8 tests. ``_specular_f0`` / ``_transmission`` / ``_complex_ior`` unit tests + end-to-end ``fetch()`` against a 3-material payload (Aluminum + Glass + Plaster) verifying null fall-through for dielectrics missing ``complexIor`` and sparse entries missing ``description`` / ``specularColor`` / ``transmission``.
- [x] ``tests/test_gpuopen_extractor.py`` — new, 12 tests. ``_authors`` (strip, wrap, empty), ``_iso_date`` (datetime → date, date passthrough, missing), ``_max_resolution_px``. End-to-end covers null description, missing dates, failed-record shape (still carries Phase B metadata derivable from the material dict).
- [x] ``tests/test_index_builder.py`` (from Phase A) still green — no schema changes needed.
- [x] Full suite: 268 pass, 1 pre-existing failure (``test_version_sync`` — standalone client not importable from the monorepo context; unrelated to #152).
- [x] ``ruff check`` + ``ruff format --check`` clean on all touched files.
- [x] Pre-commit hooks green on all 4 commits.

## Commits

1. ``feat(baker/ambientcg): populate Phase B curated fields (#152)``
2. ``feat(baker/polyhaven): populate Phase B curated fields (#152)``
3. ``feat(baker/physicallybased): populate pbr.specular_f0 / transmission / complex_ior (#152)``
4. ``feat(baker/gpuopen): populate Phase B curated fields (#152)``

Each commit passes its source's test suite independently.

## Stack position

PR 2 of 3 in the #152 stack.

- Phase A: #166 (base of this PR)
- Phase B: **this PR**
- Phase C: follow-up for ``upstream.raw`` + accessor + CI gate

Do not merge until the whole stack is approved.