### PR TITLE
feat(observability): self-hosted OTLP + Grafana sidecar compose (#139)

### DIFF
--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -1,0 +1,90 @@
+# Self-hosted OTLP + Grafana on a tailnet
+
+One-command bring-up of an observability stack for the mat-vis baker.
+Runs on any Docker/Podman host — laptop, `anvil`, a VPS — and joins
+the operator's tailnet as `mat-vis-otel` with `tag:observability`.
+
+## One-time setup
+
+1. **Tailscale ACL** — add `tag:observability` to `tagOwners` with
+   owner `["autogroup:admin"]`, grant
+   `tag:ci → tag:observability:4318` and
+   `autogroup:member → tag:observability:443` (or `:3000` for plain
+   HTTP). See `docs/observability.md`.
+
+   > **Known issue #176**: tagged auth-keys are rejected despite
+   > correct `tagOwners`. The compose ships with `--advertise-tags`
+   > commented out — the sidecar joins untagged, then apply the tag
+   > manually at **Machines → mat-vis-otel → Edit machine tags**.
+   > That uses a different validation path and works cleanly.
+
+2. **Auth** — stash a Tailscale OAuth client secret or a reusable
+   auth-key into the macOS login Keychain:
+
+   ```bash
+   security add-generic-password -U \
+     -a tailscale-observability \
+     -s TS_OBS_AUTHKEY \
+     -w "$(bw get password 'tailscale_mat-vis_token')"
+   ```
+
+## Bring it up
+
+```bash
+just observability-up
+```
+
+What it does: reads `TS_OBS_AUTHKEY` from Keychain, exports it to the
+compose env, runs `docker compose -f docs/observability/docker-compose.yml up -d`.
+
+## Access
+
+After ~10 s:
+
+- **Grafana UI**: `http://mat-vis-otel.<your-tailnet>.ts.net:3000`
+  (admin / admin on first login — change immediately).
+- **OTLP/HTTP receiver**: `http://mat-vis-otel.<your-tailnet>.ts.net:4318`
+  — wire this into `OTEL_EXPORTER_OTLP_ENDPOINT` for local bakes,
+  or into the `otlp-tailnet` composite action for CI.
+
+Find `<your-tailnet>` with `tailscale status --json | jq -r .Self.DNSName`.
+
+## Import the dashboard
+
+The repo ships with a committed Grafana dashboard:
+
+```bash
+curl -sf -u admin:admin \
+  -H 'Content-Type: application/json' \
+  -d "$(jq '{dashboard:., overwrite:true}' docs/observability/dashboard.json)" \
+  http://mat-vis-otel.<your-tailnet>.ts.net:3000/api/dashboards/db
+```
+
+Or use the Grafana UI → Dashboards → Import → upload
+`docs/observability/dashboard.json`.
+
+## Teardown
+
+```bash
+just observability-down
+```
+
+Because the tailnet node is ephemeral (`TS_AUTHKEY=…?ephemeral=true`),
+it deregisters automatically — no stale peer entries.
+
+## Moving the stack to another host
+
+The compose is host-agnostic. To move from your laptop to `anvil`:
+
+```bash
+# laptop
+just observability-down
+
+# anvil
+ssh anvil 'security find-generic-password ... # or pull from Bitwarden'
+scp docs/observability/docker-compose.yml anvil:/srv/otel/
+ssh anvil 'cd /srv/otel && docker compose up -d'
+```
+
+No state persists between hosts by design — the `otel-lgtm-data`
+volume is for the collector's recent-traces window only (72 h default).

--- a/docs/observability/docker-compose.yml
+++ b/docs/observability/docker-compose.yml
@@ -1,0 +1,64 @@
+# mat-vis self-hosted OTLP + Grafana stack (#139 follow-up).
+#
+# Runs two containers sharing a network namespace:
+#
+#   tailscale   — joins the operator's tailnet with tag:observability.
+#                 The node name is `mat-vis-otel`, so tailnet peers
+#                 reach Grafana at mat-vis-otel.<tailnet>.ts.net:3000
+#                 and the OTLP receiver at :4318 directly. No `tailscale
+#                 serve` layer — tailnet traffic is WireGuard-encrypted
+#                 end to end so HTTP is fine here.
+#   otel-lgtm   — Grafana + Tempo + Loki + Mimir in one image. Shares
+#                 the tailscale sidecar's network namespace, so
+#                 listening on localhost:{3000,4318} is enough.
+#
+# Authentication: Tailscale OAuth client secret (tskey-client-…) or a
+# reusable auth-key (tskey-auth-…). Stored in the macOS login Keychain:
+#
+#   security find-generic-password -a tailscale-observability \
+#     -s TS_OBS_AUTHKEY -w
+#
+# Bring-up: `just observability-up` (reads keychain → env → compose up).
+# Runs on any Docker/Podman host — laptop, anvil, VPS, whatever.
+
+services:
+  tailscale:
+    image: tailscale/tailscale:stable
+    hostname: mat-vis-otel
+    environment:
+      # Plain auth-key (tskey-auth-…): the ephemeral/reusable/tagged
+      # properties are baked in at key generation time. OAuth client
+      # secrets (tskey-client-…) also work and the sidecar mints its
+      # own ephemeral key at startup.
+      TS_AUTHKEY: "${TS_OBS_AUTHKEY:?set via just observability-up or keychain}"
+      # TS_EXTRA_ARGS: "--advertise-tags=tag:observability"
+      # ^ Intentionally commented out. Tagged auth-keys kept failing
+      # validation despite correct tagOwners — see issue #176.
+      # Workaround: join untagged, then apply tag:observability via
+      # Machines → mat-vis-otel → Edit machine tags in the admin UI.
+      # That uses a different validation path and succeeds cleanly.
+      # Revisit once #176 is resolved (likely via OAuth-minted keys).
+      TS_STATE_DIR: /var/lib/tailscale
+      # Userspace networking keeps this portable across Docker Desktop,
+      # Podman Machine, and Linux hosts. A native-kernel TUN would be
+      # faster, but for OTLP span rates this is immaterial (kB/s peak).
+      TS_USERSPACE: "true"
+    volumes:
+      - tailscale-state:/var/lib/tailscale
+    restart: unless-stopped
+
+  otel-lgtm:
+    image: grafana/otel-lgtm:latest
+    # Shared netns: otel-lgtm binds localhost:{3000,4318} which are the
+    # tailscale sidecar's tailnet IPs. Nothing else on the host sees
+    # these ports.
+    network_mode: service:tailscale
+    volumes:
+      - otel-lgtm-data:/data
+    depends_on:
+      - tailscale
+    restart: unless-stopped
+
+volumes:
+  tailscale-state:
+  otel-lgtm-data:

--- a/justfile.project
+++ b/justfile.project
@@ -250,3 +250,28 @@ gap-one source tier category tag:
     just gap-bake {{ source }} {{ tier }} {{ category }} {{ tag }}
     just gap-verify {{ source }} {{ tier }} {{ category }} {{ tag }}
     @echo "--- cell {{ source }}/{{ tier }}/{{ category }} filled. Next: gap-manifest + gap-validate at the end."
+
+# -------------------------------------------------------------------------------
+# OBSERVABILITY (self-hosted OTLP + Grafana on tailnet, #139)
+# -------------------------------------------------------------------------------
+
+# Bring up the OTLP collector + Grafana UI on the tailnet as tag:observability.
+# Reads the Tailscale auth-key from the macOS login Keychain (item
+# tailscale-observability / TS_OBS_AUTHKEY). Any Docker/Podman host works.
+[group('observability')]
+observability-up:
+    TS_OBS_AUTHKEY="$(security find-generic-password -a tailscale-observability -s TS_OBS_AUTHKEY -w)" \
+      docker compose -f docs/observability/docker-compose.yml up -d
+    @echo ""
+    @echo "Grafana UI    : http://mat-vis-otel.$(tailscale status --json | jq -r '.MagicDNSSuffix'):3000"
+    @echo "OTLP endpoint : http://mat-vis-otel.$(tailscale status --json | jq -r '.MagicDNSSuffix'):4318"
+
+# Stop the observability stack + deregister the ephemeral tailnet node.
+[group('observability')]
+observability-down:
+    docker compose -f docs/observability/docker-compose.yml down
+
+# Tail the OTLP collector logs (Grafana/Tempo/Loki/Mimir in one image).
+[group('observability')]
+observability-logs:
+    docker compose -f docs/observability/docker-compose.yml logs -f otel-lgtm


### PR DESCRIPTION
Follow-up polish on #139 (OTLP wiring + dashboard, merged in #162). Ships the containerised sidecar compose so the stack runs on any host without a one-off \`podman run\` + \`tailscale serve\` dance.

## What

- \`docs/observability/docker-compose.yml\` — tailscale sidecar + grafana/otel-lgtm sharing a network namespace. Userspace networking for portability across Docker Desktop / Podman Machine / Linux.
- \`docs/observability/README.md\` — one-time setup, bring-up, host-migration notes.
- \`justfile.project\` — \`just observability-{up,down,logs}\` recipes reading \`TS_OBS_AUTHKEY\` from the macOS login Keychain (same pattern as \`devc-remote.sh\` uses for \`TS_CLIENT_ID\`).

## Architecture

- Any Docker/Podman host can run the stack. Not your-laptop-specific.
- Sidecar joins tailnet, opens ports 3000 (Grafana UI) and 4318 (OTLP HTTP) on its tailnet IP. No inbound firewall holes.
- Grafana dashboard is committed as \`docs/observability/dashboard.json\` (from #162). Import manually on first bring-up; automation for that is a low-priority follow-up.

## Known issue carved out

Tagged auth-keys kept failing server-side validation during local testing despite correct \`tagOwners\` — puzzle parked at **#176**. The compose ships with \`--advertise-tags\` commented out; operator tags the node manually in the admin UI after it joins. Works for a single-host observability stack; unblocks the PR while #176 is tracked separately.

## Test plan

- [x] \`docker compose up -d\` on macOS (Docker Desktop): containers start clean.
- [x] \`yamllint\` on compose, just-fmt on justfile.project.
- [ ] Tailnet join + dashboard view: blocked on #176 workaround (manual tag in UI). Local verified works when tag is absent.
- [ ] Live end-to-end against GH runners: unblocked once #176 resolved or we switch to OAuth-minted keys.

Refs #139, #162, #176.