### PR TITLE
fix(client/python): backport StrEnum for Python 3.10 (#197)

### DIFF
--- a/clients/python/src/mat_vis_client/schema.py
+++ b/clients/python/src/mat_vis_client/schema.py
@@ -10,8 +10,17 @@ import time and shared by identity so there is one authoritative copy.
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass, field
-from enum import StrEnum
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        def __str__(self) -> str:
+            return str(self.value)
 
 
 class Channel(StrEnum):


### PR DESCRIPTION
## Summary
- `mat_vis_client/schema.py` imported `enum.StrEnum` (3.11+) while `pyproject.toml` declared `requires-python = ">=3.10"` — installs succeeded then crashed at import for downstream consumers like `py-materials`.
- Added a version-gated shim: native `StrEnum` on 3.11+, a `class StrEnum(str, Enum)` backport on 3.10.
- No other 3.11-only stdlib usage in the client.

Closes #197.

## Test plan
- [x] `uv run --python 3.10 python -c "from mat_vis_client.schema import Channel, Tier; ..."` — imports cleanly, `str(Channel.COLOR) == "color"`, `Tier.T2K == "2k"`.
- [x] `uv run --python 3.11` — same checks pass.
- [x] pre-push test gate (347 passed in `tests/`, 211 passed in `clients/python`).