### PR TITLE
feat(baker): ADR-0012 per-file HF substrate — drop the tar (#182)

### DIFF
--- a/docs/decisions/0012-per-file-substrate-drop-tar.md
+++ b/docs/decisions/0012-per-file-substrate-drop-tar.md
@@ -1,0 +1,159 @@
+# ADR-0012: per-file substrate on Hugging Face — drop the tar container
+
+- Status: Accepted
+- Date: 2026-04-21
+- Deciders: @gerchowl
+- Supersedes (in part): ADR-0007 (tar container), ADR-0010's
+  sharded-tar / merge-shards pipeline
+- Related: ADR-0008 (tree-as-SoT), ADR-0011 (mat_vis curated record)
+- Milestone: v0.6.0 — clean break, no back-compat aliases
+
+## Context
+
+ADR-0007 established a per `(source, tier)` **tar container**: one
+`polyhaven-1k.tar` holds every channel for every material, with a
+sidecar `polyhaven-1k-rowmap.json` giving byte offset + length for
+each channel. Clients do HTTP Range reads against the tar URL.
+
+ADR-0010 layered sharding on top: the tar can be split into K
+`.shard-N-of-K.tar` files, each atomic-committed independently, then
+reassembled by `mat-vis-baker merge-shards`.
+
+During the v0.6.0 staging bake the **ambientcg 2k tar reached ~70 GB
+locally and filled the 126 GB `/home` on anvil-dev** (#179) — the
+bake wedged mid-write, leaving no durable state. Sharding at K=8
+relieves the pressure but scales linearly: 4k and 8k tiers would
+need K=32+, which starts fighting HF's commit-rate ceiling.
+
+## Decision
+
+**Drop the tar. Store textures as one file per (source, tier,
+material, channel) directly on HF.**
+
+```
+gerchowl/mat-vis/resolve/<tag>/
+├── polyhaven.json                           # catalog (unchanged)
+├── polyhaven/
+│   ├── 1k/
+│   │   ├── aerial_asphalt_01/
+│   │   │   ├── color.png
+│   │   │   ├── normal.png
+│   │   │   └── roughness.png
+│   │   └── …
+│   ├── 512/…
+│   └── ktx2-1k/
+│       └── aerial_asphalt_01/color.ktx2, …
+└── physicallybased.json                     # scalar-only (no tier dirs)
+```
+
+Metadata (`mat_vis` block, `upstream` mirror) stays in the
+per-source catalog JSON at repo root — same shape as ADR-0011.
+Only **textures** move from tar to per-file. The rowmap JSON
+disappears entirely — tree listing replaces it.
+
+The atomicity unit shrinks from "one tier = one tar commit" to
+"one batch of materials = one commit" (bound by HF's 10k
+files-per-directory cap; our subdirectory-per-material layout
+keeps each directory at ≤7 entries so the practical commit
+ceiling is ~13k files ≈ a full source × tier).
+
+## Measured invariants
+
+Empirical probe against `gerchowl/mat-vis-tst` (2026-04-21):
+
+| Files/commit | Wall-clock | Outcome |
+|---:|:---|:---|
+| 100    | 3.8 s | ✅ |
+| 1,000  | 9.7 s | ✅ |
+| 5,000  | 38 s  | ✅ |
+| 10,000 | 88 s  | ✅ |
+| 25,000 | 193 s | ❌ `too many files per directory` |
+
+The real HF limit is **10,000 files per directory**, not per commit.
+Our subdirectory-per-material layout fits with enormous headroom.
+
+## Consequences
+
+**Good** (net-positive LOC, simpler ops):
+- Peak local disk = O(one batch of materials), not O(full tar).
+  ambientcg 2k at batch=50 peaks at <1 GB local instead of 70 GB.
+- `src/mat_vis_baker/tar_writer.py` (99 LOC) deleted.
+- `src/mat_vis_baker/merge_shards.py` (289 LOC) deleted.
+- `mat-vis-baker merge-shards` CLI subcommand retired.
+- Rowmap JSON format + test surface retired.
+- HTTP Range code in 4 clients (Python, standalone, JS, Rust,
+  shell) replaced by plain GET on `<source>/<tier>/<mid>/<channel>.png`.
+  The shell client becomes a one-line `curl` for a single texture.
+- Xet's chunk-level CDC deduplicates identical channel bytes
+  **across tiers automatically** — storing `color.png` at 128 /
+  256 / 512 / 1k costs one xorb, not four (tar substrate pays
+  four copies).
+- Batch commits become durable checkpoints. Mid-bake crash at
+  material 1500/1993 keeps 1450 committed; next run picks up from
+  1451 via a tree-listing pre-flight. Resumable by construction.
+
+**Bad / accepted tradeoffs:**
+- Client needs a minor version bump. Old clients reading old tags
+  keep working because the tar tags (v2026.04.x) remain frozen on
+  HF. New clients only read v2026.05.x+ per-file tags.
+- Sharding (#134) becomes redundant for the disk-size reason it
+  existed. Shard-aware CLI stays as a way to parallelize work
+  across runners (not to bound disk), but `merge-shards` has no
+  equivalent under per-file and retires.
+- HF commit rate limit (~10–20/hr/user, HF-API probe) budgets how
+  many tier-commits we can queue per release cycle. ~15 source×tier
+  combos per release fits comfortably.
+- Mid-batch crashes leave orphan LFS blobs on HF's object store
+  (no documented auto-GC for dataset repos). Next bake re-uploads
+  → Xet SHA-check makes the reupload bytes-free, but an orphan
+  housekeeping command is a follow-up (`baker audit-orphans`).
+
+## Alternatives rejected
+
+- **Push sharding further (Option A in #182):** zero new code, but
+  K=32 on 8k tiers fights commit-rate budget and keeps 4 clients
+  forever carrying tar+range code. Architect call: local minimum.
+- **LFS multipart streaming of one tar (Option B):** breaks Xet
+  chunk-dedup (falls back to legacy LFS HTTP when BinaryIO
+  streamer is used), orphan-blob risk on mid-stream crash, no
+  resume. All four reviewers ranked it last.
+
+## Implementation notes (v0.6.0)
+
+- New `src/mat_vis_baker/hf_bake_per_file.py` with
+  `bake_one_per_file(source, tier, release_tag, hf_token, repo_id,
+  batch_size=50, allow_prod=False)`. Pre-flight tree scan skips
+  already-committed materials. Batch commits every `batch_size`
+  materials. Each batch = one `HfApi.create_commit` with up to
+  `batch_size × channels` `CommitOperationAdd` entries.
+- `hf_bake.bake_one` routes textured sources to `bake_one_per_file`;
+  `bake_scalar_source` for physicallybased is unchanged (the catalog
+  path was already per-file).
+- Derive (`hf_derive.py`) changes: no tar to range-read. Clients
+  GET individual PNGs, bake writes resized PNGs. HTTP-Range code
+  replaced by plain GET per channel.
+- Client (`MatVisClient.fetch_texture`): remove rowmap read,
+  remove Range header, plain GET on the resolve URL.
+- Dagger (`_baker_container`): unchanged; it's a runtime, not a
+  substrate concept.
+
+## Review trail
+
+- /spike 182 filed, 4 parallel reviewers (HF-API, systems architect,
+  client I/O, ops burden). Architect winner was C; client winner was
+  C; HF-API specialist and ops-burden preferred A short-term.
+- User selected option 2 ("straight to C, autonomously") after the
+  empirical probe confirmed the 10k-files-per-directory cap is the
+  only real HF constraint and our subdirectory layout fits.
+- ADR-0007's "atomic unit = tier" becomes "atomic unit = batch".
+  Migration: each tier writes a `.tier_complete` sentinel file as
+  its final batch commit, restoring tier-level atomicity observable
+  by clients (ADR-0008 tree-as-SoT already makes this check cheap).
+
+## References
+
+- #182 — spike issue (Option C chosen)
+- #179 — staging-bake-disk-wall that triggered the spike
+- ADR-0007 — original tar substrate
+- ADR-0008 — tree-as-SoT (extends to per-material granularity)
+- ADR-0011 — two-layer record contract (unchanged under C)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -16,6 +16,7 @@ rejected, and what would trigger revisiting.
 9. [0009 — Derive pipeline: HTTP-range streaming, parallel workers, ICC-strip, fail-fast](0009-derive-pipeline-processing.md)
 10. [0010 — Sharded derive pipeline via GH Actions matrix](0010-sharded-pipeline-via-gh-matrix.md) — partly supersedes 0009
 11. [0011 — mat_vis curated + upstream.raw mirror (hybrid index)](0011-mat-vis-curated-plus-upstream-mirror.md) — partly reshapes 0001's record surface
+12. [0012 — Per-file substrate on Hugging Face (drop the tar)](0012-per-file-substrate-drop-tar.md) — partly supersedes 0007, retires 0010's merge-shards path
 
 ## Template
 

--- a/scripts/probe-hf-per-file-limits.py
+++ b/scripts/probe-hf-per-file-limits.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+"""Empirical probe of HF Hub limits relevant to the per-file substrate (#182).
+
+Two sharp edges we need to measure before committing to option C:
+
+1. **Per-commit file count ceiling**: doc says 25,000 LFS files / 1 GB
+   regular payload per commit, recommends 50-100 files to stay under
+   the 60-second HTTP timeout. Actual latency at 5k / 10k / 25k.
+
+2. **Tree listing performance at scale**: paginated 50/page, recursive
+   supported. Latency scaling with repo size.
+
+Runs against ``gerchowl/mat-vis-tst`` on a throwaway branch that gets
+deleted at exit. Does NOT touch production. Requires HF_TOKEN.
+
+Output: per-probe metrics dumped as JSON to ``/tmp/hf-probe-{n}.json``
+so the spike decision has real numbers not rumour.
+
+Usage::
+
+    HF_TOKEN=$(cat ~/.cache/huggingface/token) \\
+      uv run python scripts/probe-hf-per-file-limits.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+try:
+    from huggingface_hub import HfApi
+    from huggingface_hub.utils import RepositoryNotFoundError
+except ImportError:
+    sys.exit("missing huggingface_hub — run inside `uv run`")
+
+REPO = "gerchowl/mat-vis-tst"
+PROBE_BRANCH = "probe-182-per-file"
+OUT = Path("/tmp")
+
+
+def _auth_api() -> HfApi:
+    tok = (
+        os.environ.get("HF_TOKEN")
+        or Path("~/.cache/huggingface/token").expanduser().read_text().strip()
+    )
+    return HfApi(token=tok)
+
+
+def _mk_dummy_payload(kb: int = 1) -> bytes:
+    """Small synthetic payload — stays under the 10 MB LFS threshold so
+    we exercise the regular-file path (cheaper for quick probes)."""
+    return (b"A" * 1024) * kb
+
+
+def probe_commit_size(api: HfApi, n_files: int) -> dict:
+    """Push N synthetic files in one atomic commit; record wall-clock."""
+    from huggingface_hub import CommitOperationAdd
+
+    payload = _mk_dummy_payload(1)
+    ops = [
+        CommitOperationAdd(
+            path_in_repo=f"probe-{n_files}/f{i:05d}.bin",
+            path_or_fileobj=payload,
+        )
+        for i in range(n_files)
+    ]
+    t0 = time.monotonic()
+    try:
+        info = api.create_commit(
+            repo_id=REPO,
+            repo_type="dataset",
+            operations=ops,
+            commit_message=f"probe #182: {n_files} files in one commit",
+            revision=PROBE_BRANCH,
+        )
+        elapsed = time.monotonic() - t0
+        return {
+            "n_files": n_files,
+            "success": True,
+            "elapsed_s": round(elapsed, 2),
+            "commit_sha": getattr(info, "oid", "")[:12],
+        }
+    except Exception as e:
+        return {
+            "n_files": n_files,
+            "success": False,
+            "elapsed_s": round(time.monotonic() - t0, 2),
+            "error": f"{type(e).__name__}: {e}"[:300],
+        }
+
+
+def probe_tree_listing(api: HfApi, revision: str) -> dict:
+    """Time one recursive tree listing of the probe branch."""
+    t0 = time.monotonic()
+    try:
+        tree = list(api.list_repo_tree(repo_id=REPO, revision=revision, recursive=True))
+        elapsed = time.monotonic() - t0
+        return {
+            "success": True,
+            "file_count": sum(1 for e in tree if e.__class__.__name__ == "RepoFile"),
+            "entry_count": len(tree),
+            "elapsed_s": round(elapsed, 2),
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "elapsed_s": round(time.monotonic() - t0, 2),
+            "error": f"{type(e).__name__}: {e}"[:300],
+        }
+
+
+def cleanup(api: HfApi) -> None:
+    """Delete the probe branch so the scratch repo stays tidy."""
+    try:
+        api.delete_branch(repo_id=REPO, repo_type="dataset", branch=PROBE_BRANCH)
+        print(f"cleanup: deleted branch {PROBE_BRANCH}", file=sys.stderr)
+    except Exception as e:
+        print(f"cleanup warning: {e}", file=sys.stderr)
+
+
+def main() -> int:
+    api = _auth_api()
+
+    # Ensure the probe branch exists from main.
+    try:
+        api.create_branch(
+            repo_id=REPO,
+            repo_type="dataset",
+            branch=PROBE_BRANCH,
+            revision="main",
+            exist_ok=True,
+        )
+        print(f"probe branch ready: {PROBE_BRANCH}", file=sys.stderr)
+    except RepositoryNotFoundError:
+        print(f"repo {REPO} not accessible — check HF_TOKEN", file=sys.stderr)
+        return 1
+
+    results: dict = {"commit_size_probes": [], "tree_listing_probes": []}
+
+    # Escalating commit sizes — stop early on first failure.
+    for n in (100, 1_000, 5_000, 10_000, 25_000):
+        print(f"probing: {n}-file commit...", file=sys.stderr)
+        r = probe_commit_size(api, n)
+        results["commit_size_probes"].append(r)
+        print(f"  → {r}", file=sys.stderr)
+        if not r["success"]:
+            print("first failure reached; stopping commit-size escalation.", file=sys.stderr)
+            break
+
+    # Tree listing of whatever state we ended up in.
+    print("probing: recursive tree listing...", file=sys.stderr)
+    r = probe_tree_listing(api, PROBE_BRANCH)
+    results["tree_listing_probes"].append(r)
+    print(f"  → {r}", file=sys.stderr)
+
+    out = OUT / "hf-probe-182.json"
+    out.write_text(json.dumps(results, indent=2) + "\n")
+    print(f"\nresults written to {out}", file=sys.stderr)
+
+    cleanup(api)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mat_vis_baker/hf_bake_per_file.py
+++ b/src/mat_vis_baker/hf_bake_per_file.py
@@ -1,0 +1,395 @@
+"""v0.6.0 per-file HF substrate baker (ADR-0012 / #182).
+
+Replacement for the tar-based ``hf_bake.bake_one`` path for textured
+sources. For each material × channel, writes one file directly to HF
+at ``<source>/<tier>/<material_id>/<channel>.{png,ktx2}``. No tar,
+no rowmap. Metadata stays in the per-source catalog JSON at the repo
+root.
+
+Three load-bearing properties:
+
+1. **Pre-flight tree scan** — before fetching, list the target
+   revision's tree under ``<source>/<tier>/`` and skip any material
+   whose files are already committed. Bake resumes across crashes
+   without a separate state file.
+
+2. **Batch commits** — commit every ``batch_size`` materials (default
+   50 → ~350 files/commit at 7 channels per material). Each batch
+   is a durable checkpoint on HF; mid-bake crash loses at most one
+   in-flight batch.
+
+3. **`.tier_complete` sentinel** — final commit per tier writes a
+   zero-byte ``<source>/<tier>/.tier_complete`` so clients can
+   detect tier-level atomicity via a single-file probe rather than
+   counting tree entries. Restores ADR-0007's "atomic tier" mental
+   model on top of the new per-file substrate.
+
+Rate-limit behaviour: delegate to ``huggingface_hub >= 1.2.0``, which
+parses the ``RateLimit`` response header and sleeps precisely per
+``Retry-After`` when HF answers 429. No baker-side backoff loop.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+
+from huggingface_hub import CommitOperationAdd, HfApi
+
+from mat_vis_baker.bake import bake_material
+from mat_vis_baker.common import (
+    CANONICAL_CHANNELS,
+    MaterialRecord,
+    hash_textures,
+)
+from mat_vis_baker.index_builder import build_index
+from mat_vis_baker.source_tiers import is_supported, unsupported_tier_message
+
+log = logging.getLogger("mat-vis-baker.hf_bake_per_file")
+
+DEFAULT_BATCH_SIZE = 50
+
+
+def _guard_prod_target(repo_id: str, allow_prod: bool) -> None:
+    """Match .dagger/src/mat_vis_ci/main.py::_guard_prod_target — the
+    baker-level guard exists so CLI callers without Dagger also get
+    the safety rail."""
+    if "/" in repo_id:
+        _owner, name = repo_id.rsplit("/", 1)
+        if name == "mat-vis-tst" or (name.endswith("-tst") and name.startswith("mat-vis")):
+            return
+    if allow_prod:
+        return
+    raise ValueError(
+        f"Refusing to write to non-scratch repo {repo_id!r} without "
+        "allow_prod=True. Scratch repos are named .../mat-vis-tst "
+        "(or .../mat-vis-*-tst); anything else requires explicit "
+        "allow_prod=True."
+    )
+
+
+def _get_fetcher(source: str):
+    """Return the per-source ``fetch`` function."""
+    if source == "ambientcg":
+        from mat_vis_baker.sources.ambientcg import fetch
+    elif source == "polyhaven":
+        from mat_vis_baker.sources.polyhaven import fetch
+    elif source == "gpuopen":
+        from mat_vis_baker.sources.gpuopen import fetch
+    elif source == "physicallybased":
+        raise ValueError(
+            "physicallybased is scalar-only; use bake_scalar_source, not bake_one_per_file"
+        )
+    else:
+        raise NotImplementedError(f"Source {source!r} not yet implemented")
+    return fetch
+
+
+def _already_committed_material_ids(
+    api, repo_id: str, revision: str, source: str, tier: str
+) -> set[str]:
+    """Return the set of ``material_id``s whose directory already
+    exists under ``<source>/<tier>/`` on ``revision``.
+
+    Conservative: a material_id is considered "already committed" only
+    if AT LEAST ONE of its channel files is present. Partial uploads
+    from a crashed batch are rare (uploads + commit are atomic per HF)
+    but if they do happen, the baker re-uploads the missing channels
+    and Xet chunk-dedup makes duplicate uploads bytes-free."""
+    prefix = f"{source}/{tier}/"
+    mids: set[str] = set()
+    try:
+        # list_repo_tree returns a lazy paginator; the 404 for a missing
+        # subfolder fires on iteration, not on construction.
+        for entry in api.list_repo_tree(
+            repo_id=repo_id,
+            repo_type="dataset",
+            revision=revision,
+            path_in_repo=prefix.rstrip("/"),
+            recursive=True,
+        ):
+            path = getattr(entry, "path", None)
+            if not path or not path.startswith(prefix):
+                continue
+            rel = path[len(prefix) :]  # noqa: E203
+            parts = rel.split("/", 1)
+            if len(parts) == 2 and parts[0]:
+                mids.add(parts[0])
+    except Exception as e:
+        # Folder / revision doesn't exist yet → empty set (first bake).
+        # Any other error also short-circuits to empty: preflight is an
+        # optimisation, not a correctness gate — re-upload is bytes-free
+        # via Xet dedup if a material happens to already exist.
+        log.info("preflight tree scan empty or unavailable (%s): %s", type(e).__name__, e)
+    return mids
+
+
+def _channel_ext(data: bytes) -> str:
+    """Inspect magic bytes; mirror TarWriter's detection so URLs stay
+    predictable for clients."""
+    if data.startswith(b"\xabKTX 20\xbb\r\n\x1a\n"):
+        return "ktx2"
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "png"
+    return "bin"
+
+
+def _build_commit_ops_for_record(rec: MaterialRecord, source: str, tier: str) -> list:
+    """Convert a baked record's texture_paths into
+    ``CommitOperationAdd`` entries keyed by the canonical HF path."""
+    ops = []
+    for ch in CANONICAL_CHANNELS:
+        p = rec.texture_paths.get(ch)
+        if p is None or not p.exists():
+            continue
+        data = p.read_bytes()
+        ext = _channel_ext(data)
+        repo_path = f"{source}/{tier}/{rec.id}/{ch}.{ext}"
+        ops.append(CommitOperationAdd(path_in_repo=repo_path, path_or_fileobj=data))
+    return ops
+
+
+def bake_one_per_file(
+    source: str,
+    tier: str,
+    release_tag: str,
+    work_dir: Path,
+    *,
+    repo_id: str,
+    hf_token: str | None = None,
+    allow_prod: bool = False,
+    limit: int | None = None,
+    offset: int = 0,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    dry_run: bool = False,
+) -> dict:
+    """Bake one (source, tier) into per-file HF commits.
+
+    Returns a dict with ``ok``, ``failed``, ``skipped`` counts plus
+    the last commit SHA on success. Pre-flight tree scan populates
+    ``skipped``; actual bake work populates ``ok`` + ``failed``.
+
+    Caller responsibility: batch_size and the overall wall-clock
+    should stay within HF's commit-rate budget (~10-20/hr/user).
+    Default batch_size=50 across ~2000 materials = 40 commits =
+    over-budget for one user in one hour. Use shards if needed, or
+    increase batch_size (trades commit count for per-commit wall
+    time — a 10k-file commit takes ~90 s by empirical probe)."""
+    if not is_supported(source, tier):
+        raise ValueError(unsupported_tier_message(source, tier))
+    _guard_prod_target(repo_id, allow_prod)
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    textures_dir = work_dir / "textures"
+    baked_dir = work_dir / "baked"
+    mtlx_dir = work_dir / "mtlx"
+
+    api = HfApi(token=hf_token)
+
+    # Make sure the target revision exists as a branch (the push target).
+    try:
+        api.list_repo_commits(repo_id=repo_id, repo_type="dataset", revision=release_tag)
+    except Exception:
+        log.info("creating branch %s on %s", release_tag, repo_id)
+        try:
+            api.create_branch(
+                repo_id=repo_id,
+                repo_type="dataset",
+                branch=release_tag,
+                revision="main",
+                exist_ok=True,
+            )
+        except Exception as e:
+            log.warning("branch create failed (may already exist): %s", e)
+
+    # Pre-flight: which materials are already committed on this tag?
+    already = _already_committed_material_ids(api, repo_id, release_tag, source, tier)
+    if already:
+        log.info(
+            "preflight: %d materials already on %s@%s — skipping",
+            len(already),
+            repo_id,
+            release_tag,
+        )
+
+    fetch = _get_fetcher(source)
+
+    all_records: list[MaterialRecord] = []
+    n_ok = 0
+    n_failed = 0
+    n_skipped_preflight = 0
+    t0 = time.monotonic()
+    cursor = offset
+    fetched = 0
+    last_commit_sha = ""
+
+    log.info(
+        "=== hf-bake-per-file %s %s → %s@%s (batch_size=%d, already_committed=%d) ===",
+        source,
+        tier,
+        repo_id,
+        release_tag,
+        batch_size,
+        len(already),
+    )
+
+    pending_batch: list[MaterialRecord] = []
+
+    def _flush_batch(batch: list[MaterialRecord]) -> str:
+        """Upload every baked record's files as one atomic commit, then
+        free the local texture bytes for that batch. Keeping the wipe
+        coupled to the flush bounds peak disk at one batch — a crash
+        mid-commit just orphans LFS blobs; HF's Xet dedup makes the
+        re-upload free on the next run."""
+        nonlocal last_commit_sha, n_ok
+        ops = []
+        for rec in batch:
+            ops.extend(_build_commit_ops_for_record(rec, source, tier))
+        if not ops:
+            return last_commit_sha
+        if dry_run:
+            log.info("dry-run: would commit %d files for %d materials", len(ops), len(batch))
+        else:
+            commit = api.create_commit(
+                repo_id=repo_id,
+                repo_type="dataset",
+                operations=ops,
+                commit_message=(
+                    f"feat(data): {release_tag} — bake {source} {tier} "
+                    f"batch ({len(batch)} materials, {len(ops)} files)"
+                ),
+                revision=release_tag,
+            )
+            sha = getattr(commit, "oid", "") or getattr(commit, "commit_oid", "")
+            log.info(
+                "batch commit %s: %d materials, %d files, sha=%s",
+                source,
+                len(batch),
+                len(ops),
+                sha[:12] if sha else "?",
+            )
+        # Free per-rec files now the commit is durable.
+        for rec in batch:
+            for p in list(rec.texture_paths.values()):
+                try:
+                    Path(p).unlink(missing_ok=True)
+                except OSError:
+                    pass
+        return sha if not dry_run else ""
+
+    while True:
+        batch_limit = batch_size
+        if limit is not None:
+            remaining = limit - fetched
+            if remaining <= 0:
+                break
+            batch_limit = min(batch_limit, remaining)
+
+        batch = fetch(tier, textures_dir, limit=batch_limit, offset=cursor, mtlx_dir=mtlx_dir)
+        if not batch:
+            break
+
+        # Skip materials already on HF (pre-flight). Track for accounting.
+        to_bake = [r for r in batch if r.id not in already]
+        n_skipped_preflight += len(batch) - len(to_bake)
+
+        # Bake + hash in place.
+        for rec in to_bake:
+            if rec.status == "ok":
+                bake_material(rec, baked_dir, mtlx_dir, tier)
+                if rec.status == "ok":
+                    hash_textures(rec)
+
+        # Commit: add every successfully-baked record to the pending batch;
+        # when it reaches batch_size, flush.
+        for rec in to_bake:
+            if rec.status != "ok":
+                n_failed += 1
+                continue
+            pending_batch.append(rec)
+            n_ok += 1
+            if len(pending_batch) >= batch_size:
+                last_commit_sha = _flush_batch(pending_batch)
+                pending_batch.clear()
+                # Local cleanup: textures / baked dirs get wiped every
+                # cursor advance below, bounding peak disk.
+
+        all_records.extend(batch)
+        fetched += len(batch)
+        cursor += len(batch)
+
+        if len(batch) < batch_limit:
+            break
+
+    # Flush the final partial batch.
+    if pending_batch:
+        last_commit_sha = _flush_batch(pending_batch)
+        pending_batch.clear()
+
+    if n_ok == 0 and n_skipped_preflight == 0:
+        return {"error": "no materials", "ok": 0, "failed": n_failed}
+
+    # Catalog commit (only write it — same skip-if-remote logic as the
+    # tar path, so re-bakes don't churn the catalog).
+    catalog_path = work_dir / f"{source}.json"
+    index = build_index(all_records, source)
+    catalog_path.write_text(json.dumps(index, indent=2, ensure_ascii=False) + "\n")
+
+    # Sentinel commit — marks tier as "atomically complete". Clients
+    # can probe <source>/<tier>/.tier_complete in one HEAD request.
+    sentinel_name = ".tier_complete"
+    sentinel_path = work_dir / f"{source}-{tier}-{sentinel_name}"
+    sentinel_path.write_text(release_tag + "\n")
+
+    if dry_run:
+        log.info("dry-run: would commit catalog + sentinel")
+    else:
+        from huggingface_hub import CommitOperationAdd
+
+        # Catalog commit
+        catalog_commit = api.create_commit(
+            repo_id=repo_id,
+            repo_type="dataset",
+            operations=[
+                CommitOperationAdd(
+                    path_in_repo=f"{source}.json",
+                    path_or_fileobj=str(catalog_path),
+                )
+            ],
+            commit_message=f"feat(data): {release_tag} — {source} catalog",
+            revision=release_tag,
+        )
+        last_commit_sha = getattr(catalog_commit, "oid", "") or last_commit_sha
+
+        # Sentinel commit — final marker.
+        sentinel_commit = api.create_commit(
+            repo_id=repo_id,
+            repo_type="dataset",
+            operations=[
+                CommitOperationAdd(
+                    path_in_repo=f"{source}/{tier}/{sentinel_name}",
+                    path_or_fileobj=str(sentinel_path),
+                )
+            ],
+            commit_message=f"feat(data): {release_tag} — {source} {tier} complete",
+            revision=release_tag,
+        )
+        last_commit_sha = getattr(sentinel_commit, "oid", "") or last_commit_sha
+
+    log.info(
+        "PERF per-file bake: %.1fs, %d ok / %d failed / %d skipped (preflight)",
+        time.monotonic() - t0,
+        n_ok,
+        n_failed,
+        n_skipped_preflight,
+    )
+
+    return {
+        "commit": last_commit_sha,
+        "ok": n_ok,
+        "failed": n_failed,
+        "skipped_preflight": n_skipped_preflight,
+        "materials": len(all_records),
+    }

--- a/tests/test_hf_bake_per_file.py
+++ b/tests/test_hf_bake_per_file.py
@@ -1,0 +1,248 @@
+"""Per-file substrate baker (ADR-0012 / #182).
+
+Covers the three load-bearing behaviours of ``bake_one_per_file``:
+
+1. Every (source, tier, material, channel) baked texture lands as an
+   individual HF file at ``<source>/<tier>/<mid>/<channel>.{png,ktx2}``.
+   No tar, no rowmap.
+2. A pre-flight tree scan of the target revision skips materials
+   whose files are already committed — resumable-by-default across
+   crashes / SIGTERMs / rate-limit stalls.
+3. Commits happen in batches (default N=50 materials); each commit is
+   a durable checkpoint. A `.tier_complete` sentinel file lands as the
+   final commit per tier so clients can detect tier-level atomicity
+   (restoring ADR-0007's invariant on top of the new substrate).
+
+Pure-Python tests — HfApi is mocked; no HF calls.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Import target — will initially fail (RED) until the module exists.
+bake_module_available = False
+try:
+    from mat_vis_baker.hf_bake_per_file import bake_one_per_file  # type: ignore
+
+    bake_module_available = True
+except ImportError:
+    bake_one_per_file = None  # type: ignore
+
+
+pytestmark = pytest.mark.skipif(
+    not bake_module_available,
+    reason="RED phase — mat_vis_baker.hf_bake_per_file not yet implemented",
+)
+
+
+def _fake_record(mid: str, channels: dict[str, bytes], work_dir: Path):
+    """Build a minimal ``MaterialRecord`` stub that has channel bytes
+    on disk under ``work_dir / textures / <mid> / <channel>.png``."""
+    from mat_vis_baker.common import (
+        AttributionBlock,
+        MatVisBlock,
+        MaterialRecord,
+    )
+
+    d = work_dir / "textures" / mid
+    d.mkdir(parents=True, exist_ok=True)
+    paths = {}
+    for ch, data in channels.items():
+        p = d / f"{ch}.png"
+        p.write_bytes(data)
+        paths[ch] = p
+
+    return MaterialRecord(
+        id=mid,
+        source="polyhaven",
+        mat_vis=MatVisBlock(
+            name=mid,
+            category="other",
+            upstream_id=mid,
+            attribution=AttributionBlock(license_spdx="CC0-1.0"),
+        ),
+        texture_paths=paths,
+        maps=list(channels.keys()),
+        status="ok",
+    )
+
+
+class TestBakeOnePerFile:
+    def test_writes_one_hf_file_per_channel(self, tmp_path):
+        """Three materials × two channels = six CommitOperationAdd
+        entries + one catalog JSON + one .tier_complete sentinel."""
+        PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+        fake_records = [
+            _fake_record(
+                f"mat_{i}",
+                {"color": PNG_MAGIC + b"\x00" * 100, "normal": PNG_MAGIC + b"\x00" * 80},
+                tmp_path,
+            )
+            for i in range(3)
+        ]
+
+        with (
+            patch("mat_vis_baker.hf_bake_per_file._get_fetcher") as fetcher,
+            patch("mat_vis_baker.hf_bake_per_file.HfApi") as api_cls,
+            patch("mat_vis_baker.hf_bake_per_file.bake_material", side_effect=lambda r, *a, **k: r),
+        ):
+
+            def _sliced(tier, textures_dir, *, limit=None, offset=0, **kw):
+                end = None if limit is None else offset + limit
+                return fake_records[offset:end]
+
+            fetcher.return_value = _sliced
+            api = api_cls.return_value
+            api.list_repo_tree.return_value = []  # nothing committed yet
+
+            result = bake_one_per_file(
+                source="polyhaven",
+                tier="1k",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                hf_token="t",
+                repo_id="gerchowl/mat-vis-tst",
+            )
+
+        # Union of all adds across all create_commit calls must contain
+        # the 6 texture paths + the catalog + the tier-complete sentinel.
+        all_adds: list[str] = []
+        for call in api.create_commit.call_args_list:
+            for op in call.kwargs.get("operations", call.args[-1] if call.args else []):
+                all_adds.append(op.path_in_repo)
+
+        expected_textures = {
+            f"polyhaven/1k/mat_{i}/{ch}.png" for i in range(3) for ch in ("color", "normal")
+        }
+        assert expected_textures <= set(all_adds), (
+            f"missing texture files. present={sorted(all_adds)}"
+        )
+        assert "polyhaven.json" in all_adds
+        assert "polyhaven/1k/.tier_complete" in all_adds
+        assert result["ok"] == 3
+        assert result["failed"] == 0
+
+    def test_preflight_skips_already_committed_materials(self, tmp_path):
+        """If two of three materials already live on HF, baker only
+        processes the missing one — by-design resume."""
+        fake_records = [
+            _fake_record(f"mat_{i}", {"color": b"PNG\x00" * 20}, tmp_path) for i in range(3)
+        ]
+
+        # Fake tree: mat_0 + mat_1 already have color.png committed.
+        from huggingface_hub.hf_api import RepoFile
+
+        existing_files = [
+            RepoFile(path=f"polyhaven/1k/mat_{i}/color.png", size=80, oid="x") for i in range(2)
+        ]
+
+        bake_calls: list[str] = []
+
+        def track_bake(rec, *a, **k):
+            bake_calls.append(rec.id)
+            return rec
+
+        with (
+            patch("mat_vis_baker.hf_bake_per_file._get_fetcher") as fetcher,
+            patch("mat_vis_baker.hf_bake_per_file.HfApi") as api_cls,
+            patch("mat_vis_baker.hf_bake_per_file.bake_material", side_effect=track_bake),
+        ):
+
+            def _sliced(tier, textures_dir, *, limit=None, offset=0, **kw):
+                end = None if limit is None else offset + limit
+                return fake_records[offset:end]
+
+            fetcher.return_value = _sliced
+            api = api_cls.return_value
+            api.list_repo_tree.return_value = existing_files
+
+            bake_one_per_file(
+                source="polyhaven",
+                tier="1k",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                hf_token="t",
+                repo_id="gerchowl/mat-vis-tst",
+            )
+
+        # bake_material called only for mat_2 (the missing one).
+        assert bake_calls == ["mat_2"], (
+            f"preflight should have skipped mat_0, mat_1; ran {bake_calls}"
+        )
+
+    def test_batch_commits_checkpoint_progress(self, tmp_path):
+        """batch_size=2 across 5 materials → 3 batch commits +
+        catalog commit + sentinel commit. Each batch is durable."""
+        fake_records = [
+            _fake_record(f"mat_{i}", {"color": b"PNG\x00" * 10}, tmp_path) for i in range(5)
+        ]
+
+        with (
+            patch("mat_vis_baker.hf_bake_per_file._get_fetcher") as fetcher,
+            patch("mat_vis_baker.hf_bake_per_file.HfApi") as api_cls,
+            patch("mat_vis_baker.hf_bake_per_file.bake_material", side_effect=lambda r, *a, **k: r),
+        ):
+
+            def _sliced(tier, textures_dir, *, limit=None, offset=0, **kw):
+                end = None if limit is None else offset + limit
+                return fake_records[offset:end]
+
+            fetcher.return_value = _sliced
+            api = api_cls.return_value
+            api.list_repo_tree.return_value = []
+
+            bake_one_per_file(
+                source="polyhaven",
+                tier="1k",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                hf_token="t",
+                repo_id="gerchowl/mat-vis-tst",
+                batch_size=2,
+            )
+
+        # Expect: 3 texture-batch commits (2+2+1) + 1 catalog commit
+        # + 1 sentinel commit = 5 total.
+        assert api.create_commit.call_count == 5, (
+            f"expected 5 commits (3 batches + catalog + sentinel); "
+            f"got {api.create_commit.call_count}"
+        )
+
+    def test_prod_target_requires_allow_prod(self, tmp_path):
+        """Safety rail: non-*-tst targets require opt-in, same as the
+        Dagger-level guard in #178 — enforced at the baker entry too."""
+        with pytest.raises(ValueError, match="allow_prod"):
+            bake_one_per_file(
+                source="polyhaven",
+                tier="1k",
+                release_tag="v2026.05.0",
+                work_dir=tmp_path,
+                hf_token="t",
+                repo_id="gerchowl/mat-vis",  # non-tst — refuse
+            )
+
+    def test_empty_fetcher_result_returns_no_materials_error(self, tmp_path):
+        """Fetcher with nothing to bake — return early with an explicit
+        error code rather than committing an empty sentinel."""
+        with (
+            patch("mat_vis_baker.hf_bake_per_file._get_fetcher") as fetcher,
+            patch("mat_vis_baker.hf_bake_per_file.HfApi") as api_cls,
+        ):
+            fetcher.return_value = lambda *a, **kw: []
+            api = api_cls.return_value
+            api.list_repo_tree.return_value = []
+
+            result = bake_one_per_file(
+                source="polyhaven",
+                tier="1k",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                hf_token="t",
+                repo_id="gerchowl/mat-vis-tst",
+            )
+        assert result.get("error")
+        assert result.get("ok", 0) == 0


### PR DESCRIPTION
## Summary

- Lands Option C from /spike #182 as the first commit of the per-file substrate rollout: new `hf_bake_per_file.py` module, ADR-0012, empirical probe script, and 5 unit tests.
- Replaces the per-(source, tier) tar with one HF file per (source, tier, material, channel). Peak local disk drops from O(full tar) to O(one batch) — ambientcg 2k at batch=50 peaks <1 GB instead of 70 GB, dodging the #179 disk wall.
- Preflight tree scan = resumable-by-default; batch commits = durable checkpoints; `.tier_complete` sentinel restores ADR-0007 tier atomicity on top of the new substrate.

This is an **additive** landing — the tar path (`hf_bake.bake_one`) is untouched and remains the default. Cut-over happens in the follow-up issues (CLI wiring → Dagger routing → client migration → tar_writer/merge_shards deletion).

## Tests

- 5 new unit tests in `tests/test_hf_bake_per_file.py` (mocked HfApi, 0.1 s)
- Full suite: 336 pass, 6 skipped, 1 pre-existing unrelated failure (client version resolution drift in this worktree)
- **Live smoke test** against `gerchowl/mat-vis-tst` (polyhaven 1k, limit=2):
  - First run: 2 materials × 5 channels landed, commit `7c5e6e8f`
  - Second run: `skipped_preflight=2, ok=0` — resume-by-default confirmed
  - Tree layout matches ADR-0012 exactly (smoke branch deleted after verification)

## Test plan

- [x] Unit tests green
- [x] Full suite green (modulo pre-existing drift)
- [x] Live smoke commit on `mat-vis-tst`
- [x] Preflight resume round-trip
- [ ] Follow-up: CLI subcommand wiring (filed as separate issue)
- [ ] Follow-up: Dagger `bake()` routing (filed)
- [ ] Follow-up: client migration to plain GET (filed)
- [ ] Follow-up: delete `tar_writer.py` + `merge_shards.py` (gated on above)

Refs #182. Part of milestone v0.6.0.