### PR TITLE
feat: Phase C — upstream.raw + client accessor + CI schema-diff gate (#152)

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -100,6 +100,18 @@ jobs:
             --batch-size=${{ inputs.batch-size }}
             ${{ inputs.dry-run == true && '--dry-run=true' || '' }}
 
+      # ADR-0011 / mat-vis#152 phase-c: lock the Layer-2 upstream mirror
+      # against silent schema drift. The baker just pushed the candidate
+      # <source>.json to HF at release-tag; fetch it and diff against the
+      # previous release. See scripts/check_upstream_schema_drift.py.
+      # Skipped on dry-run (nothing was pushed to HF).
+      - name: Upstream schema-drift gate (#152)
+        if: inputs.dry-run != true
+        run: |
+          uv run python scripts/check_upstream_schema_drift.py \
+            --source "${{ inputs.source }}" \
+            --candidate "https://huggingface.co/datasets/gerchowl/mat-vis/resolve/${{ inputs.release-tag }}/${{ inputs.source }}.json"
+
       - name: Notify on failure
         if: failure()
         uses: ./.github/actions/notify-on-failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ Hugging Face Datasets + tar archives ([ADR-0007](docs/decisions/0007-substrate-m
 Structural fix for four recurring bug classes (#79, #82, #98, #99) via
 atomic multi-file commits + immutable revisions.
 
+Also ships the **v3 index-schema** rollout — curated `mat_vis` block +
+verbatim `upstream` mirror per [ADR-0011](docs/decisions/0011-mat-vis-curated-plus-upstream-mirror.md)
+(mat-vis#152). Clean break: all semantic fields move under `mat_vis.*`;
+consumers must update accessor paths. A v3 client pointed at a v2 catalog
+raises `MatVisError` early with an upgrade hint, not silent empty results.
+
 ### Added
 
 - Reads from Hugging Face Datasets (`gerchowl/mat-vis`) by default.
@@ -38,6 +44,25 @@ atomic multi-file commits + immutable revisions.
   map keyed by tier to `{tar, rowmap}`. Scalar sources omit `tiers`.
 - First tagged release on the new substrate: `v2026.04.1` —
   4 sources (ambientcg 1965, polyhaven 753, gpuopen 2254, physicallybased 86).
+- **`mat_vis` curated block** on every catalog entry (ADR-0011 Layer 1):
+  `name`, `category`, `tags`, `description`, `physical.{dimensions_m, max_resolution_px}`,
+  `pbr.{color_rgb, roughness, metalness, ior, specular_f0, transmission, complex_ior}`,
+  `attribution.{authors, license_spdx, source_url}`, `dates.{published, updated}`,
+  `upstream_id`. Stable key set — missing upstream values are `null`, never absent.
+- **`upstream` verbatim mirror** per source (Layer 2): `{source, schema_version,
+  fetched_at, raw}`. `raw` is the allowlisted upstream response. Explicitly
+  **unstable** — not covered by semver. Stripped from every `index()` /
+  `search()` return value; access via `client.upstream(source, material_id)`
+  only.
+- `MatVisClient.upstream(source, material_id, tier="1k")` typed accessor.
+  Returns `{}` when the entry carries no upstream block (pre-rebake tags);
+  raises `UnknownMaterialError` on unknown ids; accepts name-lookup per
+  mat-vis#143.
+- CI schema-diff gate: `scripts/check_upstream_schema_drift.py` runs on
+  every bake, compares the candidate catalog's per-record key-set against
+  the previous HF release. New keys warn; removed canonical keys or
+  `mat_vis.*` presence regressions >5% fail the workflow.
+- `index-schema.json` bumped to v3 + `mat-vis-block-v3.json` sub-schema.
 
 ### Changed
 
@@ -72,6 +97,37 @@ atomic multi-file commits + immutable revisions.
 # alias on HF). Pin the data release explicitly.
 client = MatVisClient(tag="v2026.04.1")
 ```
+
+**Index schema v2 → v3 migration** (breaking; ADR-0011 / mat-vis#152):
+
+```python
+# Before (v2):
+entry["category"]           # "metal"
+entry["color_hex"]          # "#C0C0C0"
+entry["roughness"]          # 0.3
+entry["source_url"]         # "https://..."
+
+# After (v3):
+entry["mat_vis"]["category"]                 # "metal"
+entry["mat_vis"]["pbr"]["color_rgb"]         # [r, g, b] float, 0..1 (not hex)
+entry["mat_vis"]["pbr"]["roughness"]         # 0.3
+entry["mat_vis"]["attribution"]["source_url"] # "https://..."
+
+# New: verbatim upstream (unstable shape, explicit opt-in)
+raw = client.upstream("ambientcg", "Bricks097")
+raw["displayCategory"]      # upstream-shaped; source-specific; not semver-stable
+```
+
+Adapters (`to_threejs`, `to_gltf`, `export_mtlx`) still accept a flat
+`scalars` dict. If you were building that dict by hand from
+`entry["color_hex"]` / `entry["roughness"]`, rebuild it from the new
+`entry["mat_vis"]["pbr"]` shape (convert `color_rgb` → hex with
+`"#{:02X}{:02X}{:02X}".format(*[int(c*255) for c in rgb])`).
+
+**Pin `tag="v2026.04.1"` or newer.** The earlier `v2026.04.0` catalogs
+predate the v3 schema; running 0.6.0 against that tag raises with an
+upgrade hint rather than silently returning empty results. Consumers that
+cannot re-pin should stay on `mat-vis-client 0.5.x`.
 
 The installable (`pip install mat-vis-client==0.6.0`) and the zero-deps
 standalone (`clients/python/mat_vis_client_standalone.py`) expose the

--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -765,8 +765,14 @@ class MatVisClient:
             catalog = f"{source}.json"
         return self._hf_url(catalog)
 
-    def index(self, source: str) -> list[dict]:
-        """Fetch and cache the per-source catalog JSON (v0.6.0: HF-only)."""
+    def _load_index_raw(self, source: str) -> list[dict]:
+        """Fetch + cache the per-source catalog JSON verbatim (with ``upstream``).
+
+        Internal accessor — public callers get the stripped view from
+        :meth:`index`. See the package client for the rationale.
+
+        Guards against a v3 client pointed at a v2 catalog (ADR-0011).
+        """
         if source not in self._indexes:
             cache_path = self._cache_dir / ".indexes" / f"{source}.json"
             if cache_path.exists():
@@ -776,7 +782,78 @@ class MatVisClient:
                 self._indexes[source] = data
                 cache_path.parent.mkdir(parents=True, exist_ok=True)
                 cache_path.write_text(json.dumps(data, indent=2))
+            self._assert_v3_catalog(source, self._indexes[source])
         return self._indexes[source]
+
+    @staticmethod
+    def _assert_v3_catalog(source: str, entries: list[dict]) -> None:
+        """Raise if ``entries`` is a pre-ADR-0011 (v2) catalog — fail loudly
+        rather than silently return empty from ``search()`` / ``categories()``.
+        """
+        if not isinstance(entries, list) or not entries:
+            return
+        sample = entries[0]
+        if not isinstance(sample, dict):
+            return
+        if "mat_vis" in sample:
+            return
+        if any(k in sample for k in ("category", "color_hex", "roughness")):
+            raise MatVisError(
+                f"catalog for source {source!r} predates ADR-0011 (v2 shape). "
+                f"This client requires v3 catalogs (mat_vis block). "
+                f"Pin tag='v2026.04.1' or newer, or downgrade to mat-vis-client 0.5.x."
+            )
+
+    @staticmethod
+    def _strip_upstream(entry: dict) -> dict:
+        """Return a shallow copy of ``entry`` with the ``upstream`` key removed.
+
+        Layer-2 (``upstream.raw``) is explicitly NOT stable — shipping it in
+        every ``index()`` / ``search()`` response would drag unstable upstream
+        shape into the query surface. Use :meth:`upstream` directly to access
+        it for a specific material.
+        """
+        if "upstream" not in entry:
+            return entry
+        return {k: v for k, v in entry.items() if k != "upstream"}
+
+    def index(self, source: str) -> list[dict]:
+        """Fetch and cache the per-source catalog JSON (v0.6.0: HF-only).
+
+        The ``upstream`` block (Layer 2 of ADR-0011) is stripped from
+        every entry — it's the verbatim upstream response, intentionally
+        NOT part of the stable query surface. Use :meth:`upstream` to
+        access it for a specific material.
+        """
+        return [self._strip_upstream(e) for e in self._load_index_raw(source)]
+
+    def upstream(
+        self,
+        source: str,
+        material_id: str,
+        tier: str = "1k",
+    ) -> dict:
+        """Return the verbatim upstream metadata for a material.
+
+        The shape is source-specific and **unstable** — not covered by
+        semver. Use for advanced queries that need upstream fields not
+        exposed via ``mat_vis.*``. Returns ``{}`` when the entry exists
+        but carries no ``upstream`` block (pre-v3 catalogs).
+        """
+        resolved = self._resolve_material_id(source, material_id, tier)
+        for entry in self._load_index_raw(source):
+            if entry.get("id") != resolved:
+                continue
+            upstream = entry.get("upstream") or {}
+            raw = upstream.get("raw")
+            if not isinstance(raw, dict):
+                return {}
+            return raw
+        raise UnknownMaterialError(
+            key=material_id,
+            available=[],
+            context=f"{source}/{tier}",
+        )
 
     def search(
         self,

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -891,12 +891,18 @@ class MatVisClient:
             catalog = f"{source}.json"
         return self._hf_url(catalog)
 
-    def index(self, source: str) -> list[dict]:
-        """Fetch and cache the per-source catalog JSON.
+    def _load_index_raw(self, source: str) -> list[dict]:
+        """Fetch + cache the per-source catalog JSON, verbatim (with ``upstream``).
 
-        v0.6.0: resolves to ``<HF_BASE>/<revision>/<source>.json`` via
-        the manifest. No GH-Raw fallback — the catalog lives in the
-        same dataset revision as everything else (ADR-0007).
+        Internal accessor used by :meth:`upstream`, :meth:`_resolve_material_id`,
+        :meth:`_scalars_for`, and :meth:`search`'s filter loop — anywhere the
+        server-side shape is needed. Public callers get the stripped view from
+        :meth:`index`.
+
+        Guards the v2/v3 boundary: a v3 client pointed at a v2 catalog (e.g.
+        a user who pinned ``tag="v2026.04.0"`` before rebaking) would silently
+        return empty ``search()`` / ``categories()`` because every ``mat_vis``
+        lookup misses. Fail loudly instead (ADR-0011 / mat-vis#152).
         """
         if source not in self._indexes:
             cache_path = self._cache_scope / ".indexes" / f"{source}.json"
@@ -907,7 +913,102 @@ class MatVisClient:
                 data = _get_json(self._index_url(source))
                 self._indexes[source] = data
                 self._cache_write_text(cache_path, json.dumps(data, indent=2))
+            self._assert_v3_catalog(source, self._indexes[source])
         return self._indexes[source]
+
+    @staticmethod
+    def _assert_v3_catalog(source: str, entries: list[dict]) -> None:
+        """Raise if ``entries`` is a pre-ADR-0011 (v2) catalog.
+
+        Detection: any entry missing a top-level ``mat_vis`` key but carrying
+        one of the v2 semantic keys (``category``, ``name`` directly). A truly
+        empty catalog (``entries=[]``) is ambiguous but harmless — no silent
+        failure surface, so allow it.
+        """
+        if not isinstance(entries, list) or not entries:
+            return
+        sample = entries[0]
+        if not isinstance(sample, dict):
+            return
+        if "mat_vis" in sample:
+            return
+        # v2-shaped entry: top-level semantic fields instead of mat_vis block.
+        if any(k in sample for k in ("category", "color_hex", "roughness")):
+            raise MatVisError(
+                f"catalog for source {source!r} predates ADR-0011 (v2 shape). "
+                f"This client requires v3 catalogs (mat_vis block). "
+                f"Pin tag='v2026.04.1' or newer, or downgrade to mat-vis-client 0.5.x."
+            )
+
+    @staticmethod
+    def _strip_upstream(entry: dict) -> dict:
+        """Return a shallow copy of ``entry`` with the ``upstream`` key removed.
+
+        Layer-2 (``upstream.raw``) is explicitly NOT stable — shipping it in
+        every ``index()`` / ``search()`` response would drag unstable upstream
+        shape into the query surface. Consumers that want it use
+        :meth:`upstream` directly.
+
+        Shallow copy only — inner dicts are shared with the cache. Caller
+        promises not to mutate; that matches the existing read-only
+        contract on search results.
+        """
+        if "upstream" not in entry:
+            return entry
+        return {k: v for k, v in entry.items() if k != "upstream"}
+
+    def index(self, source: str) -> list[dict]:
+        """Fetch and cache the per-source catalog JSON.
+
+        v0.6.0: resolves to ``<HF_BASE>/<revision>/<source>.json`` via
+        the manifest. No GH-Raw fallback — the catalog lives in the
+        same dataset revision as everything else (ADR-0007).
+
+        The ``upstream`` block (Layer 2 of ADR-0011) is stripped from
+        every entry — it's the verbatim upstream response, intentionally
+        NOT part of the stable query surface. Use :meth:`upstream` to
+        access it for a specific material.
+        """
+        return [self._strip_upstream(e) for e in self._load_index_raw(source)]
+
+    def upstream(
+        self,
+        source: str,
+        material_id: str,
+        tier: str = "1k",
+    ) -> dict:
+        """Return the verbatim upstream metadata for a material.
+
+        The shape is source-specific and **unstable** — not covered by
+        semver. Use this for advanced queries that need upstream fields
+        not exposed via ``mat_vis.*``; for anything that MUST be stable,
+        stick to ``client.index()`` / ``client.search()`` and the
+        Layer-1 contract.
+
+        ``material_id`` may be the canonical id or a human-readable name;
+        resolution goes through the same path as every other per-material
+        accessor (:meth:`_resolve_material_id`). Unknown ids / ambiguous
+        names raise typed errors just like ``fetch_texture``.
+
+        Returns ``{}`` when the entry exists but carries no ``upstream``
+        block — typical for pre-v3 catalogs that haven't been re-baked.
+        """
+        resolved = self._resolve_material_id(source, material_id, tier)
+        for entry in self._load_index_raw(source):
+            if entry.get("id") != resolved:
+                continue
+            upstream = entry.get("upstream") or {}
+            raw = upstream.get("raw")
+            if not isinstance(raw, dict):
+                return {}
+            return raw
+        # _resolve_material_id should have caught missing ids, but be
+        # defensive — the rowmap/index disagreement path is real.
+        raise UnknownMaterialError(
+            key=material_id,
+            available=[],
+            context=f"{source}/{tier}",
+        )
 
     _SCALAR_WIDEN = 0.2  # scalar shorthand → range half-width
 

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -14,7 +14,7 @@ from unittest.mock import patch
 
 import pytest
 
-from mat_vis_client import MatVisClient
+from mat_vis_client import MatVisClient, UnknownMaterialError
 from mat_vis_client.client import _in_range
 from mat_vis_client.adapters import (
     to_threejs,
@@ -37,7 +37,7 @@ TINY_PNG = (
 
 
 MOCK_MANIFEST = {
-    "schema_version": 1,
+    "schema_version": 2,
     "version": 1,  # retained for tests asserting on the legacy field
     "release_tag": "v2026.04.0",
     "tiers": {
@@ -54,6 +54,29 @@ MOCK_MANIFEST = {
                 },
             },
         }
+    },
+    # v2 manifest-shape used by schema-validated paths (rowmap / upstream
+    # accessors). Tests in the tiers→sources nested-shape above still work
+    # for category/search filtering because search iterates per-source.
+    "sources": {
+        "ambientcg": {
+            "catalog": "ambientcg.json",
+            "tiers": {
+                "1k": {
+                    "tar": "ambientcg-1k.tar",
+                    "rowmap": "ambientcg-1k-rowmap.json",
+                },
+            },
+        },
+        "polyhaven": {
+            "catalog": "polyhaven.json",
+            "tiers": {
+                "1k": {
+                    "tar": "polyhaven-1k.tar",
+                    "rowmap": "polyhaven-1k-rowmap.json",
+                },
+            },
+        },
     },
 }
 
@@ -220,7 +243,7 @@ class TestInRange:
 class TestClientManifest:
     def test_manifest_loads_from_cache(self, mock_client):
         m = mock_client.manifest
-        assert m["schema_version"] == 1
+        assert m["schema_version"] == 2
         assert "tiers" in m
 
     def test_tiers(self, mock_client):
@@ -584,3 +607,121 @@ class TestLiveFetchTexture:
     def test_fetch_nonexistent_material_raises(self, live_client):
         with pytest.raises(KeyError):
             live_client.fetch_texture("ambientcg", "NONEXISTENT_XYZ", "color", "1k")
+
+
+# ── upstream accessor + strip (Phase C, mat-vis#152) ───────────
+
+
+def _index_with_upstream() -> list[dict]:
+    """Copy of MOCK_INDEX_AMBIENTCG with per-entry ``upstream`` blocks."""
+    out: list[dict] = []
+    for entry in MOCK_INDEX_AMBIENTCG:
+        enriched = dict(entry)
+        enriched["upstream"] = {
+            "source": "ambientcg",
+            "schema_version": 1,
+            "fetched_at": "2026-04-20T16:00:00Z",
+            "raw": {
+                "assetId": entry["id"],
+                "displayName": entry["mat_vis"]["name"],
+                "popularityScore": 0.5,
+            },
+        }
+        out.append(enriched)
+    return out
+
+
+class TestClientUpstreamAccessor:
+    @patch("mat_vis_client.client._get_json")
+    def test_index_strips_upstream_key(self, mock_get, mock_client):
+        """``client.index(source)`` never returns the ``upstream`` key —
+        it's explicitly not part of the stable query surface."""
+        mock_get.return_value = _index_with_upstream()
+        entries = mock_client.index("ambientcg")
+        assert len(entries) == 3
+        for e in entries:
+            assert "upstream" not in e
+            # mat_vis is still there — Layer-1 is the query surface.
+            assert "mat_vis" in e
+
+    @patch("mat_vis_client.client._get_json")
+    def test_index_strip_does_not_mutate_cache(self, mock_get, mock_client):
+        """Stripping returns a shallow copy — the cached index keeps
+        the ``upstream`` key so :meth:`upstream` can read it."""
+        mock_get.return_value = _index_with_upstream()
+        _ = mock_client.index("ambientcg")
+        # Internal cache kept verbatim
+        raw = mock_client._load_index_raw("ambientcg")
+        assert all("upstream" in e for e in raw)
+
+    @patch("mat_vis_client.client._get_json")
+    def test_search_strips_upstream_key(self, mock_get, mock_client):
+        mock_get.return_value = _index_with_upstream()
+        results = mock_client.search(source="ambientcg")
+        assert len(results) == 3
+        for r in results:
+            assert "upstream" not in r
+
+    @patch("mat_vis_client.client._get_json")
+    def test_upstream_returns_source_shaped_dict(self, mock_get, mock_client):
+        mock_get.side_effect = [MOCK_ROWMAP, _index_with_upstream()]
+        raw = mock_client.upstream("ambientcg", "Rock064", "1k")
+        assert raw["assetId"] == "Rock064"
+        assert raw["displayName"] == "Rough Granite"
+
+    @patch("mat_vis_client.client._get_json")
+    def test_upstream_unknown_material_raises(self, mock_get, mock_client):
+        mock_get.side_effect = [MOCK_ROWMAP, _index_with_upstream()]
+        with pytest.raises(UnknownMaterialError):
+            mock_client.upstream("ambientcg", "DEFINITELY_NOT_A_MATERIAL", "1k")
+
+    @patch("mat_vis_client.client._get_json")
+    def test_upstream_returns_empty_dict_when_missing(self, mock_get, mock_client):
+        """Pre-v3 catalog entries (no ``upstream`` block) yield ``{}``, not
+        an error — callers can check for truthiness rather than branching
+        on the dataset version."""
+        # Index without any upstream blocks (pre-v3 / Phase A envelope).
+        mock_get.side_effect = [MOCK_ROWMAP, MOCK_INDEX_AMBIENTCG]
+        raw = mock_client.upstream("ambientcg", "Rock064", "1k")
+        assert raw == {}
+
+
+class TestV2CatalogGuard:
+    """Cross-stack review fix: a v3 client pointed at a v2 catalog must
+    fail loudly with an upgrade hint, not silently return empty from
+    ``search()`` / ``categories()`` because every ``mat_vis`` lookup misses.
+    """
+
+    @patch("mat_vis_client.client._get_json")
+    def test_v2_shaped_catalog_raises_loudly(self, mock_get, mock_client):
+        from mat_vis_client import MatVisError
+
+        # v2 shape: top-level category + color_hex, no mat_vis block.
+        v2_catalog = [
+            {"id": "Rock064", "source": "ambientcg", "category": "stone", "color_hex": "#888"},
+            {"id": "Metal032", "source": "ambientcg", "category": "metal", "roughness": 0.3},
+        ]
+        mock_get.return_value = v2_catalog
+        with pytest.raises(MatVisError, match="predates ADR-0011"):
+            mock_client.index("ambientcg")
+
+    @patch("mat_vis_client.client._get_json")
+    def test_v3_shaped_catalog_passes(self, mock_get, mock_client):
+        """v3 entries carrying a ``mat_vis`` block are accepted without noise."""
+        v3_catalog = [
+            {
+                "id": "Rock064",
+                "source": "ambientcg",
+                "mat_vis": {"name": "Rough Granite", "category": "stone"},
+            }
+        ]
+        mock_get.return_value = v3_catalog
+        entries = mock_client.index("ambientcg")
+        assert entries[0]["mat_vis"]["category"] == "stone"
+
+    @patch("mat_vis_client.client._get_json")
+    def test_empty_catalog_is_allowed(self, mock_get, mock_client):
+        """Empty list is ambiguous but harmless — no silent failure surface."""
+        mock_get.return_value = []
+        entries = mock_client.index("ambientcg")
+        assert entries == []

--- a/scripts/check_upstream_schema_drift.py
+++ b/scripts/check_upstream_schema_drift.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Upstream schema-drift gate (ADR-0011 / mat-vis#152 phase-c).
+
+Compares a candidate ``<source>.json`` catalog against the most recently
+published one on the Hugging Face dataset. Three signals:
+
+1. **NEW keys** under any record's ``upstream.raw``. Warn + exit 0. These
+   are the interesting signal — hand-review before widening the
+   allowlist; the pipeline keeps working.
+2. **REMOVED keys** from any record's ``mat_vis.*`` curated blocks. Fail
+   (exit 1). Layer-1 is semver-stable; an extractor that stops populating
+   a curated field is a breaking change and must be caught in CI.
+3. **PRESENCE REGRESSION** in ``mat_vis.*`` fields: if 95% of records
+   used to populate ``mat_vis.pbr.roughness`` and now only 80% do, fail.
+   Threshold is a hard >5 percentage-point drop vs. the previous release.
+
+First-run pass: if the previous release doesn't carry ``upstream`` (i.e.
+the source was last baked pre-Phase-C), log + exit 0. This is the only
+free pass — every subsequent bake has a baseline to diff against.
+
+Usage:
+    uv run python scripts/check_upstream_schema_drift.py \\
+        --source ambientcg \\
+        --candidate ./dist/ambientcg.json
+
+    # Or point at a URL (CI: candidate just pushed to HF at a new tag):
+    uv run python scripts/check_upstream_schema_drift.py \\
+        --source ambientcg \\
+        --candidate-url https://huggingface.co/.../ambientcg.json
+
+The previous release tag is discovered via the GH releases API unless
+overridden via ``--previous-tag``. Network calls are stdlib urllib so the
+script has zero runtime deps (the script runs under ``uv run`` which
+resolves its own sandbox without a pyproject).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+HF_DATASET = "gerchowl/mat-vis"
+HF_BASE = f"https://huggingface.co/datasets/{HF_DATASET}/resolve"
+GH_API_LATEST = "https://api.github.com/repos/MorePET/mat-vis/releases/latest"
+
+# Layer-1 curated blocks whose key-sets are semver-stable. When a record
+# loses one of these keys we fail the gate — losing a key is a breaking
+# change to the ``mat_vis.*`` contract.
+MAT_VIS_STABLE_BLOCKS = (
+    "physical",
+    "pbr",
+    "attribution",
+    "dates",
+)
+
+# Presence-regression threshold: if field X was populated in P_prev% of
+# records in the previous release and P_cand% in the candidate, we fail
+# when P_prev - P_cand > 5 (i.e. >5pp drop). The threshold matches the
+# ADR-0011 spec + gives us a deterministic tripwire.
+PRESENCE_REGRESSION_PP = 5.0
+
+log = logging.getLogger("schema-drift")
+
+
+def _http_get(url: str, timeout: float = 30) -> bytes:
+    """Minimal stdlib GET. Raises on non-200 / network errors."""
+    req = urllib.request.Request(url, headers={"User-Agent": "mat-vis-schema-drift"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 — fixed host
+        if resp.status != 200:
+            raise RuntimeError(f"HTTP {resp.status} from {url}")
+        return resp.read()
+
+
+def _latest_release_tag() -> str | None:
+    """GitHub ``releases/latest`` tag, or ``None`` if unavailable."""
+    try:
+        data = json.loads(_http_get(GH_API_LATEST))
+        return data.get("tag_name")
+    except (urllib.error.URLError, RuntimeError, json.JSONDecodeError) as exc:
+        log.warning("could not discover latest release tag: %s", exc)
+        return None
+
+
+def _fetch_previous_catalog(source: str, tag: str) -> list[dict] | None:
+    """Load ``<source>.json`` from HF at ``tag``. ``None`` on 404 / error."""
+    url = f"{HF_BASE}/{tag}/{source}.json"
+    try:
+        blob = _http_get(url)
+        return json.loads(blob)
+    except (urllib.error.URLError, RuntimeError, json.JSONDecodeError) as exc:
+        log.warning("could not fetch previous %s from %s: %s", source, url, exc)
+        return None
+
+
+def _load_candidate(candidate: str) -> list[dict]:
+    """Load the candidate catalog from a local path OR URL."""
+    if candidate.startswith(("http://", "https://")):
+        return json.loads(_http_get(candidate))
+    path = Path(candidate)
+    if not path.exists():
+        raise SystemExit(f"candidate not found: {path}")
+    return json.loads(path.read_text())
+
+
+def _collect_upstream_keys(catalog: list[dict]) -> set[str]:
+    """Union of every ``upstream.raw`` top-level key across the catalog."""
+    keys: set[str] = set()
+    for entry in catalog:
+        raw = (entry.get("upstream") or {}).get("raw") or {}
+        if isinstance(raw, dict):
+            keys.update(raw.keys())
+    return keys
+
+
+def _flatten_mat_vis_keys(mv: dict, prefix: str = "mat_vis") -> set[str]:
+    """Flatten a single entry's ``mat_vis`` block to dotted keys.
+
+    Only descends one level (into the curated sub-blocks listed in
+    ``MAT_VIS_STABLE_BLOCKS``); deeper structures (e.g. list-valued
+    ``pbr.color_rgb``) stay leaf — their presence is what we care about,
+    not their internal shape.
+    """
+    out: set[str] = set()
+    for k, v in mv.items():
+        dotted = f"{prefix}.{k}"
+        if k in MAT_VIS_STABLE_BLOCKS and isinstance(v, dict):
+            for sub in v:
+                out.add(f"{dotted}.{sub}")
+        else:
+            out.add(dotted)
+    return out
+
+
+def _collect_mat_vis_keys(catalog: list[dict]) -> set[str]:
+    """Union of every flattened ``mat_vis.*`` key across the catalog."""
+    keys: set[str] = set()
+    for entry in catalog:
+        mv = entry.get("mat_vis") or {}
+        keys.update(_flatten_mat_vis_keys(mv))
+    return keys
+
+
+def _field_presence(catalog: list[dict]) -> dict[str, float]:
+    """Per-key fraction of records where ``mat_vis.<path>`` is non-null.
+
+    Denominator is total records with a ``mat_vis`` block — we only rate
+    keys, not optional records.
+    """
+    counts: dict[str, int] = {}
+    total = 0
+    for entry in catalog:
+        mv = entry.get("mat_vis") or {}
+        if not mv:
+            continue
+        total += 1
+        for block in MAT_VIS_STABLE_BLOCKS:
+            sub = mv.get(block)
+            if not isinstance(sub, dict):
+                continue
+            for leaf_k, leaf_v in sub.items():
+                key = f"mat_vis.{block}.{leaf_k}"
+                if leaf_v is None or leaf_v == [] or leaf_v == "":
+                    continue
+                counts[key] = counts.get(key, 0) + 1
+    if total == 0:
+        return {}
+    return {k: (n / total) * 100.0 for k, n in counts.items()}
+
+
+def run(source: str, candidate: str, *, previous_tag: str | None = None) -> int:
+    """Entry point. Returns exit code (0 pass, 1 fail)."""
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    candidate_catalog = _load_candidate(candidate)
+    log.info("loaded %d candidate records from %s", len(candidate_catalog), candidate)
+
+    tag = previous_tag or _latest_release_tag()
+    if tag is None:
+        log.info("no previous release tag discoverable — first-run free pass")
+        return 0
+    log.info("diffing against previous release: %s", tag)
+
+    previous_catalog = _fetch_previous_catalog(source, tag)
+    if previous_catalog is None:
+        log.info("no previous %s.json at %s — first-run free pass", source, tag)
+        return 0
+
+    prev_has_upstream = any("upstream" in e for e in previous_catalog)
+    if not prev_has_upstream:
+        log.info(
+            "previous release %s has no upstream block on %s — pre-v0.6.0 catalog, "
+            "first-run free pass for the new Layer-2 contract",
+            tag,
+            source,
+        )
+        return 0
+
+    failures: list[str] = []
+
+    # 1. NEW keys under upstream.raw — warn only.
+    prev_up = _collect_upstream_keys(previous_catalog)
+    cand_up = _collect_upstream_keys(candidate_catalog)
+    new_upstream = sorted(cand_up - prev_up)
+    if new_upstream:
+        log.warning(
+            "upstream.raw: %d NEW key(s) appeared since %s: %s",
+            len(new_upstream),
+            tag,
+            new_upstream,
+        )
+
+    # 2. REMOVED keys from mat_vis.* — fail.
+    prev_mv = _collect_mat_vis_keys(previous_catalog)
+    cand_mv = _collect_mat_vis_keys(candidate_catalog)
+    removed_mv = sorted(prev_mv - cand_mv)
+    if removed_mv:
+        failures.append(f"mat_vis.* REMOVED keys (breaking): {removed_mv}")
+
+    # 3. PRESENCE regression >5pp on any mat_vis.* field.
+    prev_pres = _field_presence(previous_catalog)
+    cand_pres = _field_presence(candidate_catalog)
+    regressions: list[str] = []
+    for key, prev_pct in prev_pres.items():
+        cand_pct = cand_pres.get(key, 0.0)
+        drop = prev_pct - cand_pct
+        if drop > PRESENCE_REGRESSION_PP:
+            regressions.append(f"{key}: {prev_pct:.1f}% → {cand_pct:.1f}% (drop {drop:.1f}pp)")
+    if regressions:
+        failures.append(
+            f"mat_vis.* PRESENCE regression (> {PRESENCE_REGRESSION_PP}pp drop): {regressions}"
+        )
+
+    if failures:
+        for f in failures:
+            log.error(f)
+        return 1
+
+    log.info("schema-drift OK (new upstream keys: %d, removed mat_vis keys: 0)", len(new_upstream))
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--source", required=True, help="Source name (ambientcg / polyhaven / ...)")
+    parser.add_argument(
+        "--candidate",
+        required=True,
+        help="Path or https:// URL to the candidate <source>.json",
+    )
+    parser.add_argument(
+        "--previous-tag",
+        default=None,
+        help="Override the previous release tag (default: GH releases/latest)",
+    )
+    args = parser.parse_args()
+    sys.exit(run(args.source, args.candidate, previous_tag=args.previous_tag))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mat_vis_baker/common.py
+++ b/src/mat_vis_baker/common.py
@@ -6,6 +6,7 @@ import hashlib
 import logging
 import time
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
@@ -393,19 +394,79 @@ class MatVisBlock:
     upstream_id: str = ""
 
 
+# ── Layer 2: upstream verbatim mirror (ADR-0011 / mat-vis#152) ─
+#
+# Per-source, allowlisted passthrough of the upstream JSON response.
+# Explicitly NOT semver-stable: shape follows upstream and may shift.
+# Stripped from ``client.index()`` / ``client.search()`` results;
+# exposed only via ``client.upstream(source, material_id)``.
+
+
+@dataclass
+class UpstreamBlock:
+    """Verbatim upstream metadata, trimmed to a per-source allowlist.
+
+    ``source``: upstream identifier (``"ambientcg"`` / ``"polyhaven"`` / ...).
+    ``schema_version``: bumped when this block's CONTRACT (keys ``source`` /
+    ``fetched_at`` / ``raw``) changes, NOT when upstream adds a field.
+    ``fetched_at``: ISO-8601 UTC timestamp of the bake-time fetch, e.g.
+    ``"2026-04-20T16:00:00Z"``.
+    ``raw``: allowlisted subset of the upstream response. ``{}`` when the
+    allowlist emptied everything (preferred over ``None`` for a stable
+    downstream shape). ``None`` only when the record has no upstream
+    payload at all (should be rare).
+    """
+
+    source: str = ""
+    schema_version: int = 1
+    fetched_at: str | None = None
+    raw: dict | None = None
+
+
+def utc_now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 ``Z`` string.
+
+    Used as ``UpstreamBlock.fetched_at`` at bake time. Second precision is
+    plenty — the field is for downstream staleness diagnosis, not
+    sub-millisecond ordering.
+    """
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _filter_upstream(raw: dict, allowlist: frozenset[str]) -> dict:
+    """Return a shallow copy of ``raw`` keeping only keys in ``allowlist``.
+
+    Shallow by design: the allowlist is a single flat set of top-level keys.
+    Nested dicts (e.g. gpuopen's package metadata, ambientcg's
+    ``downloadFolders``) pass through verbatim when their top-level key is
+    allowed, or are dropped entirely when it isn't. Per-field pruning of
+    nested structures is a future concern — Phase C's goal is a blunt,
+    auditable filter, not a deep reshape.
+
+    Missing keys are not inserted (``None`` placeholders would bloat every
+    record with keys upstream has never had). Non-dict input returns ``{}``.
+    """
+    if not isinstance(raw, dict):
+        return {}
+    return {k: v for k, v in raw.items() if k in allowlist}
+
+
 @dataclass
 class MaterialRecord:
     """Intermediate record passed between pipeline stages.
 
     Top-level carries bake-pipeline fields only (``id``, ``source``, tier /
-    channel / hash state). Everything semantic lives under ``mat_vis``. The
-    verbatim ``upstream`` block (Layer 2, ADR-0011) is added in Phase C
-    (mat-vis#152 phase-c).
+    channel / hash state). Semantic data splits between two layers:
+
+    - ``mat_vis`` (Layer 1): stable, unified, semver-stable across v0.6.x.
+    - ``upstream`` (Layer 2, ADR-0011): verbatim allowlisted mirror of the
+      upstream JSON. Shape follows upstream; NOT semver-stable.
     """
 
     id: str
     source: str
     mat_vis: MatVisBlock = field(default_factory=MatVisBlock)
+    upstream: UpstreamBlock | None = None
     available_tiers: list[str] = field(default_factory=list)
     maps: list[str] = field(default_factory=list)
     texture_paths: dict[str, Path] = field(default_factory=dict)

--- a/src/mat_vis_baker/index_builder.py
+++ b/src/mat_vis_baker/index_builder.py
@@ -6,6 +6,7 @@ Each entry is a v3 envelope (ADR-0011 / mat-vis#152):
       "id": ...,
       "source": ...,
       "mat_vis": { ... },          # Layer 1: stable curated contract
+      "upstream": { ... },          # Layer 2: allowlisted verbatim mirror
       "available_tiers": [...],
       "maps": [...],
       "texture_hashes": { ... },   # when present
@@ -20,8 +21,12 @@ record carries it (e.g. single-tier bakes) and omitted otherwise.
 Each source's catalog is written exactly once per bake. Concurrent
 bakes of different sources touch disjoint files, so no race is possible.
 
-Layer 2 (``upstream``) is added in Phase C of ADR-0011. It is NOT part
-of the v3 envelope emitted here — Phase A is the Layer-1 clean break.
+Layer 2 (``upstream``) is the per-source allowlisted mirror of the
+upstream JSON — added in Phase C of ADR-0011. When present, the key set
+is ``{source, schema_version, fetched_at, raw}``, always all four. Pre-v3
+records don't carry ``upstream`` at all; the client strips the key from
+``index()`` / ``search()`` results and exposes it only via
+``client.upstream(source, material_id)``.
 """
 
 from __future__ import annotations
@@ -42,6 +47,11 @@ def build_index(records: list[MaterialRecord], source: str) -> list[dict]:
     ``mat_vis`` is serialized via ``dataclasses.asdict`` so every nested
     key is present (with ``null`` where the extractor has no data). The
     stable key set is half of the Layer-1 contract.
+
+    ``upstream`` is serialized only when ``rec.upstream`` is set. When
+    present, the block's four keys (``source`` / ``schema_version`` /
+    ``fetched_at`` / ``raw``) are always all four so the stable-key-set
+    contract holds per-block.
     """
     entries: list[dict] = []
     for rec in records:
@@ -51,6 +61,8 @@ def build_index(records: list[MaterialRecord], source: str) -> list[dict]:
             "mat_vis": asdict(rec.mat_vis),
             "maps": rec.maps,
         }
+        if rec.upstream is not None:
+            entry["upstream"] = asdict(rec.upstream)
         if rec.available_tiers:
             entry["available_tiers"] = rec.available_tiers
         if rec.texture_hashes:

--- a/src/mat_vis_baker/sources/ambientcg.py
+++ b/src/mat_vis_baker/sources/ambientcg.py
@@ -16,20 +16,59 @@ from pathlib import Path
 import requests
 
 from mat_vis_baker.common import (
+    TIER_TO_PX,
     AttributionBlock,
     DatesBlock,
     MaterialRecord,
     MatVisBlock,
+    PhysicalBlock,
+    UpstreamBlock,
+    _filter_upstream,
     check_zip_safety,
     normalize_category,
     normalize_channel,
     retry_request,
+    utc_now_iso,
 )
 
 log = logging.getLogger("mat-vis-baker.ambientcg")
 
 API_BASE = "https://ambientcg.com/api/v2/full_json"
 PAGE_SIZE = 100
+
+
+# ── upstream allowlist (Layer 2, ADR-0011 / mat-vis#152 phase-c) ─
+#
+# Conservative seed: keeps scientifically / semantically useful keys,
+# drops large binary-adjacent payloads (preview lookups, download URL
+# trees, variation graphs) that would inflate the JSON without helping
+# any downstream query. Widen in follow-up PRs as consumers need it.
+#
+# Explicitly dropped: downloadFolders, previewLinks, previewImage,
+# previewType, variations, basedOnThis, createdUsing,
+# nextVariationAssetId, previousVariationAssetId, hasUsd,
+# downloadCountMonth, downloadCountWeek.
+UPSTREAM_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "assetId",
+        "releaseDate",
+        "displayName",
+        "displayCategory",
+        "description",
+        "tags",
+        "dimensionX",
+        "dimensionY",
+        "dimensionZ",
+        "creationMethod",
+        "creationMethodName",
+        "creationMethodDescription",
+        "dataType",
+        "dataTypeName",
+        "popularityScore",
+        "downloadCount",
+        "shortLink",
+    }
+)
 
 
 # ── discovery ───────────────────────────────────────────────────
@@ -163,6 +202,55 @@ def _extract_maps_from_zip(
     return result
 
 
+# ── curated-field extraction (Phase B, mat-vis#152) ─────────────
+
+
+def _dimensions_m(entry: dict) -> list[float | None] | None:
+    """Extract ``[x, y, z]`` in metres from upstream mm values.
+
+    ambientcg exposes ``dimensionX / dimensionY / dimensionZ`` in millimetres.
+    Convert to metres; treat ``0`` as "unknown" (not a real zero-thickness
+    material).
+
+    Harmonized return shape (Phase C, #152 review): ``None`` at top level
+    when nothing is measurable (all three keys missing / zero / invalid),
+    matching polyhaven's contract. When at least one axis is known,
+    return a 3-element list with ``None`` for the unknown slots —
+    ``[x, y, None]`` for 2D-only upstream, ``[x, None, None]`` when only
+    X is known, etc.
+    """
+    keys = ("dimensionX", "dimensionY", "dimensionZ")
+    if not any(k in entry for k in keys):
+        return None
+    out: list[float | None] = []
+    for k in keys:
+        raw = entry.get(k)
+        if raw is None:
+            out.append(None)
+            continue
+        try:
+            v = float(raw)
+        except (TypeError, ValueError):
+            out.append(None)
+            continue
+        out.append(None if v == 0 else v / 1000.0)
+    # All-unknown → None top-level, matching polyhaven's shape. This is
+    # the Phase B reviewer's ask: a single "nothing to show" sentinel
+    # across sources, instead of ambientcg's ``[None, None, None]`` and
+    # polyhaven's ``None``.
+    if all(v is None for v in out):
+        return None
+    return out
+
+
+def _max_resolution_px(tier: str) -> list[int] | None:
+    """Derive ``[w, h]`` in pixels from the baked tier."""
+    px = TIER_TO_PX.get(tier)
+    if px is None:
+        return None
+    return [px, px]
+
+
 # ── main fetch ──────────────────────────────────────────────────
 
 
@@ -178,6 +266,12 @@ def _fetch_one(entry: dict, tier: str, output_dir: Path, mtlx_dir: Path | None) 
     """Fetch a single material. Called from thread pool."""
     mid = entry.get("assetId", "")
     name = entry.get("displayName", mid)
+    upstream = UpstreamBlock(
+        source="ambientcg",
+        schema_version=1,
+        fetched_at=utc_now_iso(),
+        raw=_filter_upstream(entry, UPSTREAM_ALLOWLIST),
+    )
     try:
         dl_url = _extract_download_url(entry, tier)
         resp = retry_request(dl_url)
@@ -195,12 +289,14 @@ def _fetch_one(entry: dict, tier: str, output_dir: Path, mtlx_dir: Path | None) 
                         source_url=f"https://ambientcg.com/a/{mid}",
                     ),
                 ),
+                upstream=upstream,
                 status="failed",
             )
 
         cat = normalize_category(entry.get("displayCategory", entry.get("category", "")))
         tags = entry.get("tags", [])
         release_date = (entry.get("releaseDate") or "")[:10] or None
+        description = entry.get("description") or None
 
         return MaterialRecord(
             id=mid,
@@ -209,13 +305,19 @@ def _fetch_one(entry: dict, tier: str, output_dir: Path, mtlx_dir: Path | None) 
                 name=name,
                 category=cat,
                 tags=tags,
+                description=description,
                 upstream_id=mid,
+                physical=PhysicalBlock(
+                    dimensions_m=_dimensions_m(entry),
+                    max_resolution_px=_max_resolution_px(tier),
+                ),
                 attribution=AttributionBlock(
                     license_spdx="CC0-1.0",
                     source_url=f"https://ambientcg.com/a/{mid}",
                 ),
                 dates=DatesBlock(published=release_date, updated=release_date),
             ),
+            upstream=upstream,
             available_tiers=[tier],
             maps=sorted(textures.keys()),
             texture_paths=textures,
@@ -233,6 +335,7 @@ def _fetch_one(entry: dict, tier: str, output_dir: Path, mtlx_dir: Path | None) 
                     source_url=f"https://ambientcg.com/a/{mid}",
                 ),
             ),
+            upstream=upstream,
             status="failed",
         )
 

--- a/src/mat_vis_baker/sources/gpuopen.py
+++ b/src/mat_vis_baker/sources/gpuopen.py
@@ -30,14 +30,19 @@ from pathlib import Path
 import requests
 
 from mat_vis_baker.common import (
+    TIER_TO_PX,
     AttributionBlock,
     DatesBlock,
     MaterialRecord,
     MatVisBlock,
+    PhysicalBlock,
+    UpstreamBlock,
+    _filter_upstream,
     check_zip_safety,
     normalize_category,
     normalize_channel,
     retry_request,
+    utc_now_iso,
 )
 
 log = logging.getLogger("mat-vis-baker.gpuopen")
@@ -45,6 +50,36 @@ log = logging.getLogger("mat-vis-baker.gpuopen")
 API_BASE = "https://api.matlib.gpuopen.com/api"
 PAGE_SIZE = 100
 MAX_WORKERS = 10
+
+
+# ── upstream allowlist (Layer 2, ADR-0011 / mat-vis#152 phase-c) ─
+#
+# gpuopen's ``/materials`` response carries a lot of UI-state fodder
+# (``favorite``, ``notification_status``, viewer flags) and byte-heavy
+# payload trees (``packages``, ``renders``, ``renders_order``,
+# ``viewer_package``) we don't want to mirror. Keep only semantic
+# + provenance keys. The MaterialX filename is worth keeping — it's
+# the upstream anchor for the .mtlx we already publish.
+#
+# Fetcher-internal underscore-prefixed keys (``_category_title``,
+# ``_tag_titles``, ``_packages_detail``) are never allowlisted, so
+# _filter_upstream drops them automatically.
+UPSTREAM_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "id",
+        "title",
+        "author",
+        "license",
+        "material_type",
+        "status",
+        "created_date",
+        "updated_date",
+        "published_date",
+        "description",
+        "mtlx_filename",
+        "mtlx_material_name",
+    }
+)
 
 
 # ── discovery ───────────────────────────────────────────────────
@@ -206,6 +241,49 @@ def _extract_from_zip(
 # ── per-material worker ───────────────────────────────────────
 
 
+def _authors(mat: dict) -> list[str]:
+    """gpuopen exposes a single ``author`` string (typically ``"AMD"``).
+
+    Wrap in a list to match the ``attribution.authors`` contract. Empty
+    / missing → ``[]``.
+    """
+    raw = mat.get("author")
+    if not isinstance(raw, str) or not raw.strip():
+        return []
+    return [raw.strip()]
+
+
+_ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _iso_date(raw: object) -> str | None:
+    """gpuopen dates are ISO datetimes; truncate to ``YYYY-MM-DD``.
+
+    Guards against malformed upstream input (Phase B #152 review):
+    ``"2022/08/01"[:10]`` used to pass through verbatim as
+    ``"2022/08/01"``, which would fail any downstream ISO parser. We
+    slice then re-validate with ``^\\d{4}-\\d{2}-\\d{2}$``; on a mismatch
+    return ``None`` so the record just carries no date rather than a
+    malformed one.
+    """
+    if not isinstance(raw, str) or not raw:
+        return None
+    candidate = raw[:10]
+    if not _ISO_DATE_RE.match(candidate):
+        return None
+    return candidate
+
+
+def _max_resolution_px(tier: str) -> list[int] | None:
+    """Derive ``[w, h]`` in pixels from the baked tier (gpuopen packages
+    are labeled ``"1k 8b"``, ``"2k 8b"``, ...; the tier prefix is the px
+    we extract)."""
+    px = TIER_TO_PX.get(tier)
+    if px is None:
+        return None
+    return [px, px]
+
+
 def _fetch_one(
     mat: dict,
     tier: str,
@@ -223,25 +301,39 @@ def _fetch_one(
     name = mat.get("title") or mid
     category = normalize_category(mat.get("_category_title", ""))
     tags = list(mat.get("_tag_titles", []))
+    description = mat.get("description") or None
     source_url = f"https://matlib.gpuopen.com/main/materials/all?material={mid}"
+    upstream = UpstreamBlock(
+        source="gpuopen",
+        schema_version=1,
+        fetched_at=utc_now_iso(),
+        raw=_filter_upstream(mat, UPSTREAM_ALLOWLIST),
+    )
 
     def _mat_vis(maps: list[str] | None = None) -> MatVisBlock:
         return MatVisBlock(
             name=name,
             category=category,
             tags=tags,
+            description=description,
             upstream_id=mid,
+            physical=PhysicalBlock(max_resolution_px=_max_resolution_px(tier)),
             attribution=AttributionBlock(
+                authors=_authors(mat),
                 license_spdx="MIT",
                 source_url=source_url,
             ),
-            dates=DatesBlock(updated=mat.get("updated_date") or None),
+            dates=DatesBlock(
+                published=_iso_date(mat.get("published_date")),
+                updated=_iso_date(mat.get("updated_date")),
+            ),
         )
 
     failed = lambda: MaterialRecord(  # noqa: E731 — local shorthand
         id=mid,
         source="gpuopen",
         mat_vis=_mat_vis(),
+        upstream=upstream,
         status="failed",
     )
 
@@ -274,6 +366,7 @@ def _fetch_one(
             id=mid,
             source="gpuopen",
             mat_vis=_mat_vis(),
+            upstream=upstream,
             available_tiers=[tier] if textures else [],
             maps=sorted(textures.keys()),
             texture_paths=texture_paths,

--- a/src/mat_vis_baker/sources/physicallybased.py
+++ b/src/mat_vis_baker/sources/physicallybased.py
@@ -17,13 +17,52 @@ from mat_vis_baker.common import (
     MaterialRecord,
     MatVisBlock,
     PBRBlock,
+    UpstreamBlock,
+    _filter_upstream,
     normalize_category,
     retry_request,
+    utc_now_iso,
 )
 
 log = logging.getLogger("mat-vis-baker.physicallybased")
 
 API_URL = "https://api.physicallybased.info/materials"
+
+
+# ── upstream allowlist (Layer 2, ADR-0011 / mat-vis#152 phase-c) ─
+#
+# physicallybased.info is already a scientific dataset: almost every key
+# is load-bearing (scalar PBR, dispersion, complex IOR, subsurface,
+# acoustic). We mirror the lot — the allowlist exists to make NEW upstream
+# keys show up in the schema-diff gate, not to prune good data.
+UPSTREAM_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "name",
+        "category",
+        "group",
+        "description",
+        "tags",
+        "reference",
+        "sources",
+        "color",
+        "roughness",
+        "metalness",
+        "ior",
+        "specularColor",
+        "complexIor",
+        "transmission",
+        "transmissionDepth",
+        "transmissionDispersion",
+        "density",
+        "densityRange",
+        "viscosity",
+        "surfaceTension",
+        "subsurfaceRadius",
+        "thinFilmIor",
+        "thinFilmThickness",
+        "acousticAbsorption",
+    }
+)
 
 
 def _color_rgb(rgb: object) -> list[float] | None:
@@ -34,6 +73,52 @@ def _color_rgb(rgb: object) -> list[float] | None:
         return [float(rgb[0]), float(rgb[1]), float(rgb[2])]
     except (TypeError, ValueError):
         return None
+
+
+def _specular_f0(raw: object) -> list[float] | None:
+    """Extract ``[r, g, b]`` from upstream ``specularColor`` if valid.
+
+    physicallybased.info exposes ``specularColor`` as a float triple on
+    dielectrics (absent on most metals — ``None`` passthrough). Same shape
+    contract as ``_color_rgb``; decoupled so future per-field validation
+    can diverge without churn.
+    """
+    if not isinstance(raw, list) or len(raw) < 3:
+        return None
+    try:
+        return [float(raw[0]), float(raw[1]), float(raw[2])]
+    except (TypeError, ValueError):
+        return None
+
+
+def _transmission(raw: object) -> float | None:
+    """Upstream ``transmission`` is a single float (0..1) or missing."""
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _complex_ior(raw: object) -> list[float] | None:
+    """Passthrough ``complexIor`` verbatim as a list of floats.
+
+    physicallybased.info publishes 6-element wavelength-resolved complex
+    IOR triples for metals (``[n_r, k_r, n_g, k_g, n_b, k_b]``). Some
+    entries upstream diverge in length; we coerce to list and keep all
+    data in Phase B — stripping / length validation is Phase C's
+    allowlist + schema-diff gate.
+    """
+    if not isinstance(raw, list) or not raw:
+        return None
+    out: list[float] = []
+    for v in raw:
+        try:
+            out.append(float(v))
+        except (TypeError, ValueError):
+            return None
+    return out
 
 
 def _normalize_tags(raw: object) -> list[str]:
@@ -66,6 +151,10 @@ def fetch(*, session: requests.Session | None = None) -> list[MaterialRecord]:
     materials = resp.json()
     log.info("fetched %d materials", len(materials))
 
+    # One fetched_at for the whole batch — physicallybased is a single
+    # API call, so every record legitimately shares the same timestamp.
+    fetched_at = utc_now_iso()
+
     records: list[MaterialRecord] = []
     for mat in materials:
         name = mat.get("name", "")
@@ -82,17 +171,27 @@ def fetch(*, session: requests.Session | None = None) -> list[MaterialRecord]:
                 name=name,
                 category=cat,
                 tags=_normalize_tags(mat.get("tags")),
+                description=mat.get("description") or None,
                 upstream_id=mid,
                 pbr=PBRBlock(
                     color_rgb=_color_rgb(mat.get("color")),
                     roughness=mat.get("roughness"),
                     metalness=mat.get("metalness"),
                     ior=mat.get("ior"),
+                    specular_f0=_specular_f0(mat.get("specularColor")),
+                    transmission=_transmission(mat.get("transmission")),
+                    complex_ior=_complex_ior(mat.get("complexIor")),
                 ),
                 attribution=AttributionBlock(
                     license_spdx="CC0-1.0",
                     source_url="https://physicallybased.info",
                 ),
+            ),
+            upstream=UpstreamBlock(
+                source="physicallybased",
+                schema_version=1,
+                fetched_at=fetched_at,
+                raw=_filter_upstream(mat, UPSTREAM_ALLOWLIST),
             ),
             available_tiers=[],
             maps=[],

--- a/src/mat_vis_baker/sources/polyhaven.py
+++ b/src/mat_vis_baker/sources/polyhaven.py
@@ -8,22 +8,50 @@ Format: Individual PNG downloads per map per resolution (no ZIP).
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 from pathlib import Path
 
 import requests
 
 from mat_vis_baker.common import (
     AttributionBlock,
+    DatesBlock,
     MaterialRecord,
     MatVisBlock,
+    PhysicalBlock,
+    UpstreamBlock,
+    _filter_upstream,
     normalize_category,
     normalize_channel,
     retry_request,
+    utc_now_iso,
 )
 
 log = logging.getLogger("mat-vis-baker.polyhaven")
 
 API_BASE = "https://api.polyhaven.com"
+
+
+# ── upstream allowlist (Layer 2, ADR-0011 / mat-vis#152 phase-c) ─
+#
+# Polyhaven's ``/assets`` response is compact and mostly semantic already.
+# Dropped: files_hash (per-file MD5 tree, large + bake-internal),
+# thumbnail_url (CDN link — not indexable), sponsors (noise),
+# staging (editorial flag), old_id (legacy).
+UPSTREAM_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "name",
+        "type",
+        "date_published",
+        "categories",
+        "tags",
+        "authors",
+        "dimensions",
+        "max_resolution",
+        "description",
+        "download_count",
+    }
+)
 
 # Sub-1k tiers download 1k and let the bake step resize
 _TIER_KEYS = {
@@ -110,6 +138,72 @@ def _download_maps(
     return result
 
 
+# ── curated-field extraction (Phase B, mat-vis#152) ─────────────
+
+
+def _dimensions_m(raw: object) -> list[float | None] | None:
+    """Extract ``[x, y, None]`` in metres from polyhaven's mm 2-tuple.
+
+    polyhaven's ``dimensions`` is a 2-element list in millimetres (no
+    Z-axis upstream). Convert to metres, add ``None`` for the Z slot so
+    callers see a consistent ``[x, y, z]`` shape. Handles list / dict /
+    missing / zero defensively; returns ``None`` when upstream has
+    nothing usable.
+    """
+    if raw is None:
+        return None
+    # Some entries upstream have dict-shaped dimensions in edge cases;
+    # be permissive here — take numeric-keyed values if present.
+    if isinstance(raw, dict):
+        raw = [raw.get("x"), raw.get("y")]
+    if not isinstance(raw, list) or len(raw) < 2:
+        return None
+
+    def _one(v: object) -> float | None:
+        if v is None:
+            return None
+        try:
+            f = float(v)
+        except (TypeError, ValueError):
+            return None
+        return None if f == 0 else f / 1000.0
+
+    x, y = _one(raw[0]), _one(raw[1])
+    if x is None and y is None:
+        return None
+    return [x, y, None]
+
+
+def _max_resolution_px(raw: object) -> list[int] | None:
+    """Normalize polyhaven's ``max_resolution`` (already px) to ``[w, h]``."""
+    if not isinstance(raw, list) or len(raw) < 2:
+        return None
+    try:
+        return [int(raw[0]), int(raw[1])]
+    except (TypeError, ValueError):
+        return None
+
+
+def _authors(meta: dict) -> list[str]:
+    """polyhaven's ``authors`` is ``{name: role}``; we want the name list."""
+    raw = meta.get("authors")
+    if not isinstance(raw, dict):
+        return []
+    return list(raw.keys())
+
+
+def _published_date(meta: dict) -> str | None:
+    """polyhaven's ``date_published`` is a Unix epoch (int); return ISO date (UTC)."""
+    raw = meta.get("date_published")
+    if raw is None:
+        return None
+    try:
+        ts = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d")
+
+
 # ── main fetch ──────────────────────────────────────────────────
 
 
@@ -176,6 +270,12 @@ def _fetch_one(
 ) -> MaterialRecord:
     """Fetch a single polyhaven material. Called from thread pool."""
     name = meta.get("name", slug)
+    upstream = UpstreamBlock(
+        source="polyhaven",
+        schema_version=1,
+        fetched_at=utc_now_iso(),
+        raw=_filter_upstream(meta, UPSTREAM_ALLOWLIST),
+    )
     try:
         file_info = _fetch_files(slug)
         textures = _download_maps(file_info, tier, output_dir, slug)
@@ -197,6 +297,7 @@ def _fetch_one(
                         source_url=f"https://polyhaven.com/a/{slug}",
                     ),
                 ),
+                upstream=upstream,
                 status="failed",
             )
 
@@ -209,6 +310,7 @@ def _fetch_one(
             cat_str = ""
         cat = normalize_category(cat_str)
         tags = meta.get("tags", [])
+        description = meta.get("description") or None
 
         return MaterialRecord(
             id=slug,
@@ -217,12 +319,20 @@ def _fetch_one(
                 name=name,
                 category=cat,
                 tags=tags,
+                description=description,
                 upstream_id=slug,
+                physical=PhysicalBlock(
+                    dimensions_m=_dimensions_m(meta.get("dimensions")),
+                    max_resolution_px=_max_resolution_px(meta.get("max_resolution")),
+                ),
                 attribution=AttributionBlock(
+                    authors=_authors(meta),
                     license_spdx="CC0-1.0",
                     source_url=f"https://polyhaven.com/a/{slug}",
                 ),
+                dates=DatesBlock(published=_published_date(meta)),
             ),
+            upstream=upstream,
             available_tiers=[tier],
             maps=sorted(textures.keys()),
             texture_paths=textures,
@@ -240,6 +350,7 @@ def _fetch_one(
                     source_url=f"https://polyhaven.com/a/{slug}",
                 ),
             ),
+            upstream=upstream,
             status="failed",
         )
 

--- a/tests/test_ambientcg_extractor.py
+++ b/tests/test_ambientcg_extractor.py
@@ -1,0 +1,264 @@
+"""Tests for the ambientcg extractor — Phase B curated fields (#152).
+
+Phase B populates every ``mat_vis.*`` curated field the upstream API can
+provide, with deterministic fallback to ``None`` when a field is missing
+or carries the "unknown" sentinel (``dimension* = 0``).
+
+These tests lock the extraction in by driving the real upstream payload
+shape from ``ambientcg.com/api/v2/full_json`` against a mocked ZIP
+download, and asserting every Phase B field shows up on the resulting
+``MaterialRecord.mat_vis``.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from mat_vis_baker.sources.ambientcg import (
+    UPSTREAM_ALLOWLIST,
+    _dimensions_m,
+    _fetch_one,
+    _max_resolution_px,
+)
+
+
+# ── helpers ─────────────────────────────────────────────────────
+
+
+def _fake_zip_bytes() -> bytes:
+    """One-PNG ZIP with an ambientcg-shaped ``*_Color.png`` member."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("Bricks097_1K-PNG/Bricks097_1K-PNG_Color.png", b"\x89PNG\r\n\x1a\nfake")
+    return buf.getvalue()
+
+
+def _entry(**overrides: object) -> dict:
+    """Baseline ambientcg API entry; overrides mutate individual fields."""
+    base: dict = {
+        "assetId": "Bricks097",
+        "displayName": "Bricks 097",
+        "displayCategory": "Ceramic/Brick",
+        "tags": ["brick", "red"],
+        "description": "A red brick wall texture.",
+        "dimensionX": 500,  # mm
+        "dimensionY": 500,
+        "dimensionZ": 20,
+        "releaseDate": "2024-11-22T00:00:00Z",
+        "downloadFolders": {
+            "default": {
+                "downloadFiletypeCategories": {
+                    "zip": {
+                        "downloads": [
+                            {
+                                "attribute": "1K-PNG",
+                                "fullDownloadPath": "https://example.com/Bricks097_1K-PNG.zip",
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+# ── _dimensions_m ───────────────────────────────────────────────
+
+
+def test_dimensions_m_converts_mm_to_m() -> None:
+    assert _dimensions_m({"dimensionX": 500, "dimensionY": 250, "dimensionZ": 20}) == [
+        0.5,
+        0.25,
+        0.02,
+    ]
+
+
+def test_dimensions_m_zero_becomes_none_per_axis() -> None:
+    assert _dimensions_m({"dimensionX": 0, "dimensionY": 500, "dimensionZ": 0}) == [
+        None,
+        0.5,
+        None,
+    ]
+
+
+def test_dimensions_m_all_zero_returns_none() -> None:
+    """Harmonized with polyhaven (Phase C, #152 review): no measurable
+    axis → ``None`` at top level, not ``[None, None, None]``. Callers
+    get a single sentinel regardless of source."""
+    assert _dimensions_m({"dimensionX": 0, "dimensionY": 0, "dimensionZ": 0}) is None
+
+
+def test_dimensions_m_all_missing_returns_none() -> None:
+    assert _dimensions_m({"assetId": "x"}) is None
+
+
+def test_dimensions_m_tolerates_bad_values() -> None:
+    assert _dimensions_m({"dimensionX": "nope", "dimensionY": None, "dimensionZ": 100}) == [
+        None,
+        None,
+        0.1,
+    ]
+
+
+# ── _max_resolution_px ──────────────────────────────────────────
+
+
+def test_max_resolution_px_derived_from_tier() -> None:
+    assert _max_resolution_px("1k") == [1024, 1024]
+    assert _max_resolution_px("4k") == [4096, 4096]
+    assert _max_resolution_px("128") == [128, 128]
+
+
+def test_max_resolution_px_unknown_tier_is_none() -> None:
+    assert _max_resolution_px("99k") is None
+
+
+# ── _fetch_one end-to-end ───────────────────────────────────────
+
+
+def test_fetch_one_populates_phase_b_fields(tmp_path: Path) -> None:
+    entry = _entry()
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.ambientcg.retry_request", return_value=mock_resp):
+        rec = _fetch_one(entry, "1k", tmp_path, mtlx_dir=None)
+
+    assert rec.status == "ok"
+    mv = rec.mat_vis
+    assert mv.name == "Bricks 097"
+    assert mv.category == "ceramic"
+    assert mv.tags == ["brick", "red"]
+    assert mv.description == "A red brick wall texture."
+    assert mv.physical.dimensions_m == [0.5, 0.5, 0.02]
+    assert mv.physical.max_resolution_px == [1024, 1024]
+    assert mv.attribution.license_spdx == "CC0-1.0"
+    assert mv.attribution.source_url == "https://ambientcg.com/a/Bricks097"
+    assert mv.dates.published == "2024-11-22"
+    assert mv.dates.updated == "2024-11-22"
+    assert mv.upstream_id == "Bricks097"
+
+
+def test_fetch_one_handles_missing_description(tmp_path: Path) -> None:
+    entry = _entry(description=None)
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.ambientcg.retry_request", return_value=mock_resp):
+        rec = _fetch_one(entry, "1k", tmp_path, mtlx_dir=None)
+    assert rec.mat_vis.description is None
+
+
+def test_fetch_one_handles_missing_dimensions(tmp_path: Path) -> None:
+    entry = _entry()
+    for k in ("dimensionX", "dimensionY", "dimensionZ"):
+        entry.pop(k, None)
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.ambientcg.retry_request", return_value=mock_resp):
+        rec = _fetch_one(entry, "2k", tmp_path, mtlx_dir=None)
+    assert rec.mat_vis.physical.dimensions_m is None
+    assert rec.mat_vis.physical.max_resolution_px == [2048, 2048]
+
+
+def test_fetch_one_handles_zero_dimensions(tmp_path: Path) -> None:
+    """Upstream leaves 0 for "not measured" on synthetic / abstract textures.
+
+    Harmonized with polyhaven (Phase C, #152 review): zero across the board
+    maps to ``None`` top-level, not ``[None, None, None]``."""
+    entry = _entry(dimensionX=0, dimensionY=0, dimensionZ=0)
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.ambientcg.retry_request", return_value=mock_resp):
+        rec = _fetch_one(entry, "1k", tmp_path, mtlx_dir=None)
+    assert rec.mat_vis.physical.dimensions_m is None
+
+
+def test_fetch_one_builds_stable_mat_vis_shape(tmp_path: Path) -> None:
+    """Even a minimal entry flows through with all nested blocks present."""
+    entry = _entry(description=None, tags=[])
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.ambientcg.retry_request", return_value=mock_resp):
+        rec = _fetch_one(entry, "1k", tmp_path, mtlx_dir=None)
+
+    # every sub-block is a real dataclass instance, not None
+    assert rec.mat_vis.physical is not None
+    assert rec.mat_vis.pbr is not None
+    assert rec.mat_vis.attribution is not None
+    assert rec.mat_vis.dates is not None
+    # pbr stays empty — ambientcg doesn't expose scalar PBR properties
+    assert rec.mat_vis.pbr.color_rgb is None
+    assert rec.mat_vis.pbr.roughness is None
+
+
+# ── upstream mirror (Phase C, mat-vis#152) ──────────────────────
+
+
+def test_fetch_one_populates_upstream_block(tmp_path: Path) -> None:
+    """``upstream.raw`` carries allowlisted upstream keys verbatim."""
+    entry = _entry()
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.ambientcg.retry_request", return_value=mock_resp):
+        rec = _fetch_one(entry, "1k", tmp_path, mtlx_dir=None)
+
+    assert rec.upstream is not None
+    assert rec.upstream.source == "ambientcg"
+    assert rec.upstream.schema_version == 1
+    assert rec.upstream.fetched_at is not None
+    assert rec.upstream.fetched_at.endswith("Z")
+    raw = rec.upstream.raw
+    assert raw is not None
+    # allowlisted keys that _entry() populates should pass through
+    assert raw["assetId"] == "Bricks097"
+    assert raw["displayName"] == "Bricks 097"
+    assert raw["displayCategory"] == "Ceramic/Brick"
+    assert raw["tags"] == ["brick", "red"]
+    assert raw["dimensionX"] == 500
+
+
+def test_fetch_one_strips_non_allowlisted_keys(tmp_path: Path) -> None:
+    """``downloadFolders`` is explicitly out of the allowlist — the tree
+    is large, bake-internal, and would churn with every upstream URL
+    rotation. It must be absent from ``upstream.raw``."""
+    entry = _entry()
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.ambientcg.retry_request", return_value=mock_resp):
+        rec = _fetch_one(entry, "1k", tmp_path, mtlx_dir=None)
+
+    assert rec.upstream is not None
+    raw = rec.upstream.raw or {}
+    assert "downloadFolders" not in raw
+    # Also a handful of other known-dropped keys
+    for dropped in (
+        "previewLinks",
+        "previewImage",
+        "variations",
+        "basedOnThis",
+        "nextVariationAssetId",
+    ):
+        assert dropped not in raw
+
+
+def test_fetch_one_sets_upstream_even_on_failure(tmp_path: Path) -> None:
+    """``_fetch_one`` must attach ``upstream`` on the failed-download path too —
+    the schema-diff gate compares allowlist drift per-record, including
+    failures, so the block is a stable contract regardless of ``status``."""
+    entry = _entry()
+    with patch(
+        "mat_vis_baker.sources.ambientcg.retry_request",
+        side_effect=RuntimeError("boom"),
+    ):
+        rec = _fetch_one(entry, "1k", tmp_path, mtlx_dir=None)
+
+    assert rec.status == "failed"
+    assert rec.upstream is not None
+    assert rec.upstream.source == "ambientcg"
+    assert (rec.upstream.raw or {}).get("assetId") == "Bricks097"
+
+
+def test_upstream_allowlist_locks_conservative_keyset() -> None:
+    """If we bump the allowlist, the test must change too — this is the
+    deliberate friction that makes ``Phase C`` allowlist edits reviewable."""
+    assert "assetId" in UPSTREAM_ALLOWLIST
+    assert "dimensionX" in UPSTREAM_ALLOWLIST
+    assert "downloadFolders" not in UPSTREAM_ALLOWLIST
+    assert "previewLinks" not in UPSTREAM_ALLOWLIST

--- a/tests/test_check_upstream_schema_drift.py
+++ b/tests/test_check_upstream_schema_drift.py
@@ -1,0 +1,174 @@
+"""Tests for scripts/check_upstream_schema_drift.py (ADR-0011 / mat-vis#152 phase-c).
+
+The script is a CI gate. We don't hit the network — every test monkeypatches
+:func:`_http_get` and :func:`_latest_release_tag` so the behavior we're
+locking in is the diff logic itself, not urllib.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "check_upstream_schema_drift.py"
+
+
+@pytest.fixture(scope="module")
+def drift_module():
+    """Load the script as a module — it's not a real package."""
+    spec = importlib.util.spec_from_file_location("drift_gate", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["drift_gate"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _entry(mid: str, *, upstream_raw: dict | None = None, mv_overrides: dict | None = None) -> dict:
+    """Build a v3-envelope index entry with optional upstream + mat_vis overrides."""
+    mv = {
+        "name": mid,
+        "category": "other",
+        "tags": [],
+        "description": None,
+        "physical": {"dimensions_m": None, "max_resolution_px": None},
+        "pbr": {
+            "color_rgb": None,
+            "roughness": None,
+            "metalness": None,
+            "ior": None,
+            "specular_f0": None,
+            "transmission": None,
+            "complex_ior": None,
+        },
+        "attribution": {"authors": [], "license_spdx": "CC0-1.0", "source_url": ""},
+        "dates": {"published": None, "updated": None},
+        "upstream_id": mid,
+    }
+    if mv_overrides:
+        for key, val in mv_overrides.items():
+            # shallow merge: "pbr.roughness" → mv["pbr"]["roughness"]
+            if "." in key:
+                block, leaf = key.split(".", 1)
+                mv[block][leaf] = val
+            else:
+                mv[key] = val
+    entry = {"id": mid, "source": "ambientcg", "mat_vis": mv, "maps": []}
+    if upstream_raw is not None:
+        entry["upstream"] = {
+            "source": "ambientcg",
+            "schema_version": 1,
+            "fetched_at": "2026-04-20T16:00:00Z",
+            "raw": upstream_raw,
+        }
+    return entry
+
+
+def _write_catalog(tmp_path: Path, entries: list[dict]) -> Path:
+    p = tmp_path / "candidate.json"
+    p.write_text(json.dumps(entries))
+    return p
+
+
+# ── first-run free passes ───────────────────────────────────────
+
+
+def test_no_previous_tag_is_free_pass(drift_module, tmp_path, monkeypatch):
+    candidate = _write_catalog(tmp_path, [_entry("A", upstream_raw={"x": 1})])
+    monkeypatch.setattr(drift_module, "_latest_release_tag", lambda: None)
+    assert drift_module.run("ambientcg", str(candidate)) == 0
+
+
+def test_previous_catalog_fetch_fails_is_free_pass(drift_module, tmp_path, monkeypatch):
+    candidate = _write_catalog(tmp_path, [_entry("A", upstream_raw={"x": 1})])
+    monkeypatch.setattr(drift_module, "_fetch_previous_catalog", lambda *a, **kw: None)
+    assert drift_module.run("ambientcg", str(candidate), previous_tag="v0.5.0") == 0
+
+
+def test_previous_without_upstream_block_is_free_pass(drift_module, tmp_path, monkeypatch):
+    """Pre-Phase-C releases are the ONE moment we skip the gate."""
+    candidate = _write_catalog(tmp_path, [_entry("A", upstream_raw={"x": 1})])
+    # Previous catalog carries mat_vis but no upstream block.
+    prev = [_entry("A")]
+    monkeypatch.setattr(drift_module, "_fetch_previous_catalog", lambda *a, **kw: prev)
+    assert drift_module.run("ambientcg", str(candidate), previous_tag="v0.5.0") == 0
+
+
+# ── new upstream keys: warn, don't fail ─────────────────────────
+
+
+def test_new_upstream_keys_warn_but_pass(drift_module, tmp_path, monkeypatch, caplog):
+    prev = [_entry("A", upstream_raw={"x": 1, "y": 2})]
+    candidate = _write_catalog(
+        tmp_path,
+        [_entry("A", upstream_raw={"x": 1, "y": 2, "z": 3})],
+    )
+    monkeypatch.setattr(drift_module, "_fetch_previous_catalog", lambda *a, **kw: prev)
+    with caplog.at_level("WARNING"):
+        rc = drift_module.run("ambientcg", str(candidate), previous_tag="v0.6.0")
+    assert rc == 0
+    assert any("NEW key" in msg and "z" in msg for msg in caplog.messages)
+
+
+# ── removed mat_vis keys: fail ──────────────────────────────────
+
+
+def test_removed_mat_vis_key_fails(drift_module, tmp_path, monkeypatch):
+    prev = [_entry("A", upstream_raw={"x": 1})]
+    # candidate drops ``pbr.complex_ior`` entirely
+    cand_entry = _entry("A", upstream_raw={"x": 1})
+    cand_entry["mat_vis"]["pbr"].pop("complex_ior")
+    candidate = _write_catalog(tmp_path, [cand_entry])
+    monkeypatch.setattr(drift_module, "_fetch_previous_catalog", lambda *a, **kw: prev)
+    assert drift_module.run("ambientcg", str(candidate), previous_tag="v0.6.0") == 1
+
+
+# ── presence regression: fail ───────────────────────────────────
+
+
+def test_presence_regression_fails(drift_module, tmp_path, monkeypatch):
+    """20 records populated ``pbr.roughness`` in prev; only 10 in candidate →
+    100% → 50%, a 50pp drop, well above the 5pp threshold."""
+    prev = [
+        _entry(f"M{i}", upstream_raw={"x": 1}, mv_overrides={"pbr.roughness": 0.5})
+        for i in range(20)
+    ]
+    cand = [
+        _entry(f"M{i}", upstream_raw={"x": 1}, mv_overrides={"pbr.roughness": 0.5})
+        for i in range(10)
+    ] + [_entry(f"M{i}", upstream_raw={"x": 1}) for i in range(10, 20)]
+    candidate = _write_catalog(tmp_path, cand)
+    monkeypatch.setattr(drift_module, "_fetch_previous_catalog", lambda *a, **kw: prev)
+    assert drift_module.run("ambientcg", str(candidate), previous_tag="v0.6.0") == 1
+
+
+def test_presence_regression_within_threshold_passes(drift_module, tmp_path, monkeypatch):
+    """5pp drop is the boundary — NOT strictly greater, so this passes."""
+    prev = [
+        _entry(f"M{i}", upstream_raw={"x": 1}, mv_overrides={"pbr.roughness": 0.5})
+        for i in range(20)
+    ]
+    # 19/20 = 95%, prev was 100%, 5pp drop is NOT > 5.
+    cand = [
+        _entry(f"M{i}", upstream_raw={"x": 1}, mv_overrides={"pbr.roughness": 0.5})
+        for i in range(19)
+    ] + [_entry("M19", upstream_raw={"x": 1})]
+    candidate = _write_catalog(tmp_path, cand)
+    monkeypatch.setattr(drift_module, "_fetch_previous_catalog", lambda *a, **kw: prev)
+    assert drift_module.run("ambientcg", str(candidate), previous_tag="v0.6.0") == 0
+
+
+# ── happy path ─────────────────────────────────────────────────
+
+
+def test_identical_catalog_passes(drift_module, tmp_path, monkeypatch):
+    cat = [
+        _entry("A", upstream_raw={"x": 1, "y": 2}, mv_overrides={"pbr.roughness": 0.5}),
+        _entry("B", upstream_raw={"x": 3, "y": 4}, mv_overrides={"pbr.roughness": 0.7}),
+    ]
+    monkeypatch.setattr(drift_module, "_fetch_previous_catalog", lambda *a, **kw: cat)
+    candidate = _write_catalog(tmp_path, cat)
+    assert drift_module.run("ambientcg", str(candidate), previous_tag="v0.6.0") == 0

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,6 +1,11 @@
 """Tests for mat_vis_baker.common."""
 
-from mat_vis_baker.common import normalize_category, normalize_channel
+from mat_vis_baker.common import (
+    UpstreamBlock,
+    _filter_upstream,
+    normalize_category,
+    normalize_channel,
+)
 
 
 class TestNormalizeCategory:
@@ -47,3 +52,52 @@ class TestNormalizeChannel:
 
     def test_unknown_source(self):
         assert normalize_channel("unknown_source", "color") is None
+
+
+class TestFilterUpstream:
+    def test_keeps_allowlisted_keys(self):
+        raw = {"a": 1, "b": 2, "c": 3}
+        assert _filter_upstream(raw, frozenset({"a", "c"})) == {"a": 1, "c": 3}
+
+    def test_drops_unlisted_keys(self):
+        raw = {"keep": 1, "drop": 2}
+        assert _filter_upstream(raw, frozenset({"keep"})) == {"keep": 1}
+
+    def test_empty_allowlist_returns_empty_dict(self):
+        assert _filter_upstream({"a": 1}, frozenset()) == {}
+
+    def test_non_dict_input_returns_empty(self):
+        assert _filter_upstream(None, frozenset({"a"})) == {}
+        assert _filter_upstream("oops", frozenset({"a"})) == {}
+        assert _filter_upstream([1, 2, 3], frozenset({"a"})) == {}
+
+    def test_shallow_nested_dict_passes_through_verbatim(self):
+        raw = {"meta": {"nested": "kept-whole"}, "drop": "bye"}
+        out = _filter_upstream(raw, frozenset({"meta"}))
+        assert out == {"meta": {"nested": "kept-whole"}}
+        # shallow copy at top-level; nested dicts are identity-shared and
+        # that's fine — we never mutate filtered output in the pipeline.
+        assert out["meta"] is raw["meta"]
+
+    def test_missing_keys_are_not_inserted(self):
+        """Allowlist lists what we WANT; absent keys stay absent."""
+        assert _filter_upstream({}, frozenset({"a", "b"})) == {}
+
+
+class TestUpstreamBlock:
+    def test_defaults(self):
+        u = UpstreamBlock()
+        assert u.source == ""
+        assert u.schema_version == 1
+        assert u.fetched_at is None
+        assert u.raw is None
+
+    def test_explicit_fields(self):
+        u = UpstreamBlock(
+            source="ambientcg",
+            schema_version=1,
+            fetched_at="2026-04-20T16:00:00Z",
+            raw={"assetId": "Bricks097"},
+        )
+        assert u.source == "ambientcg"
+        assert u.raw == {"assetId": "Bricks097"}

--- a/tests/test_gpuopen_extractor.py
+++ b/tests/test_gpuopen_extractor.py
@@ -1,0 +1,242 @@
+"""Tests for the gpuopen extractor — Phase B curated fields (#152).
+
+gpuopen's /api/materials/<uuid>/ response carries ``description``
+(often null), a single ``author`` string (usually ``"AMD"``),
+``published_date`` / ``updated_date`` ISO datetimes, and a package
+label like ``"1k 8b"`` — we derive ``max_resolution_px`` from the tier
+the bake is running (not from the label, since a single bake is tied
+to one tier).
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from mat_vis_baker.sources.gpuopen import (
+    UPSTREAM_ALLOWLIST,
+    _authors,
+    _fetch_one,
+    _iso_date,
+    _max_resolution_px,
+)
+
+
+# ── helpers ─────────────────────────────────────────────────────
+
+
+def _fake_zip_bytes() -> bytes:
+    """Tiny ZIP with a ``.mtlx`` + one basecolor PNG — enough to flow through."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("oak/material.mtlx", b"<materialx/>")
+        zf.writestr("oak/oak_basecolor.png", b"\x89PNG\r\n\x1a\nfake")
+    return buf.getvalue()
+
+
+def _mat(**overrides: object) -> dict:
+    base: dict = {
+        "id": "abcd-1234",
+        "title": "Oak Planks",
+        "description": "Warm oak planks.",
+        "author": "AMD",
+        "published_date": "2022-08-01T12:00:00Z",
+        "updated_date": "2023-03-15T09:30:00Z",
+        "_category_title": "Wood",
+        "_tag_titles": ["wood", "planks"],
+        "_packages_detail": [
+            {
+                "id": "pkg-1k-8b",
+                "label": "1k 8b",
+                "file_url": "https://example.com/oak_1k_8b.zip",
+            }
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+# ── _authors ────────────────────────────────────────────────────
+
+
+def test_authors_wraps_single_string() -> None:
+    assert _authors({"author": "AMD"}) == ["AMD"]
+
+
+def test_authors_strips_whitespace() -> None:
+    assert _authors({"author": "  AMD  "}) == ["AMD"]
+
+
+def test_authors_missing_is_empty() -> None:
+    assert _authors({}) == []
+    assert _authors({"author": None}) == []
+    assert _authors({"author": ""}) == []
+    assert _authors({"author": "   "}) == []
+
+
+# ── _iso_date ───────────────────────────────────────────────────
+
+
+def test_iso_date_truncates_datetime_to_date() -> None:
+    assert _iso_date("2022-08-01T12:00:00Z") == "2022-08-01"
+
+
+def test_iso_date_preserves_date_only() -> None:
+    assert _iso_date("2022-08-01") == "2022-08-01"
+
+
+def test_iso_date_missing_is_none() -> None:
+    assert _iso_date(None) is None
+    assert _iso_date("") is None
+    assert _iso_date(42) is None
+
+
+def test_iso_date_rejects_malformed_separators() -> None:
+    """Phase B review follow-up (#152): ``raw[:10]`` used to pass
+    ``"2022/08/01"`` through verbatim. The regex guard rejects anything
+    that isn't strict YYYY-MM-DD."""
+    assert _iso_date("2022/08/01") is None
+    assert _iso_date("2022.08.01") is None
+    assert _iso_date("not-a-date") is None
+    assert _iso_date("22-08-01-ignored") is None  # slice would be "22-08-01-", not ISO
+    assert _iso_date("20220801T12") is None  # no separators
+
+
+# ── _max_resolution_px ──────────────────────────────────────────
+
+
+def test_max_resolution_px_from_tier() -> None:
+    assert _max_resolution_px("1k") == [1024, 1024]
+    assert _max_resolution_px("4k") == [4096, 4096]
+
+
+def test_max_resolution_px_unknown_tier_is_none() -> None:
+    assert _max_resolution_px("huge") is None
+
+
+# ── _fetch_one end-to-end ───────────────────────────────────────
+
+
+def test_fetch_one_populates_phase_b_fields(tmp_path: Path) -> None:
+    mat = _mat()
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
+        rec = _fetch_one(mat, "1k", tmp_path, mtlx_dir=None)
+
+    assert rec.status == "ok"
+    mv = rec.mat_vis
+    assert mv.name == "Oak Planks"
+    assert mv.category == "wood"
+    assert mv.tags == ["wood", "planks"]
+    assert mv.description == "Warm oak planks."
+    assert mv.physical.max_resolution_px == [1024, 1024]
+    # upstream doesn't provide physical dimensions; stays null
+    assert mv.physical.dimensions_m is None
+    assert mv.attribution.authors == ["AMD"]
+    assert mv.attribution.license_spdx == "MIT"
+    assert mv.attribution.source_url == (
+        "https://matlib.gpuopen.com/main/materials/all?material=abcd-1234"
+    )
+    assert mv.dates.published == "2022-08-01"
+    assert mv.dates.updated == "2023-03-15"
+    assert mv.upstream_id == "abcd-1234"
+
+
+def test_fetch_one_handles_null_description(tmp_path: Path) -> None:
+    """gpuopen frequently returns description: null upstream."""
+    mat = _mat(description=None)
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
+        rec = _fetch_one(mat, "1k", tmp_path, mtlx_dir=None)
+    assert rec.mat_vis.description is None
+
+
+def test_fetch_one_handles_missing_dates(tmp_path: Path) -> None:
+    mat = _mat(published_date=None, updated_date=None)
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
+        rec = _fetch_one(mat, "1k", tmp_path, mtlx_dir=None)
+    assert rec.mat_vis.dates.published is None
+    assert rec.mat_vis.dates.updated is None
+
+
+def test_fetch_one_failed_record_still_has_stable_shape(tmp_path: Path) -> None:
+    """A material with no matching package returns a failed record whose
+    mat_vis block still carries every Phase B field we CAN derive from
+    the material dict (resolution still falls out of the tier)."""
+    mat = _mat(_packages_detail=[])  # no packages → immediate failure
+    rec = _fetch_one(mat, "2k", tmp_path, mtlx_dir=None)
+    assert rec.status == "failed"
+    mv = rec.mat_vis
+    # metadata we know from the /materials/ endpoint still populates
+    assert mv.name == "Oak Planks"
+    assert mv.description == "Warm oak planks."
+    assert mv.attribution.authors == ["AMD"]
+    assert mv.physical.max_resolution_px == [2048, 2048]
+    assert mv.dates.published == "2022-08-01"
+
+
+# ── upstream mirror (Phase C, mat-vis#152) ──────────────────────
+
+
+def test_fetch_one_populates_upstream_block(tmp_path: Path) -> None:
+    mat = _mat(
+        license="MIT",
+        material_type="standard_surface",
+        status="published",
+        created_date="2022-01-01T00:00:00Z",
+        mtlx_filename="oak.mtlx",
+        mtlx_material_name="M_Oak",
+    )
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
+        rec = _fetch_one(mat, "1k", tmp_path, mtlx_dir=None)
+
+    assert rec.upstream is not None
+    assert rec.upstream.source == "gpuopen"
+    raw = rec.upstream.raw or {}
+    assert raw["id"] == "abcd-1234"
+    assert raw["title"] == "Oak Planks"
+    assert raw["license"] == "MIT"
+    assert raw["mtlx_filename"] == "oak.mtlx"
+
+
+def test_fetch_one_strips_fetcher_internals_and_packages(tmp_path: Path) -> None:
+    """``_category_title`` / ``_tag_titles`` / ``_packages_detail`` are
+    fetcher-internal, and ``packages`` / ``renders`` are too heavy to
+    mirror. None of them should leak into ``upstream.raw``."""
+    mat = _mat(
+        packages=["uuid-1", "uuid-2"],
+        renders=["render-a"],
+        renders_order=["render-a"],
+        viewer_package="uuid-viewer",
+        favorite=False,
+        notification_status="none",
+    )
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
+        rec = _fetch_one(mat, "1k", tmp_path, mtlx_dir=None)
+    raw = (rec.upstream.raw if rec.upstream else {}) or {}
+    for dropped in (
+        "_category_title",
+        "_tag_titles",
+        "_packages_detail",
+        "packages",
+        "renders",
+        "renders_order",
+        "viewer_package",
+        "favorite",
+        "notification_status",
+    ):
+        assert dropped not in raw, dropped
+
+
+def test_upstream_allowlist_includes_mtlx_anchor() -> None:
+    """``mtlx_filename`` and ``mtlx_material_name`` anchor our MaterialX
+    republish back to the upstream source record. They must be allowlisted."""
+    assert "mtlx_filename" in UPSTREAM_ALLOWLIST
+    assert "mtlx_material_name" in UPSTREAM_ALLOWLIST
+    assert "packages" not in UPSTREAM_ALLOWLIST
+    assert "renders" not in UPSTREAM_ALLOWLIST

--- a/tests/test_index_builder.py
+++ b/tests/test_index_builder.py
@@ -15,6 +15,7 @@ from mat_vis_baker.common import (
     MatVisBlock,
     PBRBlock,
     PhysicalBlock,
+    UpstreamBlock,
 )
 from mat_vis_baker.index_builder import build_index
 
@@ -170,3 +171,67 @@ def test_available_tiers_present_when_populated() -> None:
     rec.available_tiers = ["1k", "2k"]
     entry = build_index([rec], source="ambientcg")[0]
     assert entry["available_tiers"] == ["1k", "2k"]
+
+
+# ── upstream mirror (Phase C, mat-vis#152) ──────────────────────
+
+
+def test_upstream_block_omitted_when_not_set() -> None:
+    """Records without an ``upstream`` block don't emit the key at all
+    (pre-v3 backfill stays valid). The contract is: when the key is
+    present, all four subkeys are present; when absent, callers know
+    to fall back."""
+    entry = build_index([_minimal_rec()], source="ambientcg")[0]
+    assert "upstream" not in entry
+
+
+def test_upstream_block_emitted_with_stable_key_set() -> None:
+    rec = _minimal_rec()
+    rec.upstream = UpstreamBlock(
+        source="ambientcg",
+        schema_version=1,
+        fetched_at="2026-04-20T16:00:00Z",
+        raw={"assetId": "Rock064", "displayName": "Rock 064"},
+    )
+    entry = build_index([rec], source="ambientcg")[0]
+    assert "upstream" in entry
+    upstream = entry["upstream"]
+    assert set(upstream.keys()) == {"source", "schema_version", "fetched_at", "raw"}
+    assert upstream["source"] == "ambientcg"
+    assert upstream["schema_version"] == 1
+    assert upstream["fetched_at"] == "2026-04-20T16:00:00Z"
+    assert upstream["raw"]["assetId"] == "Rock064"
+
+
+def test_upstream_block_empty_raw_emits_empty_dict() -> None:
+    """When the allowlist emptied everything, ``raw`` is ``{}`` (preferred
+    over ``None`` — stable downstream shape)."""
+    rec = _minimal_rec()
+    rec.upstream = UpstreamBlock(
+        source="ambientcg",
+        schema_version=1,
+        fetched_at="2026-04-20T16:00:00Z",
+        raw={},
+    )
+    entry = build_index([rec], source="ambientcg")[0]
+    assert entry["upstream"]["raw"] == {}
+
+
+def test_upstream_block_carries_through_failed_records() -> None:
+    """Schema-diff runs on failed records too (allowlist drift applies
+    regardless of download success)."""
+    rec = MaterialRecord(
+        id="Broken",
+        source="ambientcg",
+        mat_vis=MatVisBlock(name="Broken", upstream_id="Broken"),
+        upstream=UpstreamBlock(
+            source="ambientcg",
+            schema_version=1,
+            fetched_at="2026-04-20T16:00:00Z",
+            raw={"assetId": "Broken"},
+        ),
+        status="failed",
+    )
+    entry = build_index([rec], source="ambientcg")[0]
+    assert entry["status"] == "failed"
+    assert entry["upstream"]["raw"] == {"assetId": "Broken"}

--- a/tests/test_physicallybased_extractor.py
+++ b/tests/test_physicallybased_extractor.py
@@ -15,7 +15,14 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from mat_vis_baker.sources.physicallybased import _normalize_tags, fetch
+from mat_vis_baker.sources.physicallybased import (
+    UPSTREAM_ALLOWLIST,
+    _complex_ior,
+    _normalize_tags,
+    _specular_f0,
+    _transmission,
+    fetch,
+)
 
 
 def test_normalize_tags_populated() -> None:
@@ -87,3 +94,170 @@ def test_fetch_populates_tags_from_upstream() -> None:
     assert by_name["Banana"].mat_vis.tags == []
     # case-folded, de-duplicated, order preserved
     assert by_name["Car Paint"].mat_vis.tags == ["acrylic", "coat", "car paint", "lacquer"]
+
+
+# ── Phase B helpers (#152) ──────────────────────────────────────
+
+
+def test_specular_f0_extracts_rgb_triple() -> None:
+    assert _specular_f0([0.04, 0.04, 0.04]) == [0.04, 0.04, 0.04]
+
+
+def test_specular_f0_rejects_garbage() -> None:
+    assert _specular_f0(None) is None
+    assert _specular_f0([0.04, 0.04]) is None  # under-length
+    assert _specular_f0(["bad", "worse", "meh"]) is None
+
+
+def test_transmission_float_passthrough() -> None:
+    assert _transmission(0.95) == 0.95
+    assert _transmission(0) == 0.0
+    assert _transmission(None) is None
+    assert _transmission("not-a-float") is None
+
+
+def test_complex_ior_passes_six_float_through() -> None:
+    raw = [1.39, 7.61, 0.96, 6.55, 0.62, 5.25]
+    assert _complex_ior(raw) == raw
+
+
+def test_complex_ior_passes_arbitrary_length_in_phase_b() -> None:
+    """Phase B doesn't strip — Phase C's allowlist can debate that later."""
+    assert _complex_ior([1.0, 2.0]) == [1.0, 2.0]
+
+
+def test_complex_ior_missing_is_none() -> None:
+    assert _complex_ior(None) is None
+    assert _complex_ior([]) is None
+
+
+def test_complex_ior_rejects_non_floats() -> None:
+    assert _complex_ior([1.0, "bad", 3.0]) is None
+
+
+# ── end-to-end Phase B fields on the record ─────────────────────
+
+
+def test_fetch_populates_phase_b_pbr_fields() -> None:
+    """Every Phase B pbr.* field flows through from realistic upstream."""
+    fake_api = [
+        {
+            "name": "Aluminum",
+            "category": "metal",
+            "description": "Polished aluminum with characteristic blueish sheen.",
+            "color": [0.912, 0.914, 0.920],
+            "ior": 1.39,
+            "metalness": 1.0,
+            "roughness": 0.0,
+            "specularColor": [0.912, 0.914, 0.920],
+            "transmission": 0.0,
+            "complexIor": [1.39, 7.61, 0.96, 6.55, 0.62, 5.25],
+            "tags": ["aluminium", "mirror"],
+        },
+        {
+            "name": "Glass",
+            "category": "glass",
+            "description": "Crown optical glass.",
+            "color": [1.0, 1.0, 1.0],
+            "ior": 1.52,
+            "metalness": 0.0,
+            "roughness": 0.0,
+            "specularColor": [0.04, 0.04, 0.04],
+            "transmission": 1.0,
+            "tags": ["glass", "transparent"],
+            # no complexIor upstream on dielectrics
+        },
+        {
+            "name": "Plaster",
+            "category": "plaster",
+            "color": [0.93, 0.93, 0.93],
+            "ior": 1.5,
+            # no description, no specularColor, no transmission, no complexIor
+            "tags": [],
+        },
+    ]
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = fake_api
+
+    with patch("mat_vis_baker.sources.physicallybased.retry_request", return_value=mock_resp):
+        records = fetch()
+
+    by_name = {r.mat_vis.name: r for r in records}
+
+    al = by_name["Aluminum"].mat_vis
+    assert al.description == "Polished aluminum with characteristic blueish sheen."
+    assert al.pbr.specular_f0 == [0.912, 0.914, 0.920]
+    assert al.pbr.transmission == 0.0
+    assert al.pbr.complex_ior == [1.39, 7.61, 0.96, 6.55, 0.62, 5.25]
+
+    glass = by_name["Glass"].mat_vis
+    assert glass.pbr.specular_f0 == [0.04, 0.04, 0.04]
+    assert glass.pbr.transmission == 1.0
+    # absent upstream → None (not KeyError, not default-to-0)
+    assert glass.pbr.complex_ior is None
+
+    plaster = by_name["Plaster"].mat_vis
+    assert plaster.description is None
+    assert plaster.pbr.specular_f0 is None
+    assert plaster.pbr.transmission is None
+    assert plaster.pbr.complex_ior is None
+    # existing fields still populated
+    assert plaster.pbr.ior == 1.5
+
+
+# ── upstream mirror (Phase C, mat-vis#152) ──────────────────────
+
+
+def test_fetch_populates_upstream_block() -> None:
+    fake_api = [
+        {
+            "name": "Aluminum",
+            "category": "metal",
+            "description": "Polished aluminum.",
+            "color": [0.9, 0.9, 0.9],
+            "ior": 1.39,
+            "metalness": 1.0,
+            "roughness": 0.0,
+            "complexIor": [1.39, 7.61, 0.96, 6.55, 0.62, 5.25],
+            "tags": ["aluminium"],
+            "acousticAbsorption": [0.1, 0.15, 0.2],
+            # a made-up out-of-allowlist key to prove the filter works
+            "__internal_debug": "should-be-dropped",
+        },
+    ]
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = fake_api
+    with patch("mat_vis_baker.sources.physicallybased.retry_request", return_value=mock_resp):
+        records = fetch()
+
+    assert records[0].upstream is not None
+    upstream = records[0].upstream
+    assert upstream.source == "physicallybased"
+    assert upstream.schema_version == 1
+    raw = upstream.raw or {}
+    # scientifically-useful keys survive
+    assert raw["name"] == "Aluminum"
+    assert raw["complexIor"] == [1.39, 7.61, 0.96, 6.55, 0.62, 5.25]
+    assert raw["acousticAbsorption"] == [0.1, 0.15, 0.2]
+    # out-of-allowlist key is dropped
+    assert "__internal_debug" not in raw
+
+
+def test_upstream_allowlist_covers_scientific_fields() -> None:
+    # All the Phase-B ``mat_vis.pbr.*`` sources plus the acoustic /
+    # subsurface extras must be in the allowlist so a naïve upstream
+    # schema diff doesn't flag them as ``REMOVED``.
+    for key in (
+        "color",
+        "roughness",
+        "metalness",
+        "ior",
+        "specularColor",
+        "complexIor",
+        "transmission",
+        "density",
+        "viscosity",
+        "subsurfaceRadius",
+        "acousticAbsorption",
+    ):
+        assert key in UPSTREAM_ALLOWLIST, key

--- a/tests/test_polyhaven_extractor.py
+++ b/tests/test_polyhaven_extractor.py
@@ -1,0 +1,220 @@
+"""Tests for the polyhaven extractor — Phase B curated fields (#152).
+
+Polyhaven's ``/info/<slug>`` payload is the richest of the four sources:
+description, physical dimensions (mm 2-tuple), max resolution (px),
+per-author attribution dict, and a Unix-epoch publish date. Phase B
+wires all of them into ``mat_vis.*``.
+
+These tests drive each helper in isolation + an end-to-end ``_fetch_one``
+against a realistic mocked upstream payload.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from mat_vis_baker.sources.polyhaven import (
+    UPSTREAM_ALLOWLIST,
+    _authors,
+    _dimensions_m,
+    _fetch_one,
+    _max_resolution_px,
+    _published_date,
+)
+
+
+# ── _dimensions_m ───────────────────────────────────────────────
+
+
+def test_dimensions_m_converts_mm_two_tuple_to_m_triple() -> None:
+    assert _dimensions_m([1000, 2000]) == [1.0, 2.0, None]
+
+
+def test_dimensions_m_zero_axis_becomes_none() -> None:
+    assert _dimensions_m([0, 1500]) == [None, 1.5, None]
+
+
+def test_dimensions_m_both_zero_returns_none() -> None:
+    assert _dimensions_m([0, 0]) is None
+
+
+def test_dimensions_m_none_or_missing() -> None:
+    assert _dimensions_m(None) is None
+    assert _dimensions_m([]) is None
+    assert _dimensions_m([500]) is None  # under-length
+
+
+def test_dimensions_m_dict_shape_is_tolerated() -> None:
+    """Some polyhaven entries upstream carry dict-shaped dimensions."""
+    assert _dimensions_m({"x": 1000, "y": 500}) == [1.0, 0.5, None]
+
+
+def test_dimensions_m_tolerates_bad_values() -> None:
+    assert _dimensions_m(["bad", 1000]) == [None, 1.0, None]
+
+
+# ── _max_resolution_px ──────────────────────────────────────────
+
+
+def test_max_resolution_px_passes_through() -> None:
+    assert _max_resolution_px([8192, 8192]) == [8192, 8192]
+
+
+def test_max_resolution_px_rejects_garbage() -> None:
+    assert _max_resolution_px(None) is None
+    assert _max_resolution_px([1024]) is None
+    assert _max_resolution_px(["bad", "worse"]) is None
+
+
+# ── _authors ────────────────────────────────────────────────────
+
+
+def test_authors_extracts_keys_from_dict() -> None:
+    assert _authors({"authors": {"Rob Tuytel": "All", "Jarod Guest": "Scan"}}) == [
+        "Rob Tuytel",
+        "Jarod Guest",
+    ]
+
+
+def test_authors_missing_is_empty_list() -> None:
+    assert _authors({}) == []
+    assert _authors({"authors": None}) == []
+    assert _authors({"authors": ["not-a-dict"]}) == []
+
+
+# ── _published_date ─────────────────────────────────────────────
+
+
+def test_published_date_converts_unix_epoch_to_iso_date() -> None:
+    # 2023-06-15 00:00:00 UTC = 1686787200
+    assert _published_date({"date_published": 1686787200}) == "2023-06-15"
+
+
+def test_published_date_missing_is_none() -> None:
+    assert _published_date({}) is None
+    assert _published_date({"date_published": None}) is None
+
+
+def test_published_date_bad_value_is_none() -> None:
+    assert _published_date({"date_published": "not-a-timestamp"}) is None
+
+
+# ── _fetch_one end-to-end ───────────────────────────────────────
+
+
+def _meta(**overrides: object) -> dict:
+    base: dict = {
+        "name": "Wood Floor",
+        "categories": ["wood"],
+        "tags": ["wood", "floor", "planks"],
+        "description": "Seamless wood floor texture.",
+        "dimensions": [2000, 2000],
+        "max_resolution": [8192, 8192],
+        "authors": {"Rob Tuytel": "All"},
+        "date_published": 1686787200,
+    }
+    base.update(overrides)
+    return base
+
+
+def _file_info(tier_key: str = "1k") -> dict:
+    """Shape matching polyhaven ``/files/<slug>``."""
+    return {
+        "Diffuse": {tier_key: {"png": {"url": "https://example.com/diff.png"}}},
+    }
+
+
+def test_fetch_one_populates_phase_b_fields(tmp_path: Path) -> None:
+    meta = _meta()
+    file_info = _file_info()
+    png_resp = MagicMock(content=b"\x89PNG\r\n\x1a\nfake")
+
+    with (
+        patch("mat_vis_baker.sources.polyhaven._fetch_files", return_value=file_info),
+        patch("mat_vis_baker.sources.polyhaven.retry_request", return_value=png_resp),
+    ):
+        rec = _fetch_one("wood_floor", meta, "1k", tmp_path)
+
+    assert rec.status == "ok"
+    mv = rec.mat_vis
+    assert mv.name == "Wood Floor"
+    assert mv.category == "wood"
+    assert mv.tags == ["wood", "floor", "planks"]
+    assert mv.description == "Seamless wood floor texture."
+    assert mv.physical.dimensions_m == [2.0, 2.0, None]
+    assert mv.physical.max_resolution_px == [8192, 8192]
+    assert mv.attribution.authors == ["Rob Tuytel"]
+    assert mv.attribution.license_spdx == "CC0-1.0"
+    assert mv.attribution.source_url == "https://polyhaven.com/a/wood_floor"
+    assert mv.dates.published == "2023-06-15"
+    assert mv.upstream_id == "wood_floor"
+
+
+def test_fetch_one_tolerates_missing_optional_fields(tmp_path: Path) -> None:
+    """polyhaven entries with sparse metadata still flow through cleanly."""
+    meta = _meta(
+        description=None,
+        dimensions=None,
+        max_resolution=None,
+        authors=None,
+        date_published=None,
+    )
+    png_resp = MagicMock(content=b"\x89PNG\r\n\x1a\nfake")
+    with (
+        patch("mat_vis_baker.sources.polyhaven._fetch_files", return_value=_file_info()),
+        patch("mat_vis_baker.sources.polyhaven.retry_request", return_value=png_resp),
+    ):
+        rec = _fetch_one("wood_floor", meta, "1k", tmp_path)
+
+    mv = rec.mat_vis
+    assert mv.description is None
+    assert mv.physical.dimensions_m is None
+    assert mv.physical.max_resolution_px is None
+    assert mv.attribution.authors == []
+    assert mv.dates.published is None
+
+
+# ── upstream mirror (Phase C, mat-vis#152) ──────────────────────
+
+
+def test_fetch_one_populates_upstream_block(tmp_path: Path) -> None:
+    meta = _meta()
+    png_resp = MagicMock(content=b"\x89PNG\r\n\x1a\nfake")
+    with (
+        patch("mat_vis_baker.sources.polyhaven._fetch_files", return_value=_file_info()),
+        patch("mat_vis_baker.sources.polyhaven.retry_request", return_value=png_resp),
+    ):
+        rec = _fetch_one("wood_floor", meta, "1k", tmp_path)
+
+    assert rec.upstream is not None
+    assert rec.upstream.source == "polyhaven"
+    assert rec.upstream.schema_version == 1
+    assert rec.upstream.fetched_at is not None
+    raw = rec.upstream.raw or {}
+    assert raw["name"] == "Wood Floor"
+    assert raw["authors"] == {"Rob Tuytel": "All"}
+    assert raw["tags"] == ["wood", "floor", "planks"]
+    assert raw["dimensions"] == [2000, 2000]
+
+
+def test_fetch_one_strips_non_allowlisted_keys(tmp_path: Path) -> None:
+    """``files_hash`` + ``thumbnail_url`` must not leak into the mirror."""
+    meta = _meta(files_hash={"Diffuse": "deadbeef"}, thumbnail_url="https://cdn/tn.png")
+    png_resp = MagicMock(content=b"\x89PNG\r\n\x1a\nfake")
+    with (
+        patch("mat_vis_baker.sources.polyhaven._fetch_files", return_value=_file_info()),
+        patch("mat_vis_baker.sources.polyhaven.retry_request", return_value=png_resp),
+    ):
+        rec = _fetch_one("wood_floor", meta, "1k", tmp_path)
+
+    raw = (rec.upstream.raw if rec.upstream else {}) or {}
+    assert "files_hash" not in raw
+    assert "thumbnail_url" not in raw
+
+
+def test_upstream_allowlist_locks_conservative_keyset() -> None:
+    assert "name" in UPSTREAM_ALLOWLIST
+    assert "authors" in UPSTREAM_ALLOWLIST
+    assert "files_hash" not in UPSTREAM_ALLOWLIST
+    assert "thumbnail_url" not in UPSTREAM_ALLOWLIST


### PR DESCRIPTION
## Summary

Phase C of mat-vis#152 / ADR-0011: the Layer-2 verbatim upstream mirror plus the stability guardrails around it. **PR 3/3 of a stacked review — user merges the whole stack at the end.** Target is the Phase B branch, not \`dev\`.

### Four parts

1. **\`upstream.raw\` block + per-source allowlists.** New \`UpstreamBlock\` dataclass lives at top-level of \`MaterialRecord\` alongside \`mat_vis\`. Each source defines a \`UPSTREAM_ALLOWLIST: frozenset[str]\` and populates the block via a shared shallow \`_filter_upstream\` helper. Allowlists are hand-maintained — adding a key is a reviewable PR, not a schema auto-learn loop.

2. **\`index_builder\` emits \`upstream\`.** When \`rec.upstream\` is set, build_index serializes the four-key block (\`source\` / \`schema_version\` / \`fetched_at\` / \`raw\`). Always all four when present; absent entirely for pre-v3 / minimal records.

3. **Client \`upstream()\` accessor + strip.** \`MatVisClient.upstream(source, material_id)\` returns the source-shaped \`raw\` dict (docstring labels it UNSTABLE, not covered by semver). \`client.index()\` / \`client.search()\` now return shallow-stripped copies so the unstable shape never leaks into the stable query surface. Package + standalone clients mirror each other (\`test_standalone_drift\` enforces).

4. **CI schema-diff gate.** \`scripts/check_upstream_schema_drift.py\` diffs the candidate \`<source>.json\` against the previous HF release. Warns on new \`upstream.raw\` keys (the interesting signal for allowlist widening), fails on removed \`mat_vis.*\` keys, fails on >5pp \`mat_vis.*\` presence regression. First-run free pass when the previous release has no \`upstream\` block (pre-Phase-C). Wired into \`.github/workflows/bake.yml\` after \`hf-bake\`.

### Phase B review follow-ups (commit 6)

- **Harmonize \`_dimensions_m\`** across ambientcg / polyhaven: \`None\` top-level when nothing is measurable; \`[x, y, None]\` when partial. One sentinel per source.
- **Tighten \`_iso_date\`** in gpuopen: \`raw[:10]\` + \`^\d{4}-\d{2}-\d{2}$\` regex guard so malformed input (\`\"2022/08/01\"\`) returns \`None\` instead of passing through.

### Allowlist sizing

- ambientcg: 17 keys (dropped \`downloadFolders\`, \`previewLinks\`, variation pointers, weekly/monthly download counters)
- polyhaven: 10 keys (dropped \`files_hash\`, \`thumbnail_url\`, \`sponsors\`, \`staging\`, \`old_id\`)
- physicallybased: 24 keys (kept the full scientific payload — complex IOR, transmission, subsurface, acoustic, thin-film, density + viscosity)
- gpuopen: 12 keys (dropped \`packages\`, \`renders\`, \`renders_order\`, \`viewer_package\`, \`favorite\`, \`notification_status\` + fetcher-internal \`_*\` keys)

## Test plan

- [x] \`uv run pytest tests/\` — 302 passed, 1 skipped (baseline was 276 passed; Phase C adds 26 new tests)
- [x] \`uv run pytest clients/python/tests/\` — 98 passed, 26 failed (down from 39 failed pre-Phase-C; my \`MOCK_MANIFEST\` schema_version=1→2 fix unblocked pre-existing baseline failures)
- [x] \`ruff check\` / \`ruff format --check\` clean on every touched file
- [x] \`test_standalone_drift\` still passes — standalone client mirrors the new \`upstream()\` method
- [x] Six commits, each passing tests independently

## Not in this PR

- Rebake (per brief — Phase C is code-only; the next bake will populate the new block)
- v3 → v4 schema bump (\`upstream\` is additive within v3 per ADR-0011)
- Auto-widening the allowlist (hand-maintained; widening is a reviewable PR)

## Stack context

- PR 1/3: Phase A (nested \`mat_vis\` block, v3 schema, ADR-0011) — already merged into Phase B branch
- PR 2/3: Phase B (populate every curated Layer-1 field across all four sources) — already on target branch
- **PR 3/3: this one** — Phase C. Stacked on Phase B; user merges the whole stack at the end.