### PR TITLE
fix(baker): memoize discover() per process (#179 follow-up)

### DIFF
--- a/src/mat_vis_baker/sources/ambientcg.py
+++ b/src/mat_vis_baker/sources/ambientcg.py
@@ -72,6 +72,30 @@ UPSTREAM_ALLOWLIST: frozenset[str] = frozenset(
 
 
 # ── discovery ───────────────────────────────────────────────────
+#
+# Module-level memoization cache for discover(). ``bake_one`` calls
+# fetch() once per batch (batch_size=50, 1993 ambientcg records = 40
+# calls per bake); without this cache each call re-paginates the full
+# upstream catalog (~20 pages × 100 records). See tests/test_fetcher_
+# discover_memoize.py for the regression guard.
+_DISCOVER_CACHE: list[dict] | None = None
+
+
+def _reset_discover_cache() -> None:
+    """Forget the cached catalog so the next fetch re-paginates.
+
+    Intended for tests and long-running processes where upstream
+    drift is a concern; the bake loop doesn't need to call this."""
+    global _DISCOVER_CACHE
+    _DISCOVER_CACHE = None
+
+
+def _cached_entries(session: requests.Session | None = None) -> list[dict]:
+    """Return the discovered entries, paginating once per process."""
+    global _DISCOVER_CACHE
+    if _DISCOVER_CACHE is None:
+        _DISCOVER_CACHE = discover(session=session)
+    return _DISCOVER_CACHE
 
 
 def discover(*, session: requests.Session | None = None) -> list[dict]:
@@ -356,7 +380,7 @@ def fetch(
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
     s = session or requests.Session()
-    entries = discover(session=s)
+    entries = _cached_entries(s)
 
     entries = _filter_with_downloads(entries, tier)
     log.info("%d materials have downloads for tier %s", len(entries), tier)

--- a/src/mat_vis_baker/sources/gpuopen.py
+++ b/src/mat_vis_baker/sources/gpuopen.py
@@ -104,6 +104,26 @@ def _paginate(path: str, session: requests.Session) -> list[dict]:
     return out
 
 
+# Module-level memoization cache for discover(). Rationale: same as
+# the other fetchers — ``bake_one`` calls ``fetch()`` per batch and
+# without this cache each call re-paginates /materials /packages
+# /categories /tags (four paginated endpoints).
+_DISCOVER_CACHE: list[dict] | None = None
+
+
+def _reset_discover_cache() -> None:
+    """Forget the cached material list; next fetch re-paginates."""
+    global _DISCOVER_CACHE
+    _DISCOVER_CACHE = None
+
+
+def _cached_materials(session: requests.Session | None = None) -> list[dict]:
+    global _DISCOVER_CACHE
+    if _DISCOVER_CACHE is None:
+        _DISCOVER_CACHE = discover(session=session)
+    return _DISCOVER_CACHE
+
+
 def discover(*, session: requests.Session | None = None) -> list[dict]:
     """Return gpuopen materials enriched with resolved category/tag titles
     and the full package dict for each variant.
@@ -401,7 +421,7 @@ def fetch(
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
     s = session or requests.Session()
-    materials = discover(session=s)
+    materials = _cached_materials(s)
     if offset:
         materials = materials[offset:]
     if limit:

--- a/src/mat_vis_baker/sources/polyhaven.py
+++ b/src/mat_vis_baker/sources/polyhaven.py
@@ -66,6 +66,24 @@ _TIER_KEYS = {
 
 
 # ── discovery ───────────────────────────────────────────────────
+#
+# Module-level memoization cache for discover(). Same rationale as
+# ambientcg — ``bake_one`` calls ``fetch()`` per batch; without the
+# cache each call re-hits the /assets endpoint.
+_DISCOVER_CACHE: dict | None = None
+
+
+def _reset_discover_cache() -> None:
+    """Forget the cached asset map; next fetch re-hits /assets."""
+    global _DISCOVER_CACHE
+    _DISCOVER_CACHE = None
+
+
+def _cached_assets(session: requests.Session | None = None) -> dict:
+    global _DISCOVER_CACHE
+    if _DISCOVER_CACHE is None:
+        _DISCOVER_CACHE = discover(session=session)
+    return _DISCOVER_CACHE
 
 
 def discover(*, session: requests.Session | None = None) -> dict:
@@ -374,7 +392,7 @@ def fetch(
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
     s = session or requests.Session()
-    assets = discover(session=s)
+    assets = _cached_assets(s)
 
     slugs = list(assets.keys())
     if offset:

--- a/tests/test_fetcher_discover_memoize.py
+++ b/tests/test_fetcher_discover_memoize.py
@@ -1,0 +1,116 @@
+"""Discover-per-fetch regression guard (#179 follow-up).
+
+Every upstream source exposes two levels:
+
+- ``discover(session=...)`` — pages the full upstream catalog. Cheap
+  per-call in absolute seconds (~10-30 s) but expensive in API
+  traffic (ambientcg: 20 × /full_json at 100/page to cover 1993
+  materials; polyhaven: 1 × /assets). Idempotent — the catalog
+  snapshot doesn't change within a bake session.
+
+- ``fetch(tier, ..., offset=N, limit=M)`` — returns one paginated
+  slice of MaterialRecord objects. Used by ``hf_bake.bake_one`` in
+  a batching loop (``batch_size=50``).
+
+The bug caught during the v0.0.4-staging bake on 2026-04-21:
+``bake_one`` calls ``fetch()`` once per batch. Until this fix each
+``fetch()`` call internally re-invoked ``discover()`` from scratch,
+so a 1993-record ambientcg 2k bake paginated the full catalog 40
+times — ~600 wasted API calls, ~10 min wall-clock, and upstream
+rate-pressure for no semantic gain.
+
+These tests pin the fixed behaviour: discover is called at most
+once per process (module-level memoization).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+# Fixture cleans module caches between tests so test-order doesn't
+# leak a cache from one source's test into another's.
+@pytest.fixture(autouse=True)
+def _reset_discover_caches():
+    from mat_vis_baker.sources import ambientcg, gpuopen, polyhaven
+
+    for mod in (ambientcg, gpuopen, polyhaven):
+        reset = getattr(mod, "_reset_discover_cache", None)
+        if reset is not None:
+            reset()
+    yield
+    for mod in (ambientcg, gpuopen, polyhaven):
+        reset = getattr(mod, "_reset_discover_cache", None)
+        if reset is not None:
+            reset()
+
+
+class TestAmbientcgMemoizesDiscover:
+    def test_three_fetches_trigger_one_discover(self, tmp_path):
+        from mat_vis_baker.sources import ambientcg
+
+        # Return a tiny synthetic catalog — 2 materials, both with no
+        # downloads so fetch returns an empty record list fast (we're
+        # only checking the discover() call count, not fetch output).
+        fake_entries = [
+            {"assetId": "M1", "displayName": "M1", "downloadFolders": {}, "tags": []},
+            {"assetId": "M2", "displayName": "M2", "downloadFolders": {}, "tags": []},
+        ]
+
+        with patch.object(ambientcg, "discover", return_value=fake_entries) as m:
+            for offset in (0, 50, 100):
+                ambientcg.fetch("1k", tmp_path, limit=50, offset=offset)
+        assert m.call_count == 1, (
+            f"discover called {m.call_count}× across 3 fetches — "
+            "should be memoized so bake-loop batching doesn't "
+            "re-paginate (see regression note in module docstring)"
+        )
+
+
+class TestPolyhavenMemoizesDiscover:
+    def test_three_fetches_trigger_one_discover(self, tmp_path):
+        from mat_vis_baker.sources import polyhaven
+
+        fake_assets = {"a1": {"name": "a1", "type": 1}}
+        with patch.object(polyhaven, "discover", return_value=fake_assets) as m:
+            for offset in (0, 50, 100):
+                polyhaven.fetch("1k", tmp_path, limit=50, offset=offset)
+        assert m.call_count == 1, (
+            f"polyhaven.discover called {m.call_count}× across 3 fetches — "
+            "should be memoized"
+        )
+
+
+class TestGpuopenMemoizesDiscover:
+    def test_three_fetches_trigger_one_discover(self, tmp_path):
+        from mat_vis_baker.sources import gpuopen
+
+        fake_mats: list[dict] = []
+        with patch.object(gpuopen, "discover", return_value=fake_mats) as m:
+            for offset in (0, 50, 100):
+                gpuopen.fetch("1k", tmp_path, limit=50, offset=offset)
+        assert m.call_count == 1, (
+            f"gpuopen.discover called {m.call_count}× across 3 fetches — "
+            "should be memoized"
+        )
+
+
+class TestResetHelper:
+    def test_reset_allows_fresh_discover(self, tmp_path):
+        """The ``_reset_discover_cache`` helper exists so tests (and
+        hypothetical catalog-refresh scenarios) can force a re-pagination
+        on the next ``fetch``."""
+        from mat_vis_baker.sources import ambientcg
+
+        fake = [{"assetId": "M1", "displayName": "M1", "downloadFolders": {}, "tags": []}]
+        with patch.object(ambientcg, "discover", return_value=fake) as m:
+            ambientcg.fetch("1k", tmp_path, limit=50, offset=0)
+            ambientcg.fetch("1k", tmp_path, limit=50, offset=50)
+            assert m.call_count == 1
+            ambientcg._reset_discover_cache()
+            ambientcg.fetch("1k", tmp_path, limit=50, offset=100)
+            assert m.call_count == 2, (
+                "discover must be re-called after _reset_discover_cache()"
+            )


### PR DESCRIPTION
**RED-GREEN fix for the v0.0.4-staging bake slowness.**

## The bug

Caught during the anvil-dev staging bake: ambientcg 2k spent ~2h elapsed where `discover()` was re-paginating the full 1993-material catalog **once per 50-material batch**. 40 batches × 20 API pages × ~0.5s each = ~7 min of pure pagination overhead per bake, plus upstream rate-pressure for zero semantic gain (the catalog snapshot doesn't change during a bake).

## The fix

Each fetcher (ambientcg, polyhaven, gpuopen) now has:
- A module-level `_DISCOVER_CACHE` holding the first `discover()` result.
- A `_cached_entries()` / `_cached_assets()` / `_cached_materials()` helper consulted by `fetch()` instead of calling `discover()` directly.
- A `_reset_discover_cache()` helper for tests and long-running processes.

Public `discover()` signature unchanged — still callable directly. Cache only activates via `fetch()`.

## RED-GREEN

`tests/test_fetcher_discover_memoize.py`:
- 3 fetches across each source trigger `discover()` exactly once (one test per fetcher).
- `_reset_discover_cache()` forces a fresh discover on the next call.

RED: 4 fail (discover called 3× each).  
GREEN: 4 pass.  
Full suite: 332 passed (+4).

## Impact

Current bake (in flight, started before this fix): ambientcg 2k is at batch 33/40 (83%), ~5h20m elapsed. Without the fix, the remaining 7 batches will still re-paginate 7 more times (~90s wasted). Not worth restarting mid-flight.

Subsequent bakes (gpuopen 2k, KTX2 derives) benefit from the fix once this PR lands and the full-bake script is re-run.

Refs #179, observed 2026-04-21.