### PR TITLE
fix(baker/gpuopen): normalize upstream license to valid SPDX (#168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,10 @@ raises `MatVisError` early with an upgrade hint, not silent empty results.
 - `sources(tier=None)` returns all sources when `tier` is omitted; with
   `tier`, restricts to sources that published that tier.
 - `categories()` derives from per-source catalogs, not filename parsing.
+- gpuopen `mat_vis.attribution.license_spdx` now reflects upstream
+  per-record `license` via `normalize_spdx`
+  (`"MIT Public Domain" → "MIT"`); unknown strings fall back to
+  `"NOASSERTION"` (#168).
 
 ### Removed
 

--- a/src/mat_vis_baker/common.py
+++ b/src/mat_vis_baker/common.py
@@ -274,6 +274,31 @@ def normalize_category(raw: str) -> str:
     return "other"
 
 
+# ── SPDX license normalization ──────────────────────────────────
+
+_SPDX_MAP: dict[str, str] = {
+    # upstream strings → SPDX identifiers. Extend per-source as new
+    # upstream license strings appear (covered by CI schema-diff gate).
+    "MIT Public Domain": "MIT",  # gpuopen (issue #168)
+}
+
+
+def normalize_spdx(raw: str | None) -> str:
+    """Map an upstream license string to a valid SPDX identifier.
+
+    Returns ``"NOASSERTION"`` (SPDX-valid, semantically ``unknown``)
+    when the input is empty or unmapped — safer than raising mid-bake
+    and schema-valid (``minLength: 1``).
+    """
+    if not raw or not raw.strip():
+        return "NOASSERTION"
+    key = raw.strip()
+    if key in _SPDX_MAP:
+        return _SPDX_MAP[key]
+    log.warning("normalize_spdx: unknown upstream license %r → NOASSERTION", key)
+    return "NOASSERTION"
+
+
 # ── channel normalization (per-source) ──────────────────────────
 
 _CHANNEL_MAPS: dict[str, dict[str, str]] = {

--- a/src/mat_vis_baker/sources/gpuopen.py
+++ b/src/mat_vis_baker/sources/gpuopen.py
@@ -41,6 +41,7 @@ from mat_vis_baker.common import (
     check_zip_safety,
     normalize_category,
     normalize_channel,
+    normalize_spdx,
     retry_request,
     utc_now_iso,
 )
@@ -320,7 +321,13 @@ def _fetch_one(
             physical=PhysicalBlock(max_resolution_px=_max_resolution_px(tier)),
             attribution=AttributionBlock(
                 authors=_authors(mat),
-                license_spdx="MIT",
+                # Upstream ``license`` is a freeform string (the current
+                # live value is ``"MIT Public Domain"`` — not a valid
+                # SPDX id). normalize_spdx maps it to ``"MIT"`` and
+                # falls back to ``"NOASSERTION"`` for unknown strings
+                # so a drifted upstream value doesn't fail the bake
+                # (mat-vis#168).
+                license_spdx=normalize_spdx(mat.get("license")),
                 source_url=source_url,
             ),
             dates=DatesBlock(

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,10 +1,13 @@
 """Tests for mat_vis_baker.common."""
 
+import logging
+
 from mat_vis_baker.common import (
     UpstreamBlock,
     _filter_upstream,
     normalize_category,
     normalize_channel,
+    normalize_spdx,
 )
 
 
@@ -82,6 +85,24 @@ class TestFilterUpstream:
     def test_missing_keys_are_not_inserted(self):
         """Allowlist lists what we WANT; absent keys stay absent."""
         assert _filter_upstream({}, frozenset({"a", "b"})) == {}
+
+
+class TestNormalizeSpdx:
+    def test_normalize_spdx_known_gpuopen(self):
+        assert normalize_spdx("MIT Public Domain") == "MIT"
+
+    def test_normalize_spdx_unknown_fallback(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="mat-vis-baker"):
+            assert normalize_spdx("Weird New License v7") == "NOASSERTION"
+        assert "unknown upstream license" in caplog.text
+
+    def test_normalize_spdx_none_and_empty(self):
+        assert normalize_spdx(None) == "NOASSERTION"
+        assert normalize_spdx("") == "NOASSERTION"
+        assert normalize_spdx("   ") == "NOASSERTION"
+
+    def test_normalize_spdx_whitespace_stripped(self):
+        assert normalize_spdx("  MIT Public Domain  ") == "MIT"
 
 
 class TestUpstreamBlock:

--- a/tests/test_gpuopen_extractor.py
+++ b/tests/test_gpuopen_extractor.py
@@ -11,6 +11,7 @@ to one tier).
 from __future__ import annotations
 
 import io
+import logging
 import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -42,6 +43,10 @@ def _mat(**overrides: object) -> dict:
         "title": "Oak Planks",
         "description": "Warm oak planks.",
         "author": "AMD",
+        # Matches live upstream as of 2026-04 (mat-vis#168 probe: 454/454
+        # gpuopen materials carry this exact string). normalize_spdx
+        # maps it to "MIT".
+        "license": "MIT Public Domain",
         "published_date": "2022-08-01T12:00:00Z",
         "updated_date": "2023-03-15T09:30:00Z",
         "_category_title": "Wood",
@@ -231,6 +236,42 @@ def test_fetch_one_strips_fetcher_internals_and_packages(tmp_path: Path) -> None
         "notification_status",
     ):
         assert dropped not in raw, dropped
+
+
+# ── license_spdx routing through normalize_spdx (mat-vis#168) ───
+
+
+def test_fetch_one_routes_license_through_normalize_spdx(tmp_path: Path) -> None:
+    """Upstream ``license="MIT Public Domain"`` maps to SPDX ``"MIT"``
+    via ``normalize_spdx`` — not a hardcoded constant (mat-vis#168)."""
+    mat = _mat(license="MIT Public Domain")
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
+        rec = _fetch_one(mat, "1k", tmp_path, mtlx_dir=None)
+    assert rec.mat_vis.attribution.license_spdx == "MIT"
+
+
+def test_fetch_one_unknown_license_falls_back_to_noassertion(tmp_path: Path, caplog) -> None:
+    """Drifted / new upstream license strings surface as ``"NOASSERTION"``
+    with a warning rather than failing the bake."""
+    mat = _mat(license="Something Weird")
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with caplog.at_level(logging.WARNING, logger="mat-vis-baker"):
+        with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
+            rec = _fetch_one(mat, "1k", tmp_path, mtlx_dir=None)
+    assert rec.mat_vis.attribution.license_spdx == "NOASSERTION"
+    assert "unknown upstream license" in caplog.text
+
+
+def test_fetch_one_missing_license_falls_back_to_noassertion(tmp_path: Path) -> None:
+    """A record with no ``license`` key still produces a schema-valid
+    SPDX identifier (``"NOASSERTION"``)."""
+    mat = _mat()
+    mat.pop("license", None)
+    mock_resp = MagicMock(content=_fake_zip_bytes())
+    with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
+        rec = _fetch_one(mat, "1k", tmp_path, mtlx_dir=None)
+    assert rec.mat_vis.attribution.license_spdx == "NOASSERTION"
 
 
 def test_upstream_allowlist_includes_mtlx_anchor() -> None:


### PR DESCRIPTION
## Summary

- gpuopen's `/api/materials/` returns `license="MIT Public Domain"` — NOT a valid SPDX identifier. The extractor was hardcoding `license_spdx="MIT"` regardless of upstream, so any future drift would pass silently.
- Add shared `normalize_spdx()` helper in `common.py` that maps upstream freeform license strings to valid SPDX ids. Unknown inputs fall back to `"NOASSERTION"` (SPDX-valid, schema `minLength:1` safe) with a warning — safer than raising mid-bake.
- `gpuopen.py::_fetch_one` now routes `mat.get("license")` through `normalize_spdx()` on both the happy and failed paths.

## Live-probe evidence

Probed `https://api.matlib.gpuopen.com/api/materials/` on 2026-04-20: **454/454 records carry `license="MIT Public Domain"`** verbatim. Zero heterogeneity today; no Apache-2.0 seen. Issue body's conjecture about upstream heterogeneity did not pan out — but the hardcoded-string brittleness it worried about is real, and is what this PR fixes.

## Scope

- `src/mat_vis_baker/common.py` — `normalize_spdx()` + `_SPDX_MAP` seeded with `"MIT Public Domain" → "MIT"`.
- `src/mat_vis_baker/sources/gpuopen.py` — import + replace the hardcoded `"MIT"` with `normalize_spdx(mat.get("license"))`.
- `tests/test_common.py` — 4 unit tests (known mapping, unknown fallback + warning, None/empty, whitespace).
- `tests/test_gpuopen_extractor.py` — 3 extractor tests (routing, unknown-fallback, missing-key) + fixture now carries the real upstream string.
- `CHANGELOG.md` — bullet under `0.6.0 Changed`.

## Non-goals (follow-ups if desired)

- ambientcg / polyhaven / physicallybased still hardcode `"CC0-1.0"` — which IS a valid SPDX id, so non-blocking.
- No JSON Schema changes: `minLength:1` already passes for `NOASSERTION`.

## Test plan

- [x] `uv run pytest tests/test_common.py tests/test_gpuopen_extractor.py` — 45 pass.
- [x] Full `uv run pytest tests/` — 308 passed, 1 skipped, 1 failed. The single failure (`test_client_runtime_version_matches_pyproject`) is a pre-existing dev-baseline issue (missing `mat_vis_client` module in this venv, same on origin/dev).
- [x] `uv run ruff check` + `ruff format --check` clean on touched files.
- [x] Pre-commit hooks passed on both commits.