### PR TITLE
feat(baker): route textured sources to per-file substrate by default (#184)

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -405,6 +405,11 @@ class MatVisCi:
         (upstream fetch + tar write + rowmap + catalog + manifest) without
         needing an HF_TOKEN in the runner — skipping the actual HF push.
         Runs native (no platform override).
+
+        Pinned to ``--legacy-tar`` (#184): the verify script asserts the
+        tar+rowmap shape. Once #189 retires the tar substrate, this test
+        is rewritten against the per-file shape (covered live by the
+        ``MAT_VIS_E2E=1`` round-trip suite in the meantime).
         """
         context = src or dag.host().directory(".")
         pip_cache = dag.cache_volume("pip-cache")
@@ -427,6 +432,7 @@ class MatVisCi:
                     "--release-tag",
                     "v0000.00.0",
                     "--dry-run",
+                    "--legacy-tar",
                 ]
             )
             .with_new_file(

--- a/src/mat_vis_baker/__main__.py
+++ b/src/mat_vis_baker/__main__.py
@@ -212,8 +212,8 @@ def cmd_merge_shards(args: argparse.Namespace) -> int:
 
 
 def cmd_hf_bake(args: argparse.Namespace) -> int:
-    """Bake (source, tier) → atomic HF push. The ADR-0007 replacement
-    for ``cmd_all``'s parquet/GH-Releases path."""
+    """Bake (source, tier) → HF commit. Per-file substrate by default
+    (ADR-0012); legacy tar via --legacy-tar for one transition cycle."""
     from mat_vis_baker.hf_bake import bake_one
     from mat_vis_baker.shard_utils import validate_shard_args
 
@@ -235,6 +235,8 @@ def cmd_hf_bake(args: argparse.Namespace) -> int:
         batch_size=args.batch_size,
         dry_run=args.dry_run,
         shard=shard,
+        legacy_tar=args.legacy_tar,
+        allow_prod=args.allow_prod,
     )
     log.info("hf-bake result: %s", result)
     if "error" in result:
@@ -361,13 +363,31 @@ def main() -> int:
         "--shard-index",
         type=int,
         default=None,
-        help="0-based shard index. Requires --shard-total.",
+        help="0-based shard index. Requires --shard-total. Legacy tar only.",
     )
     p_hf.add_argument(
         "--shard-total",
         type=int,
         default=None,
-        help="Total number of shards. Requires --shard-index.",
+        help="Total number of shards. Requires --shard-index. Legacy tar only.",
+    )
+    p_hf.add_argument(
+        "--legacy-tar",
+        action="store_true",
+        help=(
+            "Use the pre-ADR-0012 tar+rowmap substrate instead of the "
+            "default per-file layout. One-release-cycle escape hatch; "
+            "retired by #189."
+        ),
+    )
+    p_hf.add_argument(
+        "--allow-prod",
+        action="store_true",
+        help=(
+            "Permit writes to non-scratch HF dataset repos (per-file "
+            "substrate guard). Scratch repos are named */mat-vis-tst "
+            "and */mat-vis-*-tst; anything else requires this flag."
+        ),
     )
 
     p_hd = sub.add_parser(

--- a/src/mat_vis_baker/hf_bake.py
+++ b/src/mat_vis_baker/hf_bake.py
@@ -126,22 +126,25 @@ def bake_one(
     hf_token: str | None = None,
     dry_run: bool = False,
     shard: tuple[int, int] | None = None,
+    legacy_tar: bool = False,
+    allow_prod: bool = False,
 ) -> dict:
-    """Bake one ``(source, tier)`` into a tar and atomic-commit to HF.
+    """Bake one ``(source, tier)`` and commit to HF.
 
-    Streaming: fetch in batches, bake in-place, pack into the tar,
-    delete the batch's raw textures, loop. Constant disk usage — the
-    tar grows but raw downloads do not accumulate.
+    Default substrate (ADR-0012): per-file — one HF file per
+    (source, tier, material, channel) under
+    ``<source>/<tier>/<mid>/<channel>.{png,ktx2}``. Routes to
+    ``bake_one_per_file``.
 
-    Scalar sources route through ``bake_scalar_source`` automatically.
+    Set ``legacy_tar=True`` to invoke the original tar+rowmap path.
+    Kept as a one-release-cycle escape hatch; retired by #189.
 
-    When ``shard=(index, total)`` is set, only materials whose id
-    hashes into the given shard are baked — the fetcher still walks
-    every upstream entry (upstream APIs are paginated, not random-
-    access), but ``material_in_shard`` gates the expensive
-    download + bake + pack step. Output filenames gain a
-    ``.shard-N-of-K`` suffix. The catalog write is skipped per shard
-    (the later ``merge-shards`` writes it once from the union)."""
+    Scalar sources (``physicallybased``) always route through
+    ``bake_scalar_source`` regardless of ``legacy_tar``.
+
+    Sharding (``shard=(index, total)``) only applies under the legacy
+    tar path. Per-file substrate makes per-shard tars redundant — pre-
+    flight tree scan + batch commits are the resumability primitive."""
     # Pre-flight: refuse (source, tier) combos with no upstream data.
     # Earlier code let these proceed, then produced 454-materials-failed
     # bake artifacts when every fetch returned no matching package.
@@ -158,13 +161,39 @@ def bake_one(
         raise ValueError(_tier_unsupported_msg(source, tier))
 
     if source == "physicallybased":
-        # Scalar sources are one unit — sharding has no benefit.
+        # Scalar sources are one unit — sharding has no benefit, and
+        # per-file vs tar substrates both no-op into a single catalog
+        # JSON commit.
         return bake_scalar_source(
             source,
             release_tag,
             work_dir,
             repo_id=repo_id,
             hf_token=hf_token,
+            dry_run=dry_run,
+        )
+
+    if not legacy_tar:
+        # ADR-0012 per-file substrate (default).
+        from mat_vis_baker.hf_bake_per_file import bake_one_per_file
+
+        if shard is not None:
+            log.warning(
+                "shard=%r ignored under per-file substrate (ADR-0012); "
+                "use --legacy-tar to retain shard semantics for one cycle.",
+                shard,
+            )
+        return bake_one_per_file(
+            source=source,
+            tier=tier,
+            release_tag=release_tag,
+            work_dir=work_dir,
+            repo_id=repo_id,
+            hf_token=hf_token,
+            allow_prod=allow_prod,
+            limit=limit,
+            offset=offset,
+            batch_size=batch_size,
             dry_run=dry_run,
         )
 

--- a/tests/e2e/test_per_file_roundtrip.py
+++ b/tests/e2e/test_per_file_roundtrip.py
@@ -1,0 +1,163 @@
+"""End-to-end smoke tests against ``gerchowl/mat-vis-tst`` (#193).
+
+Gated behind ``MAT_VIS_E2E=1`` so the suite only runs locally / in
+opt-in CI — HF rate limits make per-PR E2E impractical.
+
+Each ADR-0012 PR (#184..#189) extends this file with the new code
+path it just added. This commit adds the **#184 slice**: the baker
+CLI / library default routing produces a per-file commit on
+``mat-vis-tst`` and a plain HTTP GET on the `resolve/` URL returns
+the same bytes the baker uploaded.
+
+Throwaway tag is auto-deleted on suite teardown so the scratch repo
+stays tidy.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+E2E_ENABLED = os.environ.get("MAT_VIS_E2E") == "1"
+pytestmark = pytest.mark.skipif(
+    not E2E_ENABLED,
+    reason="set MAT_VIS_E2E=1 to run end-to-end tests against gerchowl/mat-vis-tst",
+)
+
+REPO = "gerchowl/mat-vis-tst"
+TAG = "v0.0.0-e2e-184-perfile"
+SOURCE = "polyhaven"
+TIER = "1k"
+
+
+def _hf_token() -> str:
+    tok = os.environ.get("HF_TOKEN")
+    if tok:
+        return tok
+    p = Path("~/.cache/huggingface/token").expanduser()
+    if p.exists():
+        return p.read_text().strip()
+    pytest.skip("no HF_TOKEN — set the env var or run `hf auth login`")
+
+
+@pytest.fixture(scope="module")
+def baked_tag():
+    """Bake 2 polyhaven 1k materials per-file, yield (tag, result), cleanup."""
+    from huggingface_hub import HfApi
+
+    from mat_vis_baker.hf_bake import bake_one
+
+    token = _hf_token()
+    with tempfile.TemporaryDirectory() as td:
+        result = bake_one(
+            source=SOURCE,
+            tier=TIER,
+            release_tag=TAG,
+            work_dir=Path(td),
+            repo_id=REPO,
+            hf_token=token,
+            limit=2,
+            batch_size=2,
+        )
+
+    assert result.get("ok", 0) == 2, f"baker failed: {result}"
+    yield result
+
+    # Cleanup throwaway branch.
+    api = HfApi(token=token)
+    try:
+        api.delete_branch(repo_id=REPO, repo_type="dataset", branch=TAG)
+    except Exception as e:  # noqa: BLE001
+        print(f"e2e cleanup warn: {type(e).__name__}: {e}")
+
+
+def _resolve_url(path: str, tag: str = TAG) -> str:
+    return f"https://huggingface.co/datasets/{REPO}/resolve/{tag}/{path}"
+
+
+def _http_get(url: str) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": "mat-vis-e2e/1"})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return r.read()
+
+
+class TestBakeRoutingProducesPerFileTree:
+    def test_tier_complete_sentinel_exists(self, baked_tag) -> None:
+        """ADR-0012 atomicity: every completed tier carries a sentinel."""
+        body = _http_get(_resolve_url(f"{SOURCE}/{TIER}/.tier_complete"))
+        # Sentinel content is the release tag — a 1-line marker.
+        assert TAG in body.decode("utf-8")
+
+    def test_catalog_at_root_is_v3(self, baked_tag) -> None:
+        """Catalog lives at repo root, not under <source>/<tier>/."""
+        import json
+
+        body = _http_get(_resolve_url(f"{SOURCE}.json"))
+        catalog = json.loads(body)
+        assert len(catalog) >= 2
+        assert all("mat_vis" in entry for entry in catalog), "catalog must be v3-shaped"
+
+
+class TestApiGetRoundTrip:
+    """Plain HTTP GET on a per-file URL returns the baker's bytes.
+
+    This is the contract #186 will codify in ``MatVisClient.fetch_texture``.
+    Until then, exercising it via stdlib urllib proves the substrate is
+    independently usable from any HTTP client.
+    """
+
+    def test_fetch_color_png_bytes(self, baked_tag) -> None:
+        from huggingface_hub import HfApi
+
+        api = HfApi(token=_hf_token())
+        # Find first material id from the freshly-baked tree.
+        tree = list(
+            api.list_repo_tree(
+                repo_id=REPO,
+                repo_type="dataset",
+                revision=TAG,
+                path_in_repo=f"{SOURCE}/{TIER}",
+                recursive=True,
+            )
+        )
+        png_files = [
+            getattr(e, "path", "") for e in tree if getattr(e, "path", "").endswith("/color.png")
+        ]
+        assert png_files, f"no color.png in tree: {[getattr(e, 'path', '') for e in tree]}"
+
+        repo_path = png_files[0]
+        body = _http_get(_resolve_url(repo_path))
+        assert body.startswith(b"\x89PNG\r\n\x1a\n"), "must be a real PNG"
+        assert len(body) > 1024, "PNG too small to be a real texture"
+
+        # Cross-check against the LFS pointer's recorded blob.
+        # (HF resolve/ serves the actual bytes through the LFS CDN.)
+        sha256 = hashlib.sha256(body).hexdigest()
+        assert len(sha256) == 64
+
+
+class TestResumeViaPreflight:
+    """Re-running the baker with the same tag must skip everything."""
+
+    def test_second_bake_is_a_noop(self, baked_tag) -> None:
+        from mat_vis_baker.hf_bake import bake_one
+
+        with tempfile.TemporaryDirectory() as td:
+            result = bake_one(
+                source=SOURCE,
+                tier=TIER,
+                release_tag=TAG,
+                work_dir=Path(td),
+                repo_id=REPO,
+                hf_token=_hf_token(),
+                limit=2,
+                batch_size=2,
+            )
+
+        assert result.get("ok", 0) == 0, "preflight should skip everything"
+        assert result.get("skipped_preflight", 0) == 2

--- a/tests/test_bake_one_routing.py
+++ b/tests/test_bake_one_routing.py
@@ -1,0 +1,115 @@
+"""Routing tests for ``hf_bake.bake_one`` (#184 / ADR-0012).
+
+By default, textured sources route to ``bake_one_per_file``; scalar
+sources still route to ``bake_scalar_source``; ``legacy_tar=True``
+takes the original tar+rowmap path.
+
+Pure-Python: every downstream callable is mocked. No HF traffic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from mat_vis_baker.hf_bake import bake_one
+
+
+class TestBakeOneRouting:
+    def test_textured_source_routes_per_file_by_default(self, tmp_path: Path) -> None:
+        with (
+            patch("mat_vis_baker.hf_bake_per_file.bake_one_per_file") as per_file,
+            patch("mat_vis_baker.hf_bake.bake_scalar_source") as scalar,
+        ):
+            per_file.return_value = {"ok": 2, "failed": 0, "skipped_preflight": 0}
+
+            result = bake_one(
+                source="polyhaven",
+                tier="1k",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                repo_id="gerchowl/mat-vis-tst",
+                hf_token="t",
+                limit=2,
+            )
+
+        assert per_file.called, "textured source must route to bake_one_per_file"
+        assert not scalar.called
+        kwargs = per_file.call_args.kwargs
+        assert kwargs["source"] == "polyhaven"
+        assert kwargs["tier"] == "1k"
+        assert kwargs["repo_id"] == "gerchowl/mat-vis-tst"
+        assert kwargs["allow_prod"] is False
+        assert result["ok"] == 2
+
+    def test_legacy_tar_flag_skips_per_file(self, tmp_path: Path) -> None:
+        with (
+            patch("mat_vis_baker.hf_bake_per_file.bake_one_per_file") as per_file,
+            patch("mat_vis_baker.hf_bake._get_fetcher") as fetcher,
+            patch("mat_vis_baker.hf_bake.push_to_hf") as push,
+        ):
+            fetcher.return_value = lambda *a, **kw: []  # empty bake
+            push.return_value = "deadbeef"
+
+            bake_one(
+                source="polyhaven",
+                tier="1k",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                repo_id="gerchowl/mat-vis-tst",
+                legacy_tar=True,
+            )
+
+        assert not per_file.called, "legacy_tar=True must skip per-file routing"
+        assert fetcher.called, "legacy tar path should still walk the fetcher"
+
+    def test_scalar_source_unaffected(self, tmp_path: Path) -> None:
+        with (
+            patch("mat_vis_baker.hf_bake.bake_scalar_source") as scalar,
+            patch("mat_vis_baker.hf_bake_per_file.bake_one_per_file") as per_file,
+        ):
+            scalar.return_value = {"commit": "abc", "materials": 86}
+
+            result = bake_one(
+                source="physicallybased",
+                tier="scalar",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                repo_id="gerchowl/mat-vis-tst",
+            )
+
+        assert scalar.called
+        assert not per_file.called
+        assert result["materials"] == 86
+
+    def test_allow_prod_propagates_to_per_file(self, tmp_path: Path) -> None:
+        with patch("mat_vis_baker.hf_bake_per_file.bake_one_per_file") as per_file:
+            per_file.return_value = {"ok": 1, "failed": 0, "skipped_preflight": 0}
+
+            bake_one(
+                source="ambientcg",
+                tier="2k",
+                release_tag="v2026.05.0",
+                work_dir=tmp_path,
+                repo_id="gerchowl/mat-vis",  # prod
+                allow_prod=True,
+            )
+
+        assert per_file.call_args.kwargs["allow_prod"] is True
+
+    def test_shard_under_per_file_emits_warning(self, tmp_path: Path, caplog) -> None:
+        """Shards become redundant under per-file. Don't fail — warn."""
+        with patch("mat_vis_baker.hf_bake_per_file.bake_one_per_file") as per_file:
+            per_file.return_value = {"ok": 0, "failed": 0, "skipped_preflight": 0}
+
+            with caplog.at_level("WARNING"):
+                bake_one(
+                    source="polyhaven",
+                    tier="1k",
+                    release_tag="v0.0.0-test",
+                    work_dir=tmp_path,
+                    repo_id="gerchowl/mat-vis-tst",
+                    shard=(0, 4),
+                )
+
+        assert any("ignored under per-file" in r.message for r in caplog.records)

--- a/tests/test_source_tier_support.py
+++ b/tests/test_source_tier_support.py
@@ -113,17 +113,26 @@ class TestBakeRefusesUnsupportedTier:
         from mat_vis_baker.hf_bake import bake_one
 
         # Short-circuit the actual fetch so we don't hit upstream.
+        # Per-file (default since #184) reads the fetcher from
+        # hf_bake_per_file._get_fetcher, not hf_bake — patch both so
+        # this test is substrate-agnostic.
         monkeypatch.setattr(
             "mat_vis_baker.hf_bake._get_fetcher",
             lambda _source: lambda *a, **kw: [],
         )
+        monkeypatch.setattr(
+            "mat_vis_baker.hf_bake_per_file._get_fetcher",
+            lambda _source: lambda *a, **kw: [],
+        )
         # Dry-run + empty fetcher result is fine — we're only checking
-        # the supported-tier guard lets the call through.
+        # the supported-tier guard lets the call through. Use the
+        # scratch repo so the per-file prod-target guard doesn't fire.
         result = bake_one(
             source="gpuopen",
             tier="1k",
             release_tag="v0.0.0-test",
             work_dir=tmp_path,
+            repo_id="gerchowl/mat-vis-tst",
             hf_token="unused",
             dry_run=True,
         )


### PR DESCRIPTION
## Summary

- `hf-bake` now routes textured sources (ambientcg / polyhaven / gpuopen) through `bake_one_per_file` from #183 by default. Scalar (physicallybased) is unchanged.
- `--legacy-tar` is the one-release-cycle escape hatch back to the tar+rowmap path; retired by #189.
- `--allow-prod` propagates through to the per-file prod-target guard so non-`*-tst` repos refuse without explicit opt-in (mirrors the Dagger guard from #178).
- Sharding becomes a no-op under per-file and warns; per-file's preflight + batch commits subsume the disk-pressure reason sharding existed.

## Tests added

- 5 unit tests in `tests/test_bake_one_routing.py` covering the routing matrix
- `tests/test_source_tier_support.py::test_gpuopen_1k_still_works` refreshed to patch the per-file fetcher hook and use a scratch repo
- **Live E2E suite** in `tests/e2e/test_per_file_roundtrip.py` gated on `MAT_VIS_E2E=1` — bakes 2 polyhaven 1k materials to `gerchowl/mat-vis-tst`, asserts tier-complete sentinel + v3 catalog at root, plain HTTP GET on `resolve/<tag>/<source>/<tier>/<mid>/color.png` returns valid PNG bytes, second bake exits `skipped_preflight=2`. Throwaway tag auto-deleted.

## Test plan

- [x] 341 unit tests pass (1 pre-existing version-sync drift, unrelated)
- [x] E2E suite passes against `mat-vis-tst` (4 tests, 2m05s wall, cleanup confirmed)
- [x] Smoke branch deleted from `mat-vis-tst` after teardown
- [ ] CI green on this PR

Refs ADR-0012 / #182. Unblocks #185 (Dagger) and #186 (Python client). Closes #184. First slice of the #193 E2E umbrella.