### PR TITLE
fix(client/standalone): port missing search kwargs + tighten signature drift test (#171)

### DIFF
--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -855,14 +855,21 @@ class MatVisClient:
             context=f"{source}/{tier}",
         )
 
+    _SCALAR_WIDEN = 0.2  # scalar shorthand → range half-width
+
     def search(
         self,
         category: str | None = None,
         *,
+        roughness: float | None = None,
+        metalness: float | None = None,
         roughness_range: tuple[float, float] | None = None,
         metalness_range: tuple[float, float] | None = None,
         source: str | None = None,
         tier: str = "1k",
+        tag: str | None = None,
+        score: bool = False,
+        limit: int | None = None,
     ) -> list[dict]:
         """Search materials by category and scalar ranges.
 
@@ -871,12 +878,47 @@ class MatVisClient:
 
         Args:
             category: Filter by material category (e.g. "metal", "wood").
+            roughness: Scalar shorthand. Matches within ± ``_SCALAR_WIDEN``.
+                Mutually exclusive with ``roughness_range``.
+            metalness: Scalar shorthand. Same semantics as ``roughness``.
             roughness_range: (min, max) roughness filter, inclusive.
             metalness_range: (min, max) metalness filter, inclusive.
             source: Limit search to one source. If None, searches all
                     sources available for the given tier.
             tier: Only return materials that have this tier available.
+            tag: Optional release tag override (see .at()).
+            score: When True and a scalar shorthand is passed, attach a
+                ``score`` field (absolute distance) and sort ascending.
+            limit: Cap the returned list length.
         """
+        if tag is not None and tag != self._tag:
+            return self.at(tag).search(
+                category,
+                roughness=roughness,
+                metalness=metalness,
+                roughness_range=roughness_range,
+                metalness_range=metalness_range,
+                source=source,
+                tier=tier,
+                score=score,
+                limit=limit,
+            )
+        # Scalar + range on the same dimension is ambiguous — reject.
+        if roughness is not None and roughness_range is not None:
+            raise MatVisError("pass roughness OR roughness_range, not both")
+        if metalness is not None and metalness_range is not None:
+            raise MatVisError("pass metalness OR metalness_range, not both")
+        # Scalar shorthand widens into an inclusive range.
+        if roughness is not None:
+            roughness_range = (
+                max(0.0, roughness - self._SCALAR_WIDEN),
+                min(1.0, roughness + self._SCALAR_WIDEN),
+            )
+        if metalness is not None:
+            metalness_range = (
+                max(0.0, metalness - self._SCALAR_WIDEN),
+                min(1.0, metalness + self._SCALAR_WIDEN),
+            )
         if category:
             valid = self.categories()  # discovered from manifest
             if valid and category not in valid:
@@ -911,6 +953,19 @@ class MatVisClient:
                     continue
                 results.append(entry)
 
+        if score and (roughness is not None or metalness is not None):
+            for r in results:
+                pbr = (r.get("mat_vis") or {}).get("pbr") or {}
+                s = 0.0
+                if roughness is not None and pbr.get("roughness") is not None:
+                    s += abs(pbr["roughness"] - roughness)
+                if metalness is not None and pbr.get("metalness") is not None:
+                    s += abs(pbr["metalness"] - metalness)
+                r["score"] = s
+            results.sort(key=lambda r: r["score"])
+
+        if limit is not None:
+            results = results[:limit]
         return results
 
     # ── Bulk operations ─────────────────────────────────────────
@@ -1699,6 +1754,59 @@ def main():
             print(
                 f"  {kind:8s}  {entry['current'] or '?'} {arrow} {entry['latest'] or '?'}{marker}"
             )
