### PR TITLE
fix(baker): refuse unsupported (source, tier) combos upfront (#179)

### DIFF
--- a/src/mat_vis_baker/hf_bake.py
+++ b/src/mat_vis_baker/hf_bake.py
@@ -142,6 +142,21 @@ def bake_one(
     download + bake + pack step. Output filenames gain a
     ``.shard-N-of-K`` suffix. The catalog write is skipped per shard
     (the later ``merge-shards`` writes it once from the union)."""
+    # Pre-flight: refuse (source, tier) combos with no upstream data.
+    # Earlier code let these proceed, then produced 454-materials-failed
+    # bake artifacts when every fetch returned no matching package.
+    # The manifest in mat_vis_baker.source_tiers names the combos the
+    # upstream actually serves; everything else routes via hf-derive.
+    from mat_vis_baker.source_tiers import (
+        is_supported as _tier_is_supported,
+    )
+    from mat_vis_baker.source_tiers import (
+        unsupported_tier_message as _tier_unsupported_msg,
+    )
+
+    if not _tier_is_supported(source, tier):
+        raise ValueError(_tier_unsupported_msg(source, tier))
+
     if source == "physicallybased":
         # Scalar sources are one unit — sharding has no benefit.
         return bake_scalar_source(

--- a/src/mat_vis_baker/source_tiers.py
+++ b/src/mat_vis_baker/source_tiers.py
@@ -1,0 +1,70 @@
+"""Per-source supported-tier manifest (#179).
+
+Upstream sources don't all serve the same resolution tiers. ambientcg
+and polyhaven publish every PNG tier from 128 up to 8k; gpuopen only
+exposes 1k and larger; physicallybased has no textures at all (scalar
+PBR only). The baker used to happily call ``bake_one(source, tier)``
+for any combo, then discover the mismatch 454-materials later when
+every fetch returned no matching package — slow, noisy, and leaves
+an ugly ``{'error': 'no materials'}`` artifact in the log.
+
+This module is the single source of truth for which (source, tier)
+combos have native upstream data. ``bake_one`` consults it upfront
+(see ``hf_bake._guard_supported_tier``) and refuses unsupported
+combos with a clear message pointing at ``hf-derive`` as the
+alternative — derive resizes existing larger tars, so gpuopen 512
+IS reachable, just not via a direct upstream bake.
+
+Captured on 2026-04-21 by enumerating live gpuopen package labels:
+
+    454 × "1k 8b", 435 × "2k 8b", 428 × "4k 8b", 169 × "8k 8b"
+
+Re-check by running ``scripts/probe-metadata-vocab.py`` (which uses
+the same ``discover()`` fetchers). If upstreams add new tiers, the
+probe picks them up and we update this file in a single commit so
+the drift stays visible in git history.
+"""
+
+from __future__ import annotations
+
+# Native bake-time tiers per upstream source. Keys are canonical
+# source names (mat_vis_baker.common.CANONICAL_SOURCES). Values are
+# the set of tier labels the baker can pass straight to the
+# fetcher without pre-processing.
+#
+# Derive-time tiers (produced by ``hf-derive`` / ``hf-derive-ktx2``
+# from a baked tar) are NOT listed here — they come into existence
+# on HF without involving this guard.
+SUPPORTED_TIERS: dict[str, frozenset[str]] = {
+    "ambientcg": frozenset({"128", "256", "512", "1k", "2k", "4k", "8k"}),
+    "polyhaven": frozenset({"128", "256", "512", "1k", "2k", "4k", "8k"}),
+    "gpuopen": frozenset({"1k", "2k", "4k", "8k"}),
+    "physicallybased": frozenset({"scalar"}),
+}
+
+
+def is_supported(source: str, tier: str) -> bool:
+    """Return True iff the baker can call ``bake_one(source, tier)``
+    without producing a 454-failures artifact."""
+    return tier in SUPPORTED_TIERS.get(source, frozenset())
+
+
+def unsupported_tier_message(source: str, tier: str) -> str:
+    """Build the error message for an unsupported (source, tier) combo.
+
+    Named so the test asserting the message content can assert on the
+    exact string rather than re-duplicating the format. Mentions the
+    source, the tier, the supported set, and points at hf-derive for
+    the smaller tiers."""
+    supported = SUPPORTED_TIERS.get(source, frozenset())
+    supported_str = ", ".join(sorted(supported)) if supported else "(none)"
+    guidance = (
+        "use `hf-derive` to resize from a larger tier"
+        if source != "physicallybased"
+        else "physicallybased has no textures; bake tier='scalar' instead"
+    )
+    return (
+        f"Source {source!r} does not natively serve tier {tier!r}. "
+        f"Supported tiers for {source}: {{{supported_str}}}. "
+        f"To produce tier {tier!r} for {source}, {guidance}."
+    )

--- a/tests/test_source_tier_support.py
+++ b/tests/test_source_tier_support.py
@@ -1,0 +1,150 @@
+"""Source-level tier-support contract (#179).
+
+Each upstream source publishes different native resolution tiers.
+The baker must declare those upfront so ``bake_one`` can:
+
+- Refuse an unsupported (source, tier) combo with a clear message
+  pointing operators at ``hf-derive`` for the smaller tiers.
+- Let ``scripts/full-bake.sh`` enumerate (source, tier) pairs that
+  will actually succeed, rather than issuing 454 per-material
+  failures when no upstream package matches.
+
+Observed on 2026-04-21 against the live APIs:
+
+- ambientcg: 128/256/512/1k/2k/4k/8k (all PNG tiers)
+- polyhaven: 128/256/512/1k/2k/4k/8k (all PNG tiers)
+- gpuopen:   1k/2k/4k/8k only — no packages below 1k
+- physicallybased: "scalar" only (no textures at all)
+
+Regressions on this set would surface as sudden rc=1 floods during a
+staging bake. The full-bake loop relies on this to stay green.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Will exist after the fix. Marked as RED by default so the pytest
+# failure on first run pins the gap in the implementation.
+supported_tiers_module_available = False
+try:
+    from mat_vis_baker.source_tiers import SUPPORTED_TIERS  # type: ignore[attr-defined]
+
+    supported_tiers_module_available = True
+except ImportError:  # pragma: no cover — RED-phase guard
+    SUPPORTED_TIERS = None
+
+
+@pytest.mark.skipif(
+    not supported_tiers_module_available,
+    reason="RED phase — mat_vis_baker.source_tiers not yet implemented",
+)
+class TestSupportedTiers:
+    def test_ambientcg_serves_full_png_range(self):
+        assert SUPPORTED_TIERS["ambientcg"] == {
+            "128",
+            "256",
+            "512",
+            "1k",
+            "2k",
+            "4k",
+            "8k",
+        }
+
+    def test_polyhaven_serves_full_png_range(self):
+        assert SUPPORTED_TIERS["polyhaven"] == {
+            "128",
+            "256",
+            "512",
+            "1k",
+            "2k",
+            "4k",
+            "8k",
+        }
+
+    def test_gpuopen_serves_only_1k_and_up(self):
+        """gpuopen's /packages/ endpoint only exposes 1k+ labels. Bakes
+        at 128/256/512 would produce 0 matching packages per material
+        (every material fails) — pointless compute."""
+        assert SUPPORTED_TIERS["gpuopen"] == {"1k", "2k", "4k", "8k"}
+
+    def test_physicallybased_is_scalar_only(self):
+        assert SUPPORTED_TIERS["physicallybased"] == {"scalar"}
+
+    def test_every_canonical_source_has_an_entry(self):
+        """No source should be missing from the map — keeps the
+        ``full-bake.sh`` loop tight."""
+        from mat_vis_baker.common import CANONICAL_SOURCES
+
+        missing = set(CANONICAL_SOURCES) - set(SUPPORTED_TIERS.keys())
+        assert not missing, f"sources missing from SUPPORTED_TIERS: {missing}"
+
+
+class TestBakeRefusesUnsupportedTier:
+    """``bake_one(source, tier, ...)`` must refuse early when the
+    (source, tier) combo is known-unsupported by the upstream. Raises
+    with a message that names the supported set + points at hf-derive
+    for the smaller tiers."""
+
+    def test_gpuopen_512_raises_with_helpful_message(self, tmp_path):
+        """The staging-bake failure mode on 2026-04-21 was 454
+        per-material failures and a cryptic {'error': 'no materials'}.
+        Should be a single upfront ValueError that names the fix.
+        """
+        from mat_vis_baker.hf_bake import bake_one
+
+        with pytest.raises(ValueError) as exc:
+            bake_one(
+                source="gpuopen",
+                tier="512",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                hf_token="unused",
+                dry_run=True,
+            )
+        msg = str(exc.value)
+        assert "gpuopen" in msg, f"error doesn't name source: {msg!r}"
+        assert "512" in msg, f"error doesn't name tier: {msg!r}"
+        assert "hf-derive" in msg, f"error should point at hf-derive as the fix: {msg!r}"
+
+    def test_gpuopen_1k_still_works(self, tmp_path, monkeypatch):
+        """Supported combos proceed past the guard — we only want the
+        RED case to fail fast, not the whole fetcher path."""
+        from mat_vis_baker.hf_bake import bake_one
+
+        # Short-circuit the actual fetch so we don't hit upstream.
+        monkeypatch.setattr(
+            "mat_vis_baker.hf_bake._get_fetcher",
+            lambda _source: lambda *a, **kw: [],
+        )
+        # Dry-run + empty fetcher result is fine — we're only checking
+        # the supported-tier guard lets the call through.
+        result = bake_one(
+            source="gpuopen",
+            tier="1k",
+            release_tag="v0.0.0-test",
+            work_dir=tmp_path,
+            hf_token="unused",
+            dry_run=True,
+        )
+        # "no materials" is the error from an empty fetcher — NOT the
+        # unsupported-tier guard. This confirms we passed the guard.
+        assert result.get("error") != "unsupported_tier"
+
+    def test_physicallybased_non_scalar_raises(self, tmp_path):
+        """Scalar-only source with a PNG tier requested — same guard
+        applies, with the analogous message."""
+        from mat_vis_baker.hf_bake import bake_one
+
+        with pytest.raises(ValueError) as exc:
+            bake_one(
+                source="physicallybased",
+                tier="1k",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                hf_token="unused",
+                dry_run=True,
+            )
+        msg = str(exc.value)
+        assert "physicallybased" in msg
+        assert "scalar" in msg


### PR DESCRIPTION
**RED-GREEN fix for the v0.6.0 staging-bake rc=1 floods.**

## The bug

During the full staging bake on anvil-dev, 3 of 15 PNG bakes failed with rc=1:
- `gpuopen 512` — 454/454 failures
- `gpuopen 256` — 454/454 failures
- `gpuopen 128` — 454/454 failures (in progress at investigation time)

Root cause: gpuopen only serves packages labeled `1k 8b`, `2k 8b`, `4k 8b`, `8k 8b`. No 512/256/128 packages. `bake_one("gpuopen", "512")` ran the full per-material loop, each picking no package, each failing.

## The fix

New `src/mat_vis_baker/source_tiers.py` manifests each source's native upstream tiers. `bake_one` consults it before any fetcher work and raises `ValueError` with a message naming the source, tier, supported set, and the `hf-derive` escape hatch.

```
ambientcg / polyhaven : {128, 256, 512, 1k, 2k, 4k, 8k}
gpuopen               : {1k, 2k, 4k, 8k}
physicallybased       : {scalar}
```

## RED-GREEN discipline

`tests/test_source_tier_support.py` committed RED first (module absent + no guard). Implemented `source_tiers` + wired into `bake_one`. Green: 8/8.

- `5 skipped, 2 failed` before the fix
- `8 passed` after
- `328 passed` full suite (0 regressions; baseline was 320)

## Follow-up

`scripts/full-bake.sh` on anvil-dev should enumerate only supported (source, tier) combos and use `hf-derive` from 1k for gpuopen sub-1k. That's tracked in #179's sibling checklist and reruns the staging bake once this PR lands.

## Test plan

- [x] `uv run pytest tests/test_source_tier_support.py -v` — 8/8 pass
- [x] `uv run pytest tests/ -q` — 328 pass (+8 from baseline)
- [ ] Post-merge: rerun full staging bake on anvil-dev with updated loop — expect zero rc=1

Refs #179.