### PR TITLE
feat(dagger): bake() passthrough — --legacy-tar + --allow-prod (#185)

### DIFF
--- a/.dagger/src/mat_vis_ci/_bake_cli.py
+++ b/.dagger/src/mat_vis_ci/_bake_cli.py
@@ -1,0 +1,66 @@
+"""Pure-Python helpers for the Dagger ``bake()`` op.
+
+Lives in its own module so it can be unit-tested without Dagger Python
+SDK in the venv. ``main.py`` (which decorates ``MatVisCi`` with Dagger's
+runtime types) imports from here; the test imports here directly.
+"""
+
+from __future__ import annotations
+
+
+def bake_argv(
+    *,
+    source: str,
+    tier: str,
+    release_tag: str,
+    repo_id: str,
+    offset: int,
+    batch_size: int,
+    limit: int,
+    dry_run: bool,
+    allow_prod: bool,
+    legacy_tar: bool,
+    shard_index: int,
+    shard_total: int,
+) -> list[str]:
+    """Build the ``mat-vis-baker hf-bake`` argv list.
+
+    Pulled out of ``MatVisCi.bake`` so the contract is unit-testable
+    without spinning up a Dagger engine. The Dagger function is then
+    a thin shell over this + container exec.
+
+    Sentinels:
+      - ``limit <= 0`` drops ``--limit``.
+      - Both ``shard_index < 0`` and ``shard_total < 0`` drops both
+        shard flags. Sharding is a no-op under per-file substrate
+        (#184 / ADR-0012); passthrough kept for ``legacy_tar=True``
+        callers only.
+    """
+    argv: list[str] = [
+        "uv",
+        "run",
+        "mat-vis-baker",
+        "hf-bake",
+        source,
+        tier,
+        "/tmp/bake",
+        "--release-tag",
+        release_tag,
+        "--repo-id",
+        repo_id,
+        "--offset",
+        str(offset),
+        "--batch-size",
+        str(batch_size),
+    ]
+    if limit > 0:
+        argv += ["--limit", str(limit)]
+    if dry_run:
+        argv.append("--dry-run")
+    if allow_prod:
+        argv.append("--allow-prod")
+    if legacy_tar:
+        argv.append("--legacy-tar")
+    if shard_index >= 0 and shard_total >= 0:
+        argv += ["--shard-index", str(shard_index), "--shard-total", str(shard_total)]
+    return argv

--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -31,6 +31,8 @@ from typing import Annotated
 import dagger
 from dagger import Doc, dag, function, object_type
 
+from mat_vis_ci._bake_cli import bake_argv as _bake_argv
+
 IMAGE = "ghcr.io/morepet/mat-vis-baker"
 TARGET_PLATFORM = dagger.Platform("linux/amd64")
 
@@ -569,55 +571,55 @@ class MatVisCi:
         limit: Annotated[int, Doc("Max materials (0 = no limit)")] = 0,
         offset: Annotated[int, Doc("Skip first N materials")] = 0,
         batch_size: Annotated[int, Doc("Materials per streaming batch")] = 50,
-        dry_run: Annotated[bool, Doc("Build tar locally; skip HF push")] = False,
+        dry_run: Annotated[bool, Doc("Build locally; skip HF push")] = False,
         shard_index: Annotated[int, Doc("0-based shard index (-1 = no sharding)")] = -1,
         shard_total: Annotated[int, Doc("Total shards (-1 = no sharding)")] = -1,
+        legacy_tar: Annotated[
+            bool,
+            Doc(
+                "Use the pre-ADR-0012 tar+rowmap substrate. One-cycle escape hatch retired by #189."
+            ),
+        ] = False,
     ) -> str:
-        """Bake one (source, tier) into an atomic HF commit (#136).
+        """Bake one (source, tier) into an HF commit (#136 / ADR-0012).
 
         Wraps ``mat-vis-baker hf-bake`` in the shared ``_baker_container``
         (#135). Returns the CLI stdout — the final line is the commit SHA
-        when ``--dry-run`` is not set. Parity target: the ``hf-bake`` step
-        in ``.github/workflows/bake.yml`` (pre-#138).
+        when ``--dry-run`` is not set.
+
+        Default substrate: per-file (ADR-0012, #184). Each material ×
+        channel lands as one file under ``<source>/<tier>/<mid>/<channel>``.
+        Pre-flight tree scan + batch commits (size ``batch_size``) make
+        bakes resumable across crashes. Pass ``legacy_tar=true`` to fall
+        back to the tar+rowmap path for one transition cycle.
 
         Sentinels: ``limit=0`` drops ``--limit``; ``shard_index=-1`` and
-        ``shard_total=-1`` drop both shard flags. Pass both to shard.
+        ``shard_total=-1`` drop both shard flags. Sharding is a no-op
+        under per-file (#184) — kept for ``legacy_tar`` callers only.
 
         Safety: defaults to ``gerchowl/mat-vis-tst`` (scratch). Any other
-        target requires ``--allow-prod=true`` — see ``_guard_prod_target``.
+        target requires ``allow_prod=true``. Both Dagger-level
+        (``_guard_prod_target``) and baker-level (per-file
+        ``_guard_prod_target``) checks fire; redundant by design so the
+        rail still holds when callers reach the baker without going
+        through Dagger.
         """
         self._guard_prod_target(repo_id, allow_prod)
         ctr = self._baker_container(context, with_ktx2=False, hf_token=hf_token)
-
-        argv: list[str] = [
-            "uv",
-            "run",
-            "mat-vis-baker",
-            "hf-bake",
-            source,
-            tier,
-            "/tmp/bake",
-            "--release-tag",
-            release_tag,
-            "--repo-id",
-            repo_id,
-            "--offset",
-            str(offset),
-            "--batch-size",
-            str(batch_size),
-        ]
-        if limit > 0:
-            argv += ["--limit", str(limit)]
-        if dry_run:
-            argv.append("--dry-run")
-        if shard_index >= 0 and shard_total >= 0:
-            argv += [
-                "--shard-index",
-                str(shard_index),
-                "--shard-total",
-                str(shard_total),
-            ]
-
+        argv = _bake_argv(
+            source=source,
+            tier=tier,
+            release_tag=release_tag,
+            repo_id=repo_id,
+            offset=offset,
+            batch_size=batch_size,
+            limit=limit,
+            dry_run=dry_run,
+            allow_prod=allow_prod,
+            legacy_tar=legacy_tar,
+            shard_index=shard_index,
+            shard_total=shard_total,
+        )
         return await ctr.with_exec(argv).stdout()
 
     @function

--- a/tests/e2e/test_per_file_roundtrip.py
+++ b/tests/e2e/test_per_file_roundtrip.py
@@ -161,3 +161,66 @@ class TestResumeViaPreflight:
 
         assert result.get("ok", 0) == 0, "preflight should skip everything"
         assert result.get("skipped_preflight", 0) == 2
+
+
+# ── #185 slice: Dagger passthrough produces the same per-file tree ──
+
+
+@pytest.mark.skipif(
+    not os.environ.get("MAT_VIS_E2E_DAGGER"),
+    reason="set MAT_VIS_E2E_DAGGER=1 to also run the Dagger smoke (needs `dagger` CLI)",
+)
+class TestDaggerBakeRoutingSmoke:
+    """Run the Dagger ``bake`` op end-to-end against ``mat-vis-tst``.
+
+    Gated on ``MAT_VIS_E2E_DAGGER=1`` (separate from the baker E2E gate)
+    because it requires a working ``dagger`` CLI on the host. CI runs
+    this in the dagger-for-github action; locally it's opt-in.
+    """
+
+    DAGGER_TAG = "v0.0.0-e2e-185-dagger"
+
+    def test_dagger_bake_2_polyhaven_lands_per_file(self) -> None:
+        import subprocess
+
+        from huggingface_hub import HfApi
+
+        token = _hf_token()
+        try:
+            cmd = [
+                "dagger",
+                "call",
+                "bake",
+                "--context=.",
+                "--source=polyhaven",
+                "--tier=1k",
+                f"--release-tag={self.DAGGER_TAG}",
+                "--hf-token=env:HF_TOKEN",
+                "--repo-id=gerchowl/mat-vis-tst",
+                "--limit=2",
+                "--batch-size=2",
+            ]
+            env = {**os.environ, "HF_TOKEN": token}
+            proc = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=600)
+            assert proc.returncode == 0, f"dagger call bake failed: {proc.stderr[-2000:]}"
+
+            api = HfApi(token=token)
+            tree = list(
+                api.list_repo_tree(
+                    repo_id=REPO,
+                    repo_type="dataset",
+                    revision=self.DAGGER_TAG,
+                    path_in_repo=f"{SOURCE}/{TIER}",
+                    recursive=True,
+                )
+            )
+            paths = {getattr(e, "path", "") for e in tree}
+            assert any(p.endswith("/color.png") for p in paths)
+            assert f"{SOURCE}/{TIER}/.tier_complete" in paths
+        finally:
+            try:
+                HfApi(token=token).delete_branch(
+                    repo_id=REPO, repo_type="dataset", branch=self.DAGGER_TAG
+                )
+            except Exception as e:  # noqa: BLE001
+                print(f"dagger e2e cleanup warn: {type(e).__name__}: {e}")

--- a/tests/test_dagger_bake_argv.py
+++ b/tests/test_dagger_bake_argv.py
@@ -1,0 +1,154 @@
+"""Regression gate for the Dagger ``bake()`` argv contract (#185).
+
+The Dagger module lives outside the main package, so ``_bake_cli.py``
+holds the pure-Python helper that builds the ``mat-vis-baker hf-bake``
+argv list. Importing it via file path keeps this test runnable in the
+default ``uv run pytest`` invocation, no Dagger engine required.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+BAKE_CLI_PATH = (
+    Path(__file__).resolve().parent.parent / ".dagger" / "src" / "mat_vis_ci" / "_bake_cli.py"
+)
+
+
+@pytest.fixture(scope="module")
+def bake_argv():
+    spec = importlib.util.spec_from_file_location("dagger_bake_cli", BAKE_CLI_PATH)
+    if spec is None or spec.loader is None:
+        pytest.skip("could not locate .dagger/src/mat_vis_ci/_bake_cli.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.bake_argv
+
+
+class TestBakeArgvContract:
+    """Locks the CLI argv shape so future refactors don't silently
+    change the surface ``dagger call bake`` produces."""
+
+    def test_default_per_file_no_shard(self, bake_argv):
+        """Per-file (default), no shard, no limit, scratch repo."""
+        argv = bake_argv(
+            source="polyhaven",
+            tier="1k",
+            release_tag="v0.0.0-test",
+            repo_id="gerchowl/mat-vis-tst",
+            offset=0,
+            batch_size=50,
+            limit=0,
+            dry_run=False,
+            allow_prod=False,
+            legacy_tar=False,
+            shard_index=-1,
+            shard_total=-1,
+        )
+        assert argv[:6] == ["uv", "run", "mat-vis-baker", "hf-bake", "polyhaven", "1k"]
+        assert "/tmp/bake" in argv
+        assert "--release-tag" in argv and "v0.0.0-test" in argv
+        assert "--repo-id" in argv and "gerchowl/mat-vis-tst" in argv
+        assert "--batch-size" in argv and "50" in argv
+        # No optional flags fired.
+        for flag in (
+            "--limit",
+            "--dry-run",
+            "--allow-prod",
+            "--legacy-tar",
+            "--shard-index",
+            "--shard-total",
+        ):
+            assert flag not in argv, f"unexpected {flag} in default argv"
+
+    def test_limit_emits_when_positive(self, bake_argv):
+        argv = bake_argv(
+            source="polyhaven",
+            tier="1k",
+            release_tag="v0.0.0-test",
+            repo_id="gerchowl/mat-vis-tst",
+            offset=0,
+            batch_size=2,
+            limit=2,
+            dry_run=False,
+            allow_prod=False,
+            legacy_tar=False,
+            shard_index=-1,
+            shard_total=-1,
+        )
+        i = argv.index("--limit")
+        assert argv[i + 1] == "2"
+
+    def test_dry_run_and_allow_prod_propagate(self, bake_argv):
+        argv = bake_argv(
+            source="ambientcg",
+            tier="2k",
+            release_tag="v2026.05.0",
+            repo_id="gerchowl/mat-vis",
+            offset=0,
+            batch_size=50,
+            limit=0,
+            dry_run=True,
+            allow_prod=True,
+            legacy_tar=False,
+            shard_index=-1,
+            shard_total=-1,
+        )
+        assert "--dry-run" in argv
+        assert "--allow-prod" in argv
+
+    def test_legacy_tar_passthrough(self, bake_argv):
+        argv = bake_argv(
+            source="polyhaven",
+            tier="1k",
+            release_tag="v0.0.0-test",
+            repo_id="gerchowl/mat-vis-tst",
+            offset=0,
+            batch_size=50,
+            limit=0,
+            dry_run=False,
+            allow_prod=False,
+            legacy_tar=True,
+            shard_index=-1,
+            shard_total=-1,
+        )
+        assert "--legacy-tar" in argv
+
+    def test_shard_flags_pair(self, bake_argv):
+        """Both shard flags or neither — never one alone."""
+        argv_pair = bake_argv(
+            source="polyhaven",
+            tier="1k",
+            release_tag="v0.0.0-test",
+            repo_id="gerchowl/mat-vis-tst",
+            offset=0,
+            batch_size=50,
+            limit=0,
+            dry_run=False,
+            allow_prod=False,
+            legacy_tar=False,
+            shard_index=2,
+            shard_total=4,
+        )
+        assert "--shard-index" in argv_pair and "2" in argv_pair
+        assert "--shard-total" in argv_pair and "4" in argv_pair
+
+        argv_solo = bake_argv(
+            source="polyhaven",
+            tier="1k",
+            release_tag="v0.0.0-test",
+            repo_id="gerchowl/mat-vis-tst",
+            offset=0,
+            batch_size=50,
+            limit=0,
+            dry_run=False,
+            allow_prod=False,
+            legacy_tar=False,
+            shard_index=2,
+            shard_total=-1,
+        )
+        assert "--shard-index" not in argv_solo
+        assert "--shard-total" not in argv_solo


### PR DESCRIPTION
## Summary

- Wire `--legacy-tar` and `--allow-prod` through `MatVisCi.bake()` to the baker CLI
- Extract argv construction into `.dagger/src/mat_vis_ci/_bake_cli.py` so the surface contract is unit-testable without a Dagger engine
- Per-file is documented as the v0.6.0 default substrate

## Tests

- `tests/test_dagger_bake_argv.py` — 5 regression gates locking the argv shape (default per-file, --limit positive-only, dry-run + allow-prod propagation, legacy-tar passthrough, shard-flag pairing)
- `tests/e2e/test_per_file_roundtrip.py` — `TestDaggerBakeRoutingSmoke` runs `dagger call bake` end-to-end against `mat-vis-tst` (gated `MAT_VIS_E2E_DAGGER=1`)
- 346 unit tests pass (1 pre-existing version-sync drift, unrelated)

Closes #185. Refs #182 / ADR-0012. Adds the second slice to the #193 E2E umbrella.