+
+
+# ── Module-level convenience API ────────────────────────────────
+#
+# Mirrors the packaged ``mat_vis_client.__init__`` helpers so that the
+# single-file standalone exposes the same free-function surface as the
+# installable package. Kept thin: delegates to a process-wide singleton
+# client so repeated calls share manifest / index / texture caches.
+
+_client: MatVisClient | None = None
+
+
+def get_client() -> MatVisClient:
+    """Return the process-wide ``MatVisClient`` singleton.
+
+    Lazily constructed on first call. Downstream consumers that want to
+    share the manifest/index/texture cache with the module-level
+    ``search()`` helper should use this instead of ``MatVisClient()``
+    directly.
+    """
+    global _client
+    if _client is None:
+        _client = MatVisClient()
+    return _client
+
+
+def search(
+    *,
+    category: str | None = None,
+    roughness: float | None = None,
+    metalness: float | None = None,
+    source: str | None = None,
+    tier: str = "1k",
+    tag: str | None = None,
+    limit: int = 20,
+) -> list[dict]:
+    """Search the mat-vis index by category and scalar similarity.
+
+    Thin forwarder to :meth:`MatVisClient.search` with ``score=True`` —
+    the scoring/sorting + default ``limit=20`` are the only module-level
+    convenience on top of the method. Every other argument is just passed
+    through.
+    """
+    return get_client().search(
+        category,
+        roughness=roughness,
+        metalness=metalness,
+        source=source,
+        tier=tier,
+        tag=tag,
+        score=True,
+        limit=limit,
+    )
 
 
 if __name__ == "__main__":

--- a/clients/python/tests/test_search_unified.py
+++ b/clients/python/tests/test_search_unified.py
@@ -10,6 +10,8 @@ different parameter conventions depending on where you called it.
 
 from __future__ import annotations
 
+import importlib.util as _importlib_util
+from pathlib import Path as _Path
 from unittest.mock import patch
 
 import pytest
@@ -250,3 +252,108 @@ def test_search_issue_167_repro_physicallybased_metals():
             results = c.search(source="physicallybased", metalness=1.0, tier="1k")
     ids = {r["material_id"] for r in results}
     assert ids == {"Iron", "Gold"}
+
+
+# ── Standalone search parity (mat-vis#171) ────────────────────────
+#
+# The single-file standalone at ``clients/python/mat_vis_client_standalone.py``
+# used to carry a minimal ``search()`` signature (no scalar shorthand, no
+# score/limit/tag). These tests exercise the ported kwargs so behavioral
+# regressions in the standalone get caught alongside the signature-drift
+# test in ``tests/test_standalone_drift.py``.
+
+
+def _load_standalone():
+    """Side-load the standalone module by file path (not on sys.path)."""
+    repo_root = _Path(__file__).resolve().parents[3]
+    path = repo_root / "clients" / "python" / "mat_vis_client_standalone.py"
+    spec = _importlib_util.spec_from_file_location("_mat_vis_standalone_for_search_tests", path)
+    assert spec is not None and spec.loader is not None
+    mod = _importlib_util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_standalone_search_scalar_roughness_widens():
+    """Standalone: ``search(roughness=0.3)`` widens into ± _SCALAR_WIDEN."""
+    std = _load_standalone()
+    c = std.MatVisClient()
+    with patch.object(c, "sources", return_value=["ambientcg"]):
+        with patch.object(c, "index", return_value=MOCK_INDEX):
+            with patch.object(c, "categories", return_value=frozenset(["metal", "wood"])):
+                results = c.search(category="metal", roughness=0.3)
+    ids = [r["material_id"] for r in results]
+    # Metal032 (0.3) and Metal050A (0.5, boundary inclusive) are within 0.3 ± 0.2.
+    assert "Metal032" in ids
+    assert "Metal050A" in ids
+
+
+def test_standalone_search_score_sorts_ascending_by_distance():
+    """Standalone: ``search(roughness=0.3, score=True)`` attaches + sorts by distance."""
+    std = _load_standalone()
+    c = std.MatVisClient()
+    with patch.object(c, "sources", return_value=["ambientcg"]):
+        with patch.object(c, "index", return_value=MOCK_INDEX):
+            with patch.object(c, "categories", return_value=frozenset(["metal", "wood"])):
+                results = c.search(category="metal", roughness=0.3, score=True)
+    ids = [r["material_id"] for r in results]
+    assert ids[0] == "Metal032"  # diff 0 comes first
+    for r in results:
+        assert "score" in r
+
+
+def test_standalone_search_limit_truncates():
+    """Standalone: ``search(limit=N)`` truncates result list."""
+    std = _load_standalone()
+    c = std.MatVisClient()
+    with patch.object(c, "sources", return_value=["ambientcg"]):
+        with patch.object(c, "index", return_value=MOCK_INDEX):
+            with patch.object(c, "categories", return_value=frozenset(["metal", "wood"])):
+                results = c.search(limit=1)
+    assert len(results) == 1
+
+
+def test_standalone_search_tag_kwarg_accepted():
+    """Standalone: ``search(tag=...)`` dispatches to a pinned client without TypeError.
+
+    We don't assert on the pinned client's behaviour — only that the call
+    signature accepts the kwarg and forwards it through ``self.at(tag)``.
+    """
+    std = _load_standalone()
+    c = std.MatVisClient()
+
+    class _FakePinned:
+        calls: list[dict] = []
+
+        def search(self, category=None, **kwargs):
+            _FakePinned.calls.append({"category": category, **kwargs})
+            return []
+
+    with patch.object(c, "at", return_value=_FakePinned()):
+        out = c.search(category="metal", tag="v2026.04.1")
+    assert out == []
+    assert _FakePinned.calls and _FakePinned.calls[0]["category"] == "metal"
+
+
+def test_standalone_search_rejects_both_scalar_and_range():
+    """Standalone mirrors the packaged guard: can't pass both shorthand + range."""
+    std = _load_standalone()
+    c = std.MatVisClient()
+    with pytest.raises(std.MatVisError, match="roughness"):
+        c.search(roughness=0.3, roughness_range=(0.1, 0.5))
+
+
+def test_standalone_module_level_search_forwards_with_score_and_limit():
+    """Standalone's module-level ``search()`` applies score=True + default limit=20."""
+    std = _load_standalone()
+    # Reset the standalone's own singleton so the patch targets a fresh client.
+    std._client = None
+    client = std.get_client()
+    with patch.object(client, "sources", return_value=["ambientcg"]):
+        with patch.object(client, "index", return_value=MOCK_INDEX):
+            with patch.object(client, "categories", return_value=frozenset(["metal", "wood"])):
+                mod_results = std.search(category="metal", roughness=0.3)
+    # score=True was applied, so results carry a 'score' field and are sorted.
+    assert mod_results
+    assert "score" in mod_results[0]
+    assert mod_results[0]["material_id"] == "Metal032"

--- a/tests/test_standalone_drift.py
+++ b/tests/test_standalone_drift.py
@@ -15,11 +15,35 @@ means CI has to enforce they agree.
 from __future__ import annotations
 
 import ast
+import importlib.util
+import inspect
+import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 PACKAGE = REPO / "clients" / "python" / "src" / "mat_vis_client" / "client.py"
 STANDALONE = REPO / "clients" / "python" / "mat_vis_client_standalone.py"
+
+# (class_name, method_name) pairs whose drift is a *pre-existing* divergence
+# documented as non-goals in mat-vis#171. The per-operation ``tag=`` kwarg on
+# ``fetch_texture`` / ``fetch_all_textures`` / ``mtlx`` / ``prefetch`` is part
+# of the ``at()`` family (standalone doesn't forward per-op tags to a pinned
+# client); the issue explicitly calls out ``at()`` and that family as
+# non-goals. ``MtlxSource.*`` is entry-listed the same way (no actual drift at
+# time of writing, but we allow the whole class to be pre-existing-divergent).
+#
+# Do NOT expand this list without citing a follow-up issue.
+_SIGNATURE_DRIFT_ALLOWLIST: set[tuple[str, str]] = {
+    ("MatVisClient", "at"),  # pre-existing divergence per mat-vis#171 non-goals
+    ("MatVisClient", "fetch_texture"),  # per-op tag= — at()-family, non-goal
+    ("MatVisClient", "fetch_all_textures"),  # per-op tag= — at()-family, non-goal
+    ("MatVisClient", "mtlx"),  # per-op tag= — at()-family, non-goal
+    ("MatVisClient", "prefetch"),  # per-op tag= — at()-family, non-goal
+}
+# Entire classes that are pre-existing-divergent (mat-vis#171 non-goals).
+_SIGNATURE_DRIFT_ALLOWLIST_CLASSES: set[str] = {
+    "MtlxSource",
+}
 
 
 def _inventory(path: Path) -> dict[str, set[str]]:
@@ -82,4 +106,116 @@ def test_standalone_exposes_same_public_module_functions():
     # lazy-imports via mat_vis_client.adapters.
     assert not missing, (
         f"standalone missing public module functions from package: {sorted(missing)}"
+    )
+
+
+def _load_module_from_file(path: Path, name: str):
+    """Import a Python file as a module object by file location.
+
+    Neither the packaged client (``clients/python/src/mat_vis_client/``)
+    nor the single-file standalone are on ``sys.path`` for this repo's
+    test root, so we side-load both by path. Keeps the drift test
+    self-contained — no optional install step required.
+    """
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_standalone_module():
+    return _load_module_from_file(STANDALONE, "_mat_vis_standalone_for_drift")
+
+
+def _load_packaged_module():
+    # The packaged client imports its own ``mat_vis_client.schema`` submodule,
+    # so the package root must be on ``sys.path`` even if the test environment
+    # didn't install the client. Import via the real package name rather than
+    # a side-loaded alias so relative imports resolve.
+    src_root = PACKAGE.parent.parent  # clients/python/src
+    if str(src_root) not in sys.path:
+        sys.path.insert(0, str(src_root))
+    import importlib
+
+    return importlib.import_module("mat_vis_client.client")
+
+
+def _sig_params(fn) -> dict[str, inspect._ParameterKind]:
+    """Return {name: kind} for every parameter of ``fn``.
+
+    Intentionally ignores type annotations and defaults — we only care
+    about the *shape* of the call surface (what kwargs the caller can
+    legitimately pass). This is what catches mat-vis#171: signature drift
+    that the AST name-only test misses.
+    """
+    sig = inspect.signature(fn)
+    return {name: p.kind for name, p in sig.parameters.items()}
+
+
+def test_standalone_method_signatures_match_package():
+    """For every (class, public method) pair present in both, compare
+    ``inspect.signature`` parameters (names + kinds).
+
+    Skips:
+      - private methods (``_``-prefixed), except ``__init__``
+      - inherited methods (only compare methods actually defined on the class)
+      - pairs listed in ``_SIGNATURE_DRIFT_ALLOWLIST`` / ``_CLASSES``
+        (pre-existing divergences documented as mat-vis#171 non-goals)
+
+    Any other drift fails loudly with a per-method diff.
+    """
+    pkg_mod = _load_packaged_module()
+    std_mod = _load_standalone_module()
+
+    mismatches: list[str] = []
+    for cls_name in dir(pkg_mod):
+        pkg_cls = getattr(pkg_mod, cls_name)
+        if not inspect.isclass(pkg_cls):
+            continue
+        if pkg_cls.__module__ != pkg_mod.__name__:
+            continue  # re-exports from stdlib etc.
+        if cls_name in _SIGNATURE_DRIFT_ALLOWLIST_CLASSES:
+            continue
+        std_cls = getattr(std_mod, cls_name, None)
+        if std_cls is None:
+            continue  # covered by test_standalone_exposes_same_classes
+
+        for method_name, pkg_m in inspect.getmembers(pkg_cls, predicate=inspect.isfunction):
+            if method_name.startswith("_") and method_name != "__init__":
+                continue
+            # Only compare methods actually defined on this class (not inherited).
+            if pkg_m.__qualname__.split(".")[0] != cls_name:
+                continue
+            if (cls_name, method_name) in _SIGNATURE_DRIFT_ALLOWLIST:
+                continue
+            std_m = getattr(std_cls, method_name, None)
+            if std_m is None:
+                continue  # covered by the class-surface test
+
+            try:
+                pkg_params = _sig_params(pkg_m)
+                std_params = _sig_params(std_m)
+            except (ValueError, TypeError):
+                continue  # e.g. built-in wrapper with no introspectable sig
+
+            if pkg_params != std_params:
+                pkg_extra = set(pkg_params) - set(std_params)
+                std_extra = set(std_params) - set(pkg_params)
+                kind_diff = {
+                    n: (pkg_params[n], std_params[n])
+                    for n in set(pkg_params) & set(std_params)
+                    if pkg_params[n] != std_params[n]
+                }
+                mismatches.append(
+                    f"{cls_name}.{method_name}: "
+                    f"missing_in_standalone={sorted(pkg_extra)} "
+                    f"extra_in_standalone={sorted(std_extra)} "
+                    f"kind_mismatch={kind_diff}"
+                )
+
+    assert not mismatches, (
+        "standalone ↔ package method signature drift (see mat-vis#171):\n  "
+        + "\n  ".join(mismatches)
     )


### PR DESCRIPTION
## Summary

Closes #171.

- **Tightens the drift test** (`tests/test_standalone_drift.py`): adds a fourth test that side-loads both the packaged client and the single-file standalone by file path, then compares `inspect.signature` parameters (names + kinds) for every (class, public method) pair defined on both. Private methods skipped. The AST-based tests were name-only — they missed kwargs drift (exactly what #171 flagged).
- **Ports missing `search()` kwargs** in `clients/python/mat_vis_client_standalone.py` so the standalone matches the packaged signature: `roughness` / `metalness` scalar shorthand, `tag` per-call override, `score` sorting, `limit` truncation. Includes the `_SCALAR_WIDEN = 0.2` module-level constant and the `self.at(tag).search(...)` forwarding.
- **Ports the module-level `search()` convenience wrapper** (plus a `get_client()` singleton) into the standalone — the packaged client exposes these in its `__init__.py`; the standalone had no equivalent.
- **Behavioral coverage** added in `clients/python/tests/test_search_unified.py` for the newly-ported kwargs on the standalone.

## Drift allowlist (mat-vis#171 non-goals)

The new signature test allows these pre-existing divergences (each with an inline rationale comment citing the issue):

- `MatVisClient.at` — documented non-goal in #171.
- `MatVisClient.fetch_texture` / `fetch_all_textures` / `mtlx` / `prefetch` — missing per-op `tag=` kwarg; part of the `at()` family, explicitly non-goal.
- `MtlxSource` (entire class) — documented non-goal. No actual drift at time of writing; allowlisted defensively.

Any drift *outside* this allowlist fails the test loudly. Do not expand the list without a follow-up issue.

## Test plan

- [x] `uv run --with pytest --with pillow --with pyarrow --with requests --with huggingface_hub pytest tests/test_standalone_drift.py -v` → 4/4 pass (including the new signature test).
- [x] Verified the new test fails on pre-fix standalone: stashing the client change leaves the test failing with `MatVisClient.search: missing_in_standalone=['limit', 'metalness', 'roughness', 'score', 'tag']` — proves it catches the issue drift.
- [x] `cd clients/python && uv run --with pytest pytest tests/ -v` → baseline 25 pre-existing failures (cache/live/network), no NEW failures. +6 new behavioral tests pass.
- [x] Ruff check + format clean on all touched files.
- [x] Pre-commit hooks pass on both commits.

## Do-not-merge

Per task: opening for review only, not merging.