### PR TITLE
feat(clients/{js,shell,rust}): port per-file fetch to all reference clients (#188)

### DIFF
--- a/clients/js/mat-vis-client.mjs
+++ b/clients/js/mat-vis-client.mjs
@@ -5,140 +5,190 @@
  *
  * Usage (browser):
  *   import { MatVisClient } from './mat-vis-client.mjs';
- *   const client = new MatVisClient();
+ *   const client = new MatVisClient({ tag: 'v2026.04.1' });
  *   const png = await client.fetchTexture('ambientcg', 'Rock064', 'color', '1k');
- *   // png is an ArrayBuffer of raw PNG bytes
+ *   // png is an ArrayBuffer of raw PNG (or KTX2) bytes
  *
  * Usage (Node CLI):
  *   node mat-vis-client.mjs list
  *   node mat-vis-client.mjs fetch ambientcg Rock064 color 1k -o rock.png
+ *
+ * Substrate: per-file HF dataset (#186 / ADR-0012). The client does
+ * a plain HTTPS GET on
+ *   <HF_BASE>/<tag>/<source>/<tier>/<material>/<channel>.{png,ktx2}
+ * and probes a `.tier_complete` sentinel once per (source, tier) so
+ * partial bakes can never serve half-baked bytes.
  */
 
-const REPO = 'MorePET/mat-vis';
-const RELEASES = `https://github.com/${REPO}/releases`;
+const HF_DATASET = 'gerchowl/mat-vis';
+const HF_BASE =
+  (typeof process !== 'undefined' && process.env?.MAT_VIS_HF_BASE) ||
+  `https://huggingface.co/datasets/${HF_DATASET}/resolve`;
 
 // SSoT: clients/js/package.json. Kept in sync by
 // scripts/sync-js-version.py (pre-commit) — a drift test in tests/
 // fails CI if these disagree. Do not hand-edit.
-export const VERSION = '0.1.0';
+export const VERSION = '0.6.0';
 const UA = `mat-vis-client/${VERSION} (JavaScript)`;
 
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47];
+const KTX2_MAGIC = [0xab, 0x4b, 0x54, 0x58];
+
+function startsWithMagic(buf, magic) {
+  if (buf.byteLength < magic.length) return false;
+  const v = new Uint8Array(buf, 0, magic.length);
+  for (let i = 0; i < magic.length; i++) {
+    if (v[i] !== magic[i]) return false;
+  }
+  return true;
+}
+
 export class MatVisClient {
-  #manifestUrl;
+  #tag;
   #manifest = null;
-  #rowmaps = new Map();
+  #catalogs = new Map();
+  #tierComplete = new Map();
 
   /**
    * @param {Object} opts
-   * @param {string} [opts.tag] - Release tag (default: latest)
-   * @param {string} [opts.manifestUrl] - Override manifest URL
+   * @param {string} [opts.tag] - Release tag (default: 'main')
    */
-  constructor({ tag, manifestUrl } = {}) {
-    if (manifestUrl) {
-      this.#manifestUrl = manifestUrl;
-    } else if (tag) {
-      this.#manifestUrl = `${RELEASES}/download/${tag}/release-manifest.json`;
-    } else {
-      this.#manifestUrl = `${RELEASES}/latest/download/release-manifest.json`;
-    }
+  constructor({ tag } = {}) {
+    this.#tag = tag || 'main';
+  }
+
+  #hfUrl(path) {
+    return `${HF_BASE}/${this.#tag}/${path}`;
   }
 
   async manifest() {
     if (!this.#manifest) {
-      const resp = await fetch(this.#manifestUrl, { headers: { 'User-Agent': UA } });
+      const url = this.#hfUrl('release-manifest.json');
+      const resp = await fetch(url, { headers: { 'User-Agent': UA } });
       if (!resp.ok) throw new Error(`Failed to fetch manifest: ${resp.status}`);
       this.#manifest = await resp.json();
+      const sv = this.#manifest.schema_version;
+      if (sv !== 3) {
+        throw new Error(
+          `Unsupported manifest schema_version=${sv}; this client requires v3 (per-file substrate, ADR-0012).`,
+        );
+      }
     }
     return this.#manifest;
   }
 
   async tiers() {
     const m = await this.manifest();
-    return Object.keys(m.tiers);
+    const seen = new Set();
+    for (const src of Object.values(m.sources || {})) {
+      for (const t of Object.keys(src.tiers || {})) seen.add(t);
+    }
+    return [...seen].sort();
   }
 
   async sources(tier = '1k') {
     const m = await this.manifest();
-    return Object.keys(m.tiers[tier]?.sources || {});
+    const out = [];
+    for (const [name, entry] of Object.entries(m.sources || {})) {
+      if (entry.tiers && tier in entry.tiers) out.push(name);
+    }
+    return out.sort();
   }
 
-  async rowmap(source, tier) {
-    const key = `${source}-${tier}`;
-    if (!this.#rowmaps.has(key)) {
-      const m = await this.manifest();
-      const tierData = m.tiers[tier];
-      if (!tierData) throw new Error(`Tier ${tier} not found`);
-      const srcData = tierData.sources[source];
-      if (!srcData) throw new Error(`Source ${source} not found for tier ${tier}`);
-
-      const rowmapFiles = srcData.rowmap_files || [srcData.rowmap_file];
-
-      // Fetch all partition rowmaps and merge materials
-      const merged = { materials: {} };
-      for (const rmf of rowmapFiles) {
-        const url = tierData.base_url + rmf;
-        const resp = await fetch(url, { headers: { 'User-Agent': UA } });
-        if (!resp.ok) throw new Error(`Failed to fetch rowmap ${rmf}: ${resp.status}`);
-        const rm = await resp.json();
-        const pqFile = rm.parquet_file || '';
-        for (const [mid, channels] of Object.entries(rm.materials || {})) {
-          for (const chData of Object.values(channels)) {
-            chData.parquet_file = pqFile;
-          }
-          merged.materials[mid] = channels;
-        }
-        for (const k of ['version', 'release_tag', 'source', 'tier']) {
-          if (rm[k]) merged[k] = rm[k];
-        }
-      }
-      this.#rowmaps.set(key, merged);
-    }
-    return this.#rowmaps.get(key);
+  async #catalog(source) {
+    if (this.#catalogs.has(source)) return this.#catalogs.get(source);
+    const m = await this.manifest();
+    const srcEntry = m.sources?.[source];
+    if (!srcEntry) throw new Error(`Source ${source} not found in manifest`);
+    const catalogPath = srcEntry.catalog || `${source}.json`;
+    const url = this.#hfUrl(catalogPath);
+    const resp = await fetch(url, { headers: { 'User-Agent': UA } });
+    if (!resp.ok) throw new Error(`Failed to fetch catalog ${catalogPath}: ${resp.status}`);
+    const entries = await resp.json();
+    if (!Array.isArray(entries)) throw new Error(`Catalog ${catalogPath} is not a list`);
+    this.#catalogs.set(source, entries);
+    return entries;
   }
 
   async materials(source, tier = '1k') {
-    const rm = await this.rowmap(source, tier);
-    return Object.keys(rm.materials).sort();
+    const cat = await this.#catalog(source);
+    return cat
+      .filter((e) => Array.isArray(e.available_tiers) && e.available_tiers.includes(tier))
+      .map((e) => e.id)
+      .filter((id) => typeof id === 'string')
+      .sort();
   }
 
   async channels(source, materialId, tier = '1k') {
-    const rm = await this.rowmap(source, tier);
-    return Object.keys(rm.materials[materialId] || {}).sort();
+    void tier;
+    const cat = await this.#catalog(source);
+    const entry = cat.find((e) => e.id === materialId);
+    if (!entry) return [];
+    const maps = Array.isArray(entry.maps)
+      ? entry.maps
+      : Object.keys(entry.texture_hashes || {});
+    return [...maps].filter((m) => typeof m === 'string').sort();
+  }
+
+  async #assertTierComplete(source, tier) {
+    const key = `${source}/${tier}`;
+    if (this.#tierComplete.get(key)) return;
+    const url = this.#hfUrl(`${source}/${tier}/.tier_complete`);
+    const resp = await fetch(url, { headers: { 'User-Agent': UA } });
+    if (!resp.ok) {
+      throw new Error(
+        `tier ${source}/${tier} is not atomically complete on this release ` +
+          `(no .tier_complete sentinel). The bake may still be running, or ` +
+          `this revision was committed mid-batch. Re-run the bake or pin a ` +
+          `known-complete tag.`,
+      );
+    }
+    this.#tierComplete.set(key, true);
   }
 
   /**
-   * Fetch a single texture PNG via HTTP range read.
-   * @returns {Promise<ArrayBuffer>} Raw PNG bytes
+   * Fetch a single texture via plain HTTPS GET (#186 / ADR-0012).
+   *
+   * URL: <HF_BASE>/<tag>/<source>/<tier>/<material>/<channel>.{png,ktx2}.
+   * PNG is tried first; on 404 falls back to .ktx2 for derived tiers.
+   *
+   * @returns {Promise<ArrayBuffer>} Raw PNG or KTX2 bytes.
    */
   async fetchTexture(source, materialId, channel, tier = '1k') {
-    const rm = await this.rowmap(source, tier);
-    const mat = rm.materials[materialId];
-    if (!mat) throw new Error(`Material ${materialId} not found`);
-    const rng = mat[channel];
-    if (!rng) throw new Error(`Channel ${channel} not found for ${materialId}`);
-
-    const m = await this.manifest();
-    const pqFile = rng.parquet_file || rm.parquet_file || '';
-    const url = m.tiers[tier].base_url + pqFile;
-
-    const resp = await fetch(url, {
-      headers: {
-        'User-Agent': UA,
-        Range: `bytes=${rng.offset}-${rng.offset + rng.length - 1}`,
-      },
-    });
-
-    if (!resp.ok && resp.status !== 206) {
-      throw new Error(`Range read failed: ${resp.status}`);
+    const cat = await this.#catalog(source);
+    const entry = cat.find((e) => e.id === materialId);
+    if (!entry) throw new Error(`Material ${materialId} not found in ${source}`);
+    if (!(entry.available_tiers || []).includes(tier)) {
+      throw new Error(`Material ${materialId} is not staged at tier ${tier}`);
+    }
+    const available = await this.channels(source, materialId, tier);
+    if (!available.includes(channel)) {
+      throw new Error(
+        `channel ${channel} not found (context: ${source}/${tier}/${materialId}). ` +
+          `Available: ${available.join(', ')}`,
+      );
     }
 
-    const buf = await resp.arrayBuffer();
-    const magic = new Uint8Array(buf, 0, 4);
-    if (magic[0] !== 0x89 || magic[1] !== 0x50 || magic[2] !== 0x4e || magic[3] !== 0x47) {
-      throw new Error(`Expected PNG, got ${Array.from(magic).map((b) => b.toString(16)).join(' ')}`);
-    }
+    await this.#assertTierComplete(source, tier);
 
-    return buf;
+    let lastErr = null;
+    for (const ext of ['png', 'ktx2']) {
+      const url = this.#hfUrl(`${source}/${tier}/${materialId}/${channel}.${ext}`);
+      const resp = await fetch(url, { headers: { 'User-Agent': UA } });
+      if (!resp.ok) {
+        lastErr = new Error(`HTTP ${resp.status} on ${url}`);
+        continue;
+      }
+      const buf = await resp.arrayBuffer();
+      if (!startsWithMagic(buf, PNG_MAGIC) && !startsWithMagic(buf, KTX2_MAGIC)) {
+        const head = new Uint8Array(buf, 0, Math.min(12, buf.byteLength));
+        throw new Error(
+          `Expected PNG or KTX2 bytes, got ${[...head].map((b) => b.toString(16)).join(' ')}`,
+        );
+      }
+      return buf;
+    }
+    throw lastErr || new Error(`channel ${channel} not available for ${source}/${materialId}`);
   }
 }
 

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mat-vis-client",
-  "version": "0.1.0",
-  "description": "Pure JavaScript client for mat-vis PBR textures — HTTP range reads, zero deps, browser + Node 18+",
+  "version": "0.6.0",
+  "description": "Pure JavaScript client for mat-vis PBR textures — per-file HF dataset, zero deps, browser + Node 18+",
   "type": "module",
   "main": "mat-vis-client.mjs",
   "exports": {

--- a/clients/js/test_client.mjs
+++ b/clients/js/test_client.mjs
@@ -1,71 +1,228 @@
 /**
- * Tests for the JavaScript reference client against live release data.
+ * Tests for the JavaScript reference client.
+ *
+ * Two test modes:
+ *   1. Structural tests — always run. Verify URL contract, magic-byte
+ *      parsing, and v3 manifest shape using a stubbed `fetch()`.
+ *   2. Live tests — gated on MAT_VIS_LIVE_TESTS=1. Hit the prod HF
+ *      dataset; default-skipped because v0.6 dropped tar support and
+ *      prod isn't rebaked under the per-file substrate yet (see #179).
  *
  * Uses Node's built-in test runner (node:test) — zero dependencies.
  * Run with: node --test test_client.mjs
  */
 
-import { describe, it } from 'node:test';
+import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
 import { MatVisClient } from './mat-vis-client.mjs';
 
-const TAG = process.env.MAT_VIS_TAG || 'v2026.04.0';
-const client = new MatVisClient({ tag: TAG });
+// ── stubbed-fetch structural tests ─────────────────────────────────
 
-describe('manifest', () => {
-  it('fetches manifest with schema_version field', async () => {
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0]);
+
+function stubFetch(routes) {
+  return async (url, _opts) => {
+    for (const [pattern, handler] of routes) {
+      if (typeof pattern === 'string' && url.includes(pattern)) return handler(url);
+      if (pattern instanceof RegExp && pattern.test(url)) return handler(url);
+    }
+    return {
+      ok: false,
+      status: 404,
+      async json() { return {}; },
+      async arrayBuffer() { return new ArrayBuffer(0); },
+    };
+  };
+}
+
+function jsonResp(obj) {
+  return {
+    ok: true,
+    status: 200,
+    async json() { return obj; },
+    async arrayBuffer() { return new ArrayBuffer(0); },
+  };
+}
+
+function bytesResp(u8) {
+  return {
+    ok: true,
+    status: 200,
+    async json() { throw new Error('not json'); },
+    async arrayBuffer() {
+      return u8.buffer.slice(u8.byteOffset, u8.byteOffset + u8.byteLength);
+    },
+  };
+}
+
+const MOCK_MANIFEST = {
+  schema_version: 3,
+  release_tag: 'vtest',
+  sources: {
+    ambientcg: { catalog: 'ambientcg.json', tiers: { '1k': { complete: true } } },
+  },
+};
+const MOCK_CATALOG = [
+  {
+    id: 'Rock064',
+    source: 'ambientcg',
+    mat_vis: { name: 'Rock064', category: 'stone' },
+    available_tiers: ['1k'],
+    maps: ['color', 'normal'],
+  },
+];
+
+describe('structural', () => {
+  let originalFetch;
+
+  before(() => {
+    originalFetch = globalThis.fetch;
+  });
+  after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('fetchTexture builds a per-file URL and returns PNG bytes', async () => {
+    const calledUrls = [];
+    globalThis.fetch = stubFetch([
+      ['/release-manifest.json', () => jsonResp(MOCK_MANIFEST)],
+      ['/ambientcg.json', () => jsonResp(MOCK_CATALOG)],
+      [
+        '/.tier_complete',
+        (url) => {
+          calledUrls.push(url);
+          return jsonResp({});
+        },
+      ],
+      [
+        '/Rock064/color.png',
+        (url) => {
+          calledUrls.push(url);
+          return bytesResp(PNG);
+        },
+      ],
+    ]);
+    const client = new MatVisClient({ tag: 'vtest' });
+    const buf = await client.fetchTexture('ambientcg', 'Rock064', 'color', '1k');
+    assert.ok(buf.byteLength > 0, 'should return non-empty bytes');
+    const head = new Uint8Array(buf, 0, 4);
+    assert.deepStrictEqual([...head], [0x89, 0x50, 0x4e, 0x47]);
+    assert.ok(
+      calledUrls.some((u) => u.endsWith('/ambientcg/1k/.tier_complete')),
+      'must probe sentinel before fetch',
+    );
+    assert.ok(
+      calledUrls.some((u) => u.endsWith('/ambientcg/1k/Rock064/color.png')),
+      'must hit per-file URL',
+    );
+  });
+
+  it('fetchTexture falls back to .ktx2 when .png 404s', async () => {
+    globalThis.fetch = stubFetch([
+      ['/release-manifest.json', () => jsonResp(MOCK_MANIFEST)],
+      ['/ambientcg.json', () => jsonResp(MOCK_CATALOG)],
+      ['/.tier_complete', () => jsonResp({})],
+      [
+        '/color.png',
+        () => ({
+          ok: false,
+          status: 404,
+          async json() { return {}; },
+          async arrayBuffer() { return new ArrayBuffer(0); },
+        }),
+      ],
+      [
+        '/color.ktx2',
+        () =>
+          bytesResp(
+            new Uint8Array([
+              0xab, 0x4b, 0x54, 0x58, 0x20, 0x32, 0x30, 0xbb, 0x0d, 0x0a, 0x1a, 0x0a, 0,
+            ]),
+          ),
+      ],
+    ]);
+    const client = new MatVisClient({ tag: 'vtest' });
+    const buf = await client.fetchTexture('ambientcg', 'Rock064', 'color', '1k');
+    const head = new Uint8Array(buf, 0, 4);
+    assert.deepStrictEqual([...head], [0xab, 0x4b, 0x54, 0x58]);
+  });
+
+  it('fetchTexture rejects when sentinel is missing', async () => {
+    globalThis.fetch = stubFetch([
+      ['/release-manifest.json', () => jsonResp(MOCK_MANIFEST)],
+      ['/ambientcg.json', () => jsonResp(MOCK_CATALOG)],
+      // intentionally NO route for .tier_complete → 404
+    ]);
+    const client = new MatVisClient({ tag: 'vtest' });
+    await assert.rejects(
+      () => client.fetchTexture('ambientcg', 'Rock064', 'color', '1k'),
+      /not atomically complete/,
+    );
+  });
+
+  it('manifest rejects pre-v3 schema', async () => {
+    globalThis.fetch = stubFetch([
+      ['/release-manifest.json', () => jsonResp({ schema_version: 2, sources: {} })],
+    ]);
+    const client = new MatVisClient({ tag: 'vtest' });
+    await assert.rejects(() => client.manifest(), /schema_version=2/);
+  });
+
+  it('materials filters by available_tiers', async () => {
+    globalThis.fetch = stubFetch([
+      ['/release-manifest.json', () => jsonResp(MOCK_MANIFEST)],
+      [
+        '/ambientcg.json',
+        () =>
+          jsonResp([
+            ...MOCK_CATALOG,
+            { id: 'Wood001', available_tiers: ['2k'], maps: ['color'] },
+          ]),
+      ],
+    ]);
+    const client = new MatVisClient({ tag: 'vtest' });
+    const mats = await client.materials('ambientcg', '1k');
+    assert.deepStrictEqual(mats, ['Rock064']);
+  });
+
+  it('channels reads from catalog maps array', async () => {
+    globalThis.fetch = stubFetch([
+      ['/release-manifest.json', () => jsonResp(MOCK_MANIFEST)],
+      ['/ambientcg.json', () => jsonResp(MOCK_CATALOG)],
+    ]);
+    const client = new MatVisClient({ tag: 'vtest' });
+    const chs = await client.channels('ambientcg', 'Rock064', '1k');
+    assert.deepStrictEqual(chs, ['color', 'normal']);
+  });
+});
+
+// ── live tests ──────────────────────────────────────────────────────
+
+const LIVE_ENABLED = process.env.MAT_VIS_LIVE_TESTS === '1';
+const LIVE_TAG = process.env.MAT_VIS_LIVE_TAG || 'v2026.04.1';
+
+const liveDescribe = LIVE_ENABLED ? describe : describe.skip;
+
+liveDescribe('live (set MAT_VIS_LIVE_TESTS=1; needs per-file prod tag)', () => {
+  const client = new MatVisClient({ tag: LIVE_TAG });
+
+  it('manifest is v3', async () => {
     const m = await client.manifest();
-    assert.strictEqual(m.schema_version, 1);
-    assert.ok(m.tiers, 'manifest should have tiers');
+    assert.strictEqual(m.schema_version, 3);
+    assert.ok(m.sources, 'manifest should have sources block');
   });
 
-  it('lists tiers including 1k', async () => {
+  it('lists 1k tier', async () => {
     const tiers = await client.tiers();
-    assert.ok(tiers.includes('1k'), 'tiers should include 1k');
+    assert.ok(tiers.includes('1k'));
   });
 
-  it('lists sources including ambientcg', async () => {
-    const sources = await client.sources('1k');
-    assert.ok(sources.includes('ambientcg'), 'sources should include ambientcg');
-  });
-});
-
-describe('rowmap', () => {
-  it('fetches rowmap with materials', async () => {
-    const rm = await client.rowmap('ambientcg', '1k');
-    assert.ok(rm.materials, 'rowmap should have materials');
-    assert.ok(Object.keys(rm.materials).length > 0, 'materials should be non-empty');
-  });
-
-  it('lists material IDs', async () => {
+  it('returns valid PNG bytes via per-file URL', async () => {
     const mats = await client.materials('ambientcg', '1k');
-    assert.ok(mats.length > 0, 'should have materials');
-    assert.ok(mats.every((m) => typeof m === 'string'), 'all IDs should be strings');
-  });
-
-  it('lists channels for first material', async () => {
-    const mats = await client.materials('ambientcg', '1k');
-    const channels = await client.channels('ambientcg', mats[0], '1k');
-    assert.ok(channels.includes('color'), 'channels should include color');
-  });
-});
-
-describe('fetch texture', () => {
-  it('returns valid PNG bytes via range read', async () => {
-    const mats = await client.materials('ambientcg', '1k');
+    assert.ok(mats.length > 0);
     const buf = await client.fetchTexture('ambientcg', mats[0], 'color', '1k');
     const magic = new Uint8Array(buf, 0, 4);
-    assert.strictEqual(magic[0], 0x89);
-    assert.strictEqual(magic[1], 0x50); // P
-    assert.strictEqual(magic[2], 0x4e); // N
-    assert.strictEqual(magic[3], 0x47); // G
-    assert.ok(buf.byteLength > 1000, 'PNG should not be trivially small');
-  });
-
-  it('throws on nonexistent material', async () => {
-    await assert.rejects(
-      () => client.fetchTexture('ambientcg', 'NONEXISTENT_XYZ', 'color', '1k'),
-      /not found/i,
-    );
+    assert.deepStrictEqual([...magic], [0x89, 0x50, 0x4e, 0x47]);
+    assert.ok(buf.byteLength > 1000);
   });
 });

--- a/clients/js/test_client.mjs
+++ b/clients/js/test_client.mjs
@@ -82,7 +82,9 @@ describe('structural', () => {
     globalThis.fetch = originalFetch;
   });
 
-  it('fetchTexture builds a per-file URL and returns PNG bytes', async () => {
+  it('fetchTexture probes sentinel BEFORE the texture GET', async () => {
+    // Order matters — a regression that fetched the .png first would
+    // surface mid-batch bytes. Record call order and assert it.
     const calledUrls = [];
     globalThis.fetch = stubFetch([
       ['/release-manifest.json', () => jsonResp(MOCK_MANIFEST)],
@@ -107,13 +109,30 @@ describe('structural', () => {
     assert.ok(buf.byteLength > 0, 'should return non-empty bytes');
     const head = new Uint8Array(buf, 0, 4);
     assert.deepStrictEqual([...head], [0x89, 0x50, 0x4e, 0x47]);
+    const sentinelIdx = calledUrls.findIndex((u) => u.endsWith('/ambientcg/1k/.tier_complete'));
+    const pngIdx = calledUrls.findIndex((u) => u.endsWith('/ambientcg/1k/Rock064/color.png'));
+    assert.ok(sentinelIdx >= 0, 'sentinel must be probed');
+    assert.ok(pngIdx >= 0, 'per-file URL must be hit');
     assert.ok(
-      calledUrls.some((u) => u.endsWith('/ambientcg/1k/.tier_complete')),
-      'must probe sentinel before fetch',
+      sentinelIdx < pngIdx,
+      `sentinel must run before texture (got sentinel@${sentinelIdx}, png@${pngIdx})`,
     );
-    assert.ok(
-      calledUrls.some((u) => u.endsWith('/ambientcg/1k/Rock064/color.png')),
-      'must hit per-file URL',
+  });
+
+  it('fetchTexture rejects bytes whose magic is neither PNG nor KTX2', async () => {
+    globalThis.fetch = stubFetch([
+      ['/release-manifest.json', () => jsonResp(MOCK_MANIFEST)],
+      ['/ambientcg.json', () => jsonResp(MOCK_CATALOG)],
+      ['/.tier_complete', () => jsonResp({})],
+      [
+        '/color.png',
+        () => bytesResp(new Uint8Array([0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0])),
+      ],
+    ]);
+    const client = new MatVisClient({ tag: 'vtest' });
+    await assert.rejects(
+      () => client.fetchTexture('ambientcg', 'Rock064', 'color', '1k'),
+      /Expected PNG or KTX2 bytes/,
     );
   });
 

--- a/clients/mat-vis.sh
+++ b/clients/mat-vis.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # mat-vis reference client — curl + jq only.
 #
+# Substrate: per-file HF dataset (#186 / ADR-0012). One curl per
+# texture; no rowmap, no tar, no range read.
+#
 # Usage:
 #   mat-vis.sh list                                 # list sources × tiers
 #   mat-vis.sh materials ambientcg 1k               # list material IDs
@@ -8,20 +11,23 @@
 #   mat-vis.sh fetch ambientcg Rock064 color 1k -o rock.png
 #
 # Environment:
-#   MAT_VIS_TAG     — release tag (default: latest)
+#   MAT_VIS_TAG     — release tag (default: main)
 #   MAT_VIS_CACHE   — cache directory (default: ~/.cache/mat-vis)
+#   MAT_VIS_HF_BASE — HF resolve URL prefix (default: prod)
 
 set -euo pipefail
 
-REPO="MorePET/mat-vis"
-RELEASES="https://github.com/$REPO/releases"
-TAG="${MAT_VIS_TAG:-latest}"
+HF_DATASET="gerchowl/mat-vis"
+HF_BASE="${MAT_VIS_HF_BASE:-https://huggingface.co/datasets/$HF_DATASET/resolve}"
+TAG="${MAT_VIS_TAG:-main}"
 CACHE="${MAT_VIS_CACHE:-$HOME/.cache/mat-vis}"
-UA="mat-vis-client/0.1 (shell)"
+UA="mat-vis-client/0.6.0 (shell)"
 
 # ── helpers ──────────────────────────────────────────────────────
 
 die() { echo "error: $*" >&2; exit 1; }
+
+hf_url() { echo "$HF_BASE/$TAG/$1"; }
 
 fetch_json() {
     local url=$1 cache_file=$2
@@ -34,44 +40,65 @@ fetch_json() {
     cat "$cache_file"
 }
 
-manifest_url() {
-    if [ "$TAG" = "latest" ]; then
-        echo "$RELEASES/latest/download/release-manifest.json"
-    else
-        echo "$RELEASES/download/$TAG/release-manifest.json"
-    fi
+get_manifest() {
+    local m sv
+    m=$(fetch_json "$(hf_url release-manifest.json)" "$CACHE/$TAG/.manifest.json")
+    sv=$(echo "$m" | jq -r '.schema_version // empty')
+    [ "$sv" = "3" ] || die "manifest schema_version=$sv (need 3 — per-file substrate, ADR-0012)"
+    echo "$m"
 }
 
-get_manifest() {
-    fetch_json "$(manifest_url)" "$CACHE/.manifest.json"
+# Fetch the catalog (ADR-0011 v3) for a source. Cached locally.
+get_catalog() {
+    local source=$1
+    local manifest catalog_path
+    manifest=$(get_manifest)
+    catalog_path=$(echo "$manifest" | jq -r ".sources[\"$source\"].catalog // \"$source.json\"")
+    fetch_json "$(hf_url "$catalog_path")" "$CACHE/$TAG/.catalogs/$catalog_path"
+}
+
+# Probe `<source>/<tier>/.tier_complete` once per (source, tier).
+# ADR-0012: the sentinel is the final commit per tier — its presence
+# is our atomicity guarantee; reject partial tiers loudly.
+assert_tier_complete() {
+    local source=$1 tier=$2
+    local marker="$CACHE/$TAG/.sentinel/$source/$tier"
+    [ -f "$marker" ] && return 0
+    local url
+    url=$(hf_url "$source/$tier/.tier_complete")
+    if ! curl -sfL -H "User-Agent: $UA" -o /dev/null --head "$url"; then
+        die "tier $source/$tier is not atomically complete on $TAG (no .tier_complete sentinel). Re-run the bake or pin a known-complete tag."
+    fi
+    mkdir -p "$(dirname "$marker")"
+    : > "$marker"
 }
 
 # ── commands ─────────────────────────────────────────────────────
 
 cmd_list() {
-    get_manifest | jq -r '.tiers | to_entries[] | "\(.key): \(.value.sources | keys | join(", "))"'
+    get_manifest \
+        | jq -r '.sources | to_entries[] | . as $s | ($s.value.tiers // {}) | keys[] | "\(.) \($s.key)"' \
+        | sort -u \
+        | awk '{ a[$1] = ($1 in a ? a[$1] ", " : "") $2 } END { for (t in a) print t ": " a[t] }' \
+        | sort
 }
 
 cmd_materials() {
     local source=${1:?source required} tier=${2:-1k}
-    local manifest
-    manifest=$(get_manifest)
+    get_catalog "$source" \
+        | jq -r --arg tier "$tier" \
+              '.[] | select((.available_tiers // []) | index($tier)) | .id' \
+        | sort
+}
 
-    local base_url
-    base_url=$(echo "$manifest" | jq -r ".tiers[\"$tier\"].base_url")
-    local rowmap_files
-    rowmap_files=$(echo "$manifest" | jq -r ".tiers[\"$tier\"].sources[\"$source\"].rowmap_files[]")
-
-    [ -z "$rowmap_files" ] && die "No rowmaps for $source/$tier"
-
-    # Fetch all partition rowmaps and merge material IDs
-    local all_materials=""
-    while IFS= read -r rmf; do
-        local rm
-        rm=$(fetch_json "${base_url}${rmf}" "$CACHE/.rowmaps/$rmf")
-        all_materials="$all_materials$(echo "$rm" | jq -r '.materials | keys[]')"$'\n'
-    done <<< "$rowmap_files"
-    echo "$all_materials" | sort -u | grep -v '^$'
+emit() {
+    local file=$1 output=$2 tag=$3
+    if [ -n "$output" ]; then
+        cp "$file" "$output"
+        echo "$tag: $output ($(wc -c < "$file" | tr -d ' ') bytes)" >&2
+    else
+        cat "$file"
+    fi
 }
 
 cmd_fetch() {
@@ -80,8 +107,6 @@ cmd_fetch() {
     local channel=${3:?channel required}
     local tier=${4:-1k}
     local output=""
-
-    # Parse -o flag
     shift 4 || true
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -90,62 +115,34 @@ cmd_fetch() {
         esac
     done
 
-    # Check cache
-    local cache_file="$CACHE/$source/$tier/$material/${channel}.png"
-    if [ -f "$cache_file" ]; then
-        if [ -n "$output" ]; then
-            cp "$cache_file" "$output"
-            echo "Cached: $output ($(wc -c < "$cache_file") bytes)" >&2
-        else
-            cat "$cache_file"
+    local cache_dir="$CACHE/$TAG/$source/$tier/$material"
+    for ext in png ktx2; do
+        [ -f "$cache_dir/${channel}.${ext}" ] && {
+            emit "$cache_dir/${channel}.${ext}" "$output" "Cached"
+            return
+        }
+    done
+
+    assert_tier_complete "$source" "$tier"
+    mkdir -p "$cache_dir"
+    local cache_file=""
+    for ext in png ktx2; do
+        local cf="$cache_dir/${channel}.${ext}"
+        if curl -sfL -H "User-Agent: $UA" "$(hf_url "$source/$tier/$material/${channel}.${ext}")" -o "$cf"; then
+            cache_file="$cf"; break
         fi
-        return
-    fi
+        rm -f "$cf"
+    done
+    [ -n "$cache_file" ] || die "$material/$channel not found at $source/$tier (tried .png and .ktx2)"
 
-    # Get manifest + search all partition rowmaps for this material
-    local manifest
-    manifest=$(get_manifest)
-    local base_url
-    base_url=$(echo "$manifest" | jq -r ".tiers[\"$tier\"].base_url")
-    local rowmap_files
-    rowmap_files=$(echo "$manifest" | jq -r ".tiers[\"$tier\"].sources[\"$source\"].rowmap_files[]")
-    [ -z "$rowmap_files" ] && die "No rowmaps for $source/$tier"
-
-    local offset="" length="" parquet_file=""
-    while IFS= read -r rmf; do
-        local rm
-        rm=$(fetch_json "${base_url}${rmf}" "$CACHE/.rowmaps/$rmf")
-        local found
-        found=$(echo "$rm" | jq -r ".materials[\"$material\"][\"$channel\"].offset // empty")
-        if [ -n "$found" ]; then
-            offset=$found
-            length=$(echo "$rm" | jq -r ".materials[\"$material\"][\"$channel\"].length")
-            parquet_file=$(echo "$rm" | jq -r ".parquet_file")
-            break
-        fi
-    done <<< "$rowmap_files"
-
-    [ -z "$offset" ] && die "$material/$channel not found in any rowmap partition"
-
-    local parquet_url="${base_url}${parquet_file}"
-    local range_end=$((offset + length - 1))
-
-    # Range read
-    mkdir -p "$(dirname "$cache_file")"
-    curl -sfL -H "User-Agent: $UA" -H "Range: bytes=${offset}-${range_end}" "$parquet_url" -o "$cache_file" \
-        || die "Range read failed: $parquet_url"
-
-    # Verify PNG
     local magic
-    magic=$(head -c4 "$cache_file" | xxd -p)
-    [ "$magic" = "89504e47" ] || die "Not a PNG (got $magic)"
+    magic=$(head -c4 "$cache_file" | od -An -tx1 | tr -d ' \n')
+    case "$magic" in
+        89504e47|ab4b5458) ;;
+        *) rm -f "$cache_file"; die "Not PNG or KTX2 (got $magic)" ;;
+    esac
 
-    if [ -n "$output" ]; then
-        cp "$cache_file" "$output"
-        echo "Fetched: $output ($length bytes)" >&2
-    else
-        cat "$cache_file"
-    fi
+    emit "$cache_file" "$output" "Fetched"
 }
 
 # ── dispatch ─────────────────────────────────────────────────────
@@ -155,7 +152,7 @@ case "${1:-help}" in
     materials)  shift; cmd_materials "$@" ;;
     fetch)      shift; cmd_fetch "$@" ;;
     *)
-        echo "mat-vis client — fetch PBR textures via HTTP range reads"
+        echo "mat-vis client — per-file PBR texture fetch via curl + jq"
         echo ""
         echo "Usage:"
         echo "  mat-vis.sh list                                 List sources × tiers"
@@ -163,7 +160,8 @@ case "${1:-help}" in
         echo "  mat-vis.sh fetch <source> <id> <channel> [tier] [-o file]"
         echo ""
         echo "Environment:"
-        echo "  MAT_VIS_TAG     Release tag (default: latest)"
+        echo "  MAT_VIS_TAG     Release tag (default: main)"
         echo "  MAT_VIS_CACHE   Cache dir (default: ~/.cache/mat-vis)"
+        echo "  MAT_VIS_HF_BASE HF resolve URL (default: prod)"
         ;;
 esac

--- a/clients/mat-vis.sh
+++ b/clients/mat-vis.sh
@@ -66,7 +66,10 @@ assert_tier_complete() {
     [ -f "$marker" ] && return 0
     local url
     url=$(hf_url "$source/$tier/.tier_complete")
-    if ! curl -sfL -H "User-Agent: $UA" -o /dev/null --head "$url"; then
+    # Use GET (not HEAD) to mirror the Python client's sentinel
+    # probe — HF's CDN is documented to behave consistently for GET
+    # but HEAD has occasionally diverged (auth gates, byte-counts).
+    if ! curl -sfL -H "User-Agent: $UA" -o /dev/null "$url"; then
         die "tier $source/$tier is not atomically complete on $TAG (no .tier_complete sentinel). Re-run the bake or pin a known-complete tag."
     fi
     mkdir -p "$(dirname "$marker")"

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "mat-vis-client"
-version = "0.1.0"
+version = "0.6.0"
 edition = "2021"
-description = "mat-vis PBR texture client — fetch textures via HTTP range reads"
+description = "mat-vis PBR texture client — per-file HF dataset (ADR-0012)"
 license = "MIT"
 
 [[bin]]

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -66,6 +66,16 @@ fn client() -> reqwest::blocking::Client {
         .expect("Failed to build HTTP client")
 }
 
+fn validate_schema(m: &Manifest) -> Result<(), String> {
+    if m.schema_version != 3 {
+        return Err(format!(
+            "Unsupported manifest schema_version={}; this client requires v3 (per-file substrate, ADR-0012).",
+            m.schema_version
+        ));
+    }
+    Ok(())
+}
+
 fn fetch_manifest(tag: &str) -> Manifest {
     let url = hf_url(tag, "release-manifest.json");
     let m: Manifest = client()
@@ -76,11 +86,9 @@ fn fetch_manifest(tag: &str) -> Manifest {
         .expect("Failed to fetch manifest")
         .json()
         .expect("Failed to parse manifest");
-    if m.schema_version != 3 {
-        panic!(
-            "Unsupported manifest schema_version={}; this client requires v3 (per-file substrate, ADR-0012).",
-            m.schema_version
-        );
+    if let Err(e) = validate_schema(&m) {
+        eprintln!("{e}");
+        std::process::exit(1);
     }
     m
 }
@@ -303,6 +311,28 @@ mod tests {
     fn ktx2_magic_matches() {
         let bytes = b"\xabKTX 20\xbb\r\n\x1a\n\x00";
         assert!(bytes.starts_with(KTX2_MAGIC));
+    }
+
+    #[test]
+    fn random_magic_rejected() {
+        let bytes = [0xffu8; 8];
+        assert!(!bytes.starts_with(PNG_MAGIC));
+        assert!(!bytes.starts_with(KTX2_MAGIC));
+    }
+
+    #[test]
+    fn validate_schema_rejects_v2() {
+        let m = serde_json::from_str::<Manifest>(r#"{"schema_version": 2, "sources": {}}"#)
+            .expect("parse");
+        let err = validate_schema(&m).expect_err("v2 must be rejected");
+        assert!(err.contains("schema_version=2"), "error message: {err}");
+    }
+
+    #[test]
+    fn validate_schema_accepts_v3() {
+        let m = serde_json::from_str::<Manifest>(r#"{"schema_version": 3, "sources": {}}"#)
+            .expect("parse");
+        assert!(validate_schema(&m).is_ok());
     }
 
     // ── live (opt-in via MAT_VIS_LIVE_TESTS=1) ─────────────────────

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -1,5 +1,8 @@
 //! mat-vis reference client — Rust.
 //!
+//! Substrate: per-file HF dataset (#186 / ADR-0012). One reqwest::get
+//! per texture; no rowmap, no tar, no range read.
+//!
 //! Usage:
 //!   mat-vis list                                 # list sources × tiers
 //!   mat-vis materials ambientcg 1k               # list material IDs
@@ -13,40 +16,47 @@ use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 
-const REPO: &str = "MorePET/mat-vis";
+const HF_DATASET: &str = "gerchowl/mat-vis";
 // SSoT: Cargo.toml version. `concat!` + `env!` fold at compile time, so
 // bumping `[package].version` is the only edit needed for a release —
 // the HTTP User-Agent string follows automatically.
 const UA: &str = concat!("mat-vis-client/", env!("CARGO_PKG_VERSION"), " (Rust)");
 
-#[derive(Deserialize)]
-struct Manifest {
-    tiers: HashMap<String, TierEntry>,
+const PNG_MAGIC: &[u8] = &[0x89, 0x50, 0x4e, 0x47];
+const KTX2_MAGIC: &[u8] = &[0xab, 0x4b, 0x54, 0x58];
+
+fn hf_base() -> String {
+    std::env::var("MAT_VIS_HF_BASE")
+        .unwrap_or_else(|_| format!("https://huggingface.co/datasets/{HF_DATASET}/resolve"))
+}
+
+fn hf_url(tag: &str, path: &str) -> String {
+    format!("{}/{tag}/{path}", hf_base())
 }
 
 #[derive(Deserialize)]
-struct TierEntry {
-    base_url: String,
+struct Manifest {
+    schema_version: u32,
+    #[serde(default)]
     sources: HashMap<String, SourceEntry>,
 }
 
 #[derive(Deserialize)]
 struct SourceEntry {
-    parquet_files: Vec<String>,
-    rowmap_files: Option<Vec<String>>,
-    rowmap_file: Option<String>,
+    catalog: Option<String>,
+    #[serde(default)]
+    tiers: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Deserialize)]
-struct Rowmap {
-    parquet_file: String,
-    materials: HashMap<String, HashMap<String, ChannelRange>>,
-}
-
-#[derive(Deserialize)]
-struct ChannelRange {
-    offset: u64,
-    length: u64,
+struct CatalogEntry {
+    id: String,
+    #[serde(default)]
+    available_tiers: Vec<String>,
+    #[serde(default)]
+    maps: Vec<String>,
+    #[serde(default)]
+    texture_hashes: HashMap<String, serde_json::Value>,
 }
 
 fn client() -> reqwest::blocking::Client {
@@ -56,52 +66,85 @@ fn client() -> reqwest::blocking::Client {
         .expect("Failed to build HTTP client")
 }
 
-fn fetch_manifest(tag: &Option<String>) -> Manifest {
-    let url = match tag {
-        Some(t) => format!("https://github.com/{REPO}/releases/download/{t}/release-manifest.json"),
-        None => format!("https://github.com/{REPO}/releases/latest/download/release-manifest.json"),
-    };
-    client()
+fn fetch_manifest(tag: &str) -> Manifest {
+    let url = hf_url(tag, "release-manifest.json");
+    let m: Manifest = client()
         .get(&url)
         .send()
         .expect("Failed to fetch manifest")
+        .error_for_status()
+        .expect("Failed to fetch manifest")
         .json()
-        .expect("Failed to parse manifest")
+        .expect("Failed to parse manifest");
+    if m.schema_version != 3 {
+        panic!(
+            "Unsupported manifest schema_version={}; this client requires v3 (per-file substrate, ADR-0012).",
+            m.schema_version
+        );
+    }
+    m
 }
 
-fn fetch_rowmap(base_url: &str, src: &SourceEntry) -> Rowmap {
-    let fallback;
-    let files: &[String] = if let Some(ref f) = src.rowmap_files {
-        f.as_slice()
-    } else if let Some(ref f) = src.rowmap_file {
-        fallback = [f.clone()];
-        &fallback
-    } else {
-        panic!("No rowmap file");
-    };
-    let url = format!("{}{}", base_url, files[0]);
+fn fetch_catalog(tag: &str, source: &str, manifest: &Manifest) -> Vec<CatalogEntry> {
+    let src_entry = manifest
+        .sources
+        .get(source)
+        .unwrap_or_else(|| panic!("Source '{source}' not found in manifest"));
+    let catalog_path = src_entry
+        .catalog
+        .clone()
+        .unwrap_or_else(|| format!("{source}.json"));
+    let url = hf_url(tag, &catalog_path);
     client()
         .get(&url)
         .send()
-        .expect("Failed to fetch rowmap")
+        .expect("Failed to fetch catalog")
+        .error_for_status()
+        .expect("Failed to fetch catalog")
         .json()
-        .expect("Failed to parse rowmap")
+        .expect("Failed to parse catalog")
 }
 
-fn range_read(url: &str, offset: u64, length: u64) -> Vec<u8> {
-    let range = format!("bytes={}-{}", offset, offset + length - 1);
-    let resp = client()
-        .get(url)
-        .header("Range", &range)
-        .send()
-        .expect("Range read failed");
-    resp.bytes().expect("Failed to read body").to_vec()
+fn assert_tier_complete(tag: &str, source: &str, tier: &str) {
+    let url = hf_url(tag, &format!("{source}/{tier}/.tier_complete"));
+    let resp = client().get(&url).send().expect("network error on sentinel probe");
+    if !resp.status().is_success() {
+        panic!(
+            "tier {source}/{tier} is not atomically complete on {tag} (no .tier_complete sentinel). \
+             The bake may still be running, or this revision was committed mid-batch. \
+             Re-run the bake or pin a known-complete tag."
+        );
+    }
+}
+
+fn fetch_texture_bytes(tag: &str, source: &str, material: &str, channel: &str, tier: &str) -> Vec<u8> {
+    let mut last_status: Option<reqwest::StatusCode> = None;
+    for ext in ["png", "ktx2"] {
+        let url = hf_url(tag, &format!("{source}/{tier}/{material}/{channel}.{ext}"));
+        let resp = client().get(&url).send().expect("network error");
+        if !resp.status().is_success() {
+            last_status = Some(resp.status());
+            continue;
+        }
+        let bytes = resp.bytes().expect("Failed to read body").to_vec();
+        if !bytes.starts_with(PNG_MAGIC) && !bytes.starts_with(KTX2_MAGIC) {
+            panic!(
+                "Expected PNG or KTX2 bytes, got {:?}",
+                &bytes[..4.min(bytes.len())]
+            );
+        }
+        return bytes;
+    }
+    panic!(
+        "{material}/{channel} not found at {source}/{tier} (last status={:?})",
+        last_status
+    );
 }
 
 #[derive(Parser)]
-#[command(name = "mat-vis", about = "mat-vis PBR texture client")]
+#[command(name = "mat-vis", about = "mat-vis PBR texture client (per-file HF substrate)")]
 struct Cli {
-    #[arg(long, help = "Release tag (default: latest)")]
+    #[arg(long, help = "Release tag (default: main)")]
     tag: Option<String>,
 
     #[command(subcommand)]
@@ -118,7 +161,7 @@ enum Commands {
         #[arg(default_value = "1k")]
         tier: String,
     },
-    /// Fetch a texture PNG
+    /// Fetch a texture (PNG or KTX2)
     Fetch {
         source: String,
         material: String,
@@ -130,26 +173,41 @@ enum Commands {
     },
 }
 
-fn tag_from_env() -> Option<String> {
-    std::env::var("MAT_VIS_TAG").ok().or_else(|| Some("v2026.04.0".to_string()))
+fn resolved_tag(cli_tag: &Option<String>) -> String {
+    cli_tag
+        .clone()
+        .or_else(|| std::env::var("MAT_VIS_TAG").ok())
+        .unwrap_or_else(|| "main".to_string())
 }
 
 fn main() {
     let cli = Cli::parse();
-    let manifest = fetch_manifest(&cli.tag);
+    let tag = resolved_tag(&cli.tag);
+    let manifest = fetch_manifest(&tag);
 
     match cli.cmd {
         Commands::List => {
-            for (tier, entry) in &manifest.tiers {
-                let sources: Vec<&String> = entry.sources.keys().collect();
-                println!("{tier}: {}", sources.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", "));
+            let mut by_tier: HashMap<&str, Vec<&str>> = HashMap::new();
+            for (src, entry) in &manifest.sources {
+                for tier in entry.tiers.keys() {
+                    by_tier.entry(tier.as_str()).or_default().push(src.as_str());
+                }
+            }
+            let mut tiers: Vec<&&str> = by_tier.keys().collect();
+            tiers.sort();
+            for tier in tiers {
+                let mut srcs = by_tier[tier].clone();
+                srcs.sort();
+                println!("{tier}: {}", srcs.join(", "));
             }
         }
         Commands::Materials { source, tier } => {
-            let tier_data = manifest.tiers.get(&tier).expect("Tier not found");
-            let src_data = tier_data.sources.get(&source).expect("Source not found");
-            let rowmap = fetch_rowmap(&tier_data.base_url, src_data);
-            let mut ids: Vec<&String> = rowmap.materials.keys().collect();
+            let cat = fetch_catalog(&tag, &source, &manifest);
+            let mut ids: Vec<String> = cat
+                .into_iter()
+                .filter(|e| e.available_tiers.iter().any(|t| t == &tier))
+                .map(|e| e.id)
+                .collect();
             ids.sort();
             for id in ids {
                 println!("{id}");
@@ -162,29 +220,39 @@ fn main() {
             tier,
             output,
         } => {
-            let tier_data = manifest.tiers.get(&tier).expect("Tier not found");
-            let src_data = tier_data.sources.get(&source).expect("Source not found");
-            let rowmap = fetch_rowmap(&tier_data.base_url, src_data);
-            let mat = rowmap.materials.get(&material).expect("Material not found");
-            let rng = mat.get(&channel).expect("Channel not found");
+            let cat = fetch_catalog(&tag, &source, &manifest);
+            let entry = cat
+                .iter()
+                .find(|e| e.id == material)
+                .unwrap_or_else(|| panic!("Material '{material}' not found in {source}"));
+            if !entry.available_tiers.iter().any(|t| t == &tier) {
+                panic!("Material '{material}' is not staged at tier {tier}");
+            }
+            let maps: Vec<&str> = if !entry.maps.is_empty() {
+                entry.maps.iter().map(String::as_str).collect()
+            } else {
+                entry.texture_hashes.keys().map(String::as_str).collect()
+            };
+            if !maps.iter().any(|m| *m == channel) {
+                panic!(
+                    "channel '{channel}' not found (context: {source}/{tier}/{material}). \
+                     Available: {:?}",
+                    maps
+                );
+            }
 
-            let url = format!("{}{}", tier_data.base_url, rowmap.parquet_file);
-            let data = range_read(&url, rng.offset, rng.length);
-
-            // Verify PNG
-            assert!(
-                data.len() >= 4 && data[..4] == [0x89, 0x50, 0x4E, 0x47],
-                "Expected PNG, got {:?}",
-                &data[..4.min(data.len())]
-            );
+            assert_tier_complete(&tag, &source, &tier);
+            let bytes = fetch_texture_bytes(&tag, &source, &material, &channel, &tier);
 
             match output {
                 Some(path) => {
-                    fs::write(&path, &data).expect("Failed to write file");
-                    eprintln!("Wrote {} ({} bytes)", path.display(), data.len());
+                    fs::write(&path, &bytes).expect("Failed to write file");
+                    eprintln!("Wrote {} ({} bytes)", path.display(), bytes.len());
                 }
                 None => {
-                    std::io::stdout().write_all(&data).expect("Failed to write to stdout");
+                    std::io::stdout()
+                        .write_all(&bytes)
+                        .expect("Failed to write to stdout");
                 }
             }
         }
@@ -195,57 +263,78 @@ fn main() {
 mod tests {
     use super::*;
 
-    fn test_tag() -> Option<String> {
-        Some(std::env::var("MAT_VIS_TAG").unwrap_or_else(|_| "v2026.04.0".to_string()))
+    fn live_enabled() -> bool {
+        std::env::var("MAT_VIS_LIVE_TESTS").as_deref() == Ok("1")
     }
 
-    #[test]
-    fn test_fetch_manifest() {
-        let tag = test_tag();
-        let manifest = fetch_manifest(&tag);
-        assert!(manifest.tiers.contains_key("1k"), "manifest should have 1k tier");
+    fn live_tag() -> String {
+        std::env::var("MAT_VIS_LIVE_TAG").unwrap_or_else(|_| "v2026.04.1".to_string())
     }
 
+    /// URL contract — does not hit the network.
     #[test]
-    fn test_list_sources() {
-        let tag = test_tag();
-        let manifest = fetch_manifest(&tag);
-        let tier = manifest.tiers.get("1k").expect("1k tier missing");
-        assert!(tier.sources.contains_key("ambientcg"), "should have ambientcg source");
-    }
-
-    #[test]
-    fn test_fetch_rowmap() {
-        let tag = test_tag();
-        let manifest = fetch_manifest(&tag);
-        let tier = manifest.tiers.get("1k").expect("1k tier missing");
-        let src = tier.sources.get("ambientcg").expect("ambientcg missing");
-        let rowmap = fetch_rowmap(&tier.base_url, src);
-        assert!(!rowmap.materials.is_empty(), "rowmap should have materials");
-    }
-
-    #[test]
-    fn test_range_read_png() {
-        let tag = test_tag();
-        let manifest = fetch_manifest(&tag);
-        let tier = manifest.tiers.get("1k").expect("1k tier missing");
-        let src = tier.sources.get("ambientcg").expect("ambientcg missing");
-        let rowmap = fetch_rowmap(&tier.base_url, src);
-
-        let (mid, channels) = rowmap.materials.iter().next().expect("no materials");
-        let rng = channels.get("color").unwrap_or_else(|| {
-            channels.values().next().expect("no channels")
-        });
-
-        let url = format!("{}{}", tier.base_url, rowmap.parquet_file);
-        let data = range_read(&url, rng.offset, rng.length);
-
-        assert!(data.len() > 4, "data too small");
-        assert_eq!(
-            &data[..4],
-            &[0x89, 0x50, 0x4E, 0x47],
-            "expected PNG magic bytes for material {mid}"
+    fn per_file_url_shape() {
+        let url = hf_url("vtest", "ambientcg/1k/Rock064/color.png");
+        assert!(
+            url.ends_with("/vtest/ambientcg/1k/Rock064/color.png"),
+            "unexpected URL: {url}"
         );
-        assert!(data.len() > 1000, "PNG should not be trivially small");
+    }
+
+    #[test]
+    fn sentinel_url_shape() {
+        let url = hf_url("vtest", "ambientcg/1k/.tier_complete");
+        assert!(url.ends_with("/vtest/ambientcg/1k/.tier_complete"), "{url}");
+    }
+
+    #[test]
+    fn ua_includes_version_and_lang() {
+        assert!(UA.contains("mat-vis-client/"));
+        assert!(UA.contains("(Rust)"));
+    }
+
+    #[test]
+    fn png_magic_matches() {
+        let bytes = b"\x89PNG\r\n\x1a\n\x00\x00\x00\x00";
+        assert!(bytes.starts_with(PNG_MAGIC));
+    }
+
+    #[test]
+    fn ktx2_magic_matches() {
+        let bytes = b"\xabKTX 20\xbb\r\n\x1a\n\x00";
+        assert!(bytes.starts_with(KTX2_MAGIC));
+    }
+
+    // ── live (opt-in via MAT_VIS_LIVE_TESTS=1) ─────────────────────
+
+    #[test]
+    fn live_fetch_manifest_is_v3() {
+        if !live_enabled() {
+            eprintln!("(skipped: set MAT_VIS_LIVE_TESTS=1)");
+            return;
+        }
+        let m = fetch_manifest(&live_tag());
+        assert_eq!(m.schema_version, 3);
+        assert!(!m.sources.is_empty(), "manifest sources should be non-empty");
+    }
+
+    #[test]
+    fn live_fetch_color_png() {
+        if !live_enabled() {
+            eprintln!("(skipped: set MAT_VIS_LIVE_TESTS=1)");
+            return;
+        }
+        let tag = live_tag();
+        let m = fetch_manifest(&tag);
+        let cat = fetch_catalog(&tag, "ambientcg", &m);
+        let mid = cat
+            .iter()
+            .find(|e| e.available_tiers.iter().any(|t| t == "1k"))
+            .map(|e| e.id.clone())
+            .expect("no 1k-staged ambientcg material");
+        assert_tier_complete(&tag, "ambientcg", "1k");
+        let bytes = fetch_texture_bytes(&tag, "ambientcg", &mid, "color", "1k");
+        assert!(bytes.starts_with(PNG_MAGIC));
+        assert!(bytes.len() > 1000);
     }
 }

--- a/clients/test_client.sh
+++ b/clients/test_client.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
-# Tests for the shell reference client against live release data.
+# Tests for the shell reference client.
 #
-# Requires: curl, jq, xxd (usually in vim or xxd package)
+# Two modes:
+#   1. Structural — always run. Stubs HF behind a local file:// tree
+#      and exercises mat-vis.sh end-to-end. No network.
+#   2. Live — gated on MAT_VIS_LIVE_TESTS=1. Hits prod HF; default-skipped
+#      because v0.6 dropped tar support and prod isn't rebaked under
+#      the per-file substrate yet (#179).
+#
+# Requires: curl, jq, od (tested on macOS + alpine).
 # Run with: bash test_client.sh
 
 set -euo pipefail
@@ -9,80 +16,189 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CLIENT="$SCRIPT_DIR/mat-vis.sh"
 
-export MAT_VIS_TAG="${MAT_VIS_TAG:-v2026.04.0}"
-export MAT_VIS_CACHE
-MAT_VIS_CACHE="$(mktemp -d)"
-
-trap 'rm -rf "$MAT_VIS_CACHE"' EXIT
-
 PASS=0
 FAIL=0
 
-assert_ok() {
-    local desc="$1"; shift
-    if "$@" >/dev/null 2>&1; then
+assert_eq() {
+    local desc="$1" actual="$2" expected="$3"
+    if [ "$actual" = "$expected" ]; then
         echo "  PASS $desc"
         PASS=$((PASS + 1))
     else
-        echo "  FAIL $desc"
+        echo "  FAIL $desc — expected '$expected', got '$actual'"
         FAIL=$((FAIL + 1))
     fi
 }
 
 assert_contains() {
     local desc="$1" output="$2" needle="$3"
-    if echo "$output" | grep -q "$needle"; then
+    if echo "$output" | grep -q -- "$needle"; then
         echo "  PASS $desc"
         PASS=$((PASS + 1))
     else
-        echo "  FAIL $desc — expected '$needle' in output"
+        printf "  FAIL %s — expected '%s' in output:\n%s\n" "$desc" "$needle" "$output"
         FAIL=$((FAIL + 1))
     fi
 }
 
-echo "=== manifest ==="
+assert_fails() {
+    local desc="$1"; shift
+    if "$@" >/dev/null 2>&1; then
+        echo "  FAIL $desc — expected non-zero exit"
+        FAIL=$((FAIL + 1))
+    else
+        echo "  PASS $desc"
+        PASS=$((PASS + 1))
+    fi
+}
 
-LIST_OUTPUT=$("$CLIENT" list)
-assert_contains "list includes 1k tier" "$LIST_OUTPUT" "1k"
-assert_contains "list includes ambientcg" "$LIST_OUTPUT" "ambientcg"
+# ── structural: stub HF behind a file:// tree ──────────────────────
 
-echo "=== materials ==="
+setup_mock_hf() {
+    local root=$1 tag=$2
+    local td="$root/$tag"
+    mkdir -p "$td/ambientcg/1k/Rock064"
 
-MATERIALS=$("$CLIENT" materials ambientcg 1k)
-MAT_COUNT=$(echo "$MATERIALS" | wc -l | tr -d ' ')
-FIRST_MAT=$(echo "$MATERIALS" | head -1)
+    cat > "$td/release-manifest.json" <<EOF
+{
+  "schema_version": 3,
+  "release_tag": "$tag",
+  "sources": {
+    "ambientcg": {
+      "catalog": "ambientcg.json",
+      "tiers": { "1k": { "complete": true } }
+    }
+  }
+}
+EOF
+    cat > "$td/ambientcg.json" <<'EOF'
+[
+  {
+    "id": "Rock064",
+    "source": "ambientcg",
+    "mat_vis": { "name": "Rock064", "category": "stone" },
+    "available_tiers": ["1k"],
+    "maps": ["color", "normal"]
+  }
+]
+EOF
+    # PNG: 8-byte magic + 1.5KiB filler so it clears 'wc -c > 1000' checks
+    {
+        printf '\x89PNG\r\n\x1a\n'
+        head -c 1500 /dev/zero
+    } > "$td/ambientcg/1k/Rock064/color.png"
+    : > "$td/ambientcg/1k/.tier_complete"
+}
 
-if [ "$MAT_COUNT" -gt 0 ] && [ -n "$FIRST_MAT" ]; then
-    echo "  PASS materials list non-empty ($MAT_COUNT materials)"
+structural_tests() {
+    echo "=== structural (stubbed HF tree) ==="
+    local mockroot
+    mockroot=$(mktemp -d)
+    local cache
+    cache=$(mktemp -d)
+    trap 'rm -rf "$mockroot" "$cache"' RETURN
+
+    local TAG="vtest"
+    setup_mock_hf "$mockroot" "$TAG"
+
+    export MAT_VIS_HF_BASE="file://$mockroot"
+    export MAT_VIS_TAG="$TAG"
+    export MAT_VIS_CACHE="$cache"
+
+    # list
+    local list_out
+    list_out=$("$CLIENT" list)
+    assert_contains "list shows 1k tier" "$list_out" "1k"
+    assert_contains "list includes ambientcg" "$list_out" "ambientcg"
+
+    # materials
+    local mats
+    mats=$("$CLIENT" materials ambientcg 1k)
+    assert_eq "materials returns Rock064" "$mats" "Rock064"
+
+    # fetch — stdout
+    local fetched_size
+    "$CLIENT" fetch ambientcg Rock064 color 1k > "$cache/out.png"
+    fetched_size=$(wc -c < "$cache/out.png" | tr -d ' ')
+    if [ "$fetched_size" -gt 100 ]; then
+        echo "  PASS fetch wrote PNG bytes ($fetched_size B)"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL fetch produced too-small file ($fetched_size B)"
+        FAIL=$((FAIL + 1))
+    fi
+    local magic
+    magic=$(head -c4 "$cache/out.png" | od -An -tx1 | tr -d ' \n')
+    assert_eq "fetch emits PNG magic" "$magic" "89504e47"
+
+    # cache hit on second fetch
+    "$CLIENT" fetch ambientcg Rock064 color 1k > "$cache/out2.png"
+    if cmp -s "$cache/out.png" "$cache/out2.png"; then
+        echo "  PASS cache hit yields identical bytes"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL cache hit yields different bytes"
+        FAIL=$((FAIL + 1))
+    fi
+
+    # missing-sentinel rejection
+    rm -rf "$cache"
+    cache=$(mktemp -d)
+    export MAT_VIS_CACHE="$cache"
+    rm -f "$mockroot/$TAG/ambientcg/1k/.tier_complete"
+    assert_fails "missing sentinel rejects fetch" \
+        "$CLIENT" fetch ambientcg Rock064 color 1k
+
+    : > "$mockroot/$TAG/ambientcg/1k/.tier_complete"
+
+    unset MAT_VIS_HF_BASE MAT_VIS_TAG MAT_VIS_CACHE
+}
+
+# ── live: opt-in via MAT_VIS_LIVE_TESTS=1 ──────────────────────────
+
+live_tests() {
+    if [ "${MAT_VIS_LIVE_TESTS:-0}" != "1" ]; then
+        echo "=== live (skipped; set MAT_VIS_LIVE_TESTS=1 + a per-file MAT_VIS_LIVE_TAG) ==="
+        return
+    fi
+    echo "=== live (HF round-trip) ==="
+    export MAT_VIS_TAG="${MAT_VIS_LIVE_TAG:-v2026.04.1}"
+    local cache
+    cache=$(mktemp -d)
+    export MAT_VIS_CACHE="$cache"
+    trap 'rm -rf "$cache"' RETURN
+
+    local list_out
+    list_out=$("$CLIENT" list)
+    assert_contains "list includes 1k tier" "$list_out" "1k"
+    assert_contains "list includes ambientcg" "$list_out" "ambientcg"
+
+    local mats first
+    mats=$("$CLIENT" materials ambientcg 1k)
+    first=$(echo "$mats" | head -1)
+    [ -n "$first" ] || { echo "  FAIL materials list empty"; FAIL=$((FAIL + 1)); return; }
+    echo "  PASS materials list non-empty (first=$first)"
     PASS=$((PASS + 1))
-else
-    echo "  FAIL materials list empty"
-    FAIL=$((FAIL + 1))
-fi
 
-echo "=== fetch texture ==="
+    local out="$cache/test_output.png"
+    "$CLIENT" fetch ambientcg "$first" color 1k -o "$out"
+    if [ -f "$out" ] && [ "$(wc -c < "$out" | tr -d ' ')" -gt 1000 ]; then
+        echo "  PASS fetch wrote file ($(wc -c < "$out" | tr -d ' ') bytes)"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL fetch did not produce valid file"
+        FAIL=$((FAIL + 1))
+    fi
+    local magic
+    magic=$(head -c4 "$out" | od -An -tx1 | tr -d ' \n')
+    case "$magic" in
+        89504e47|ab4b5458) echo "  PASS PNG/KTX2 magic verified ($magic)"; PASS=$((PASS + 1)) ;;
+        *) echo "  FAIL unexpected magic: $magic"; FAIL=$((FAIL + 1)) ;;
+    esac
+}
 
-TEXTURE_FILE="$MAT_VIS_CACHE/test_output.png"
-"$CLIENT" fetch ambientcg "$FIRST_MAT" color 1k -o "$TEXTURE_FILE"
-
-# Verify file exists and is non-trivial
-if [ -f "$TEXTURE_FILE" ] && [ "$(wc -c < "$TEXTURE_FILE")" -gt 1000 ]; then
-    echo "  PASS fetch wrote file ($(wc -c < "$TEXTURE_FILE") bytes)"
-    PASS=$((PASS + 1))
-else
-    echo "  FAIL fetch did not produce valid file"
-    FAIL=$((FAIL + 1))
-fi
-
-# Verify PNG magic bytes
-MAGIC=$(head -c4 "$TEXTURE_FILE" | xxd -p)
-if [ "$MAGIC" = "89504e47" ]; then
-    echo "  PASS PNG magic bytes verified"
-    PASS=$((PASS + 1))
-else
-    echo "  FAIL expected PNG magic 89504e47, got $MAGIC"
-    FAIL=$((FAIL + 1))
-fi
+structural_tests
+live_tests
 
 echo ""
 echo "$PASS passed, $FAIL failed"

--- a/clients/test_client.sh
+++ b/clients/test_client.sh
@@ -151,6 +151,59 @@ structural_tests() {
 
     : > "$mockroot/$TAG/ambientcg/1k/.tier_complete"
 
+    # KTX2 fallback: serve a 404 on .png by removing it; .ktx2 must take over.
+    rm -rf "$cache"
+    cache=$(mktemp -d)
+    export MAT_VIS_CACHE="$cache"
+    rm -f "$mockroot/$TAG/ambientcg/1k/Rock064/color.png"
+    {
+        printf '\xab\x4b\x54\x58\x20\x32\x30\xbb\r\n\x1a\n'
+        head -c 1500 /dev/zero
+    } > "$mockroot/$TAG/ambientcg/1k/Rock064/color.ktx2"
+    "$CLIENT" fetch ambientcg Rock064 color 1k > "$cache/ktx2.out"
+    local k_magic
+    k_magic=$(head -c4 "$cache/ktx2.out" | od -An -tx1 | tr -d ' \n')
+    assert_eq "fetch falls back to .ktx2 when .png 404s" "$k_magic" "ab4b5458"
+    # restore for further tests
+    rm -f "$mockroot/$TAG/ambientcg/1k/Rock064/color.ktx2"
+    {
+        printf '\x89PNG\r\n\x1a\n'
+        head -c 1500 /dev/zero
+    } > "$mockroot/$TAG/ambientcg/1k/Rock064/color.png"
+
+    # Magic-byte rejection: .png served with bogus magic must be rejected.
+    rm -rf "$cache"
+    cache=$(mktemp -d)
+    export MAT_VIS_CACHE="$cache"
+    head -c 64 /dev/zero > "$mockroot/$TAG/ambientcg/1k/Rock064/color.png"
+    assert_fails "bogus magic rejected" \
+        "$CLIENT" fetch ambientcg Rock064 color 1k
+    {
+        printf '\x89PNG\r\n\x1a\n'
+        head -c 1500 /dev/zero
+    } > "$mockroot/$TAG/ambientcg/1k/Rock064/color.png"
+
+    # Pre-v3 manifest must be rejected loudly — the v0.6 client doesn't speak tar.
+    rm -rf "$cache"
+    cache=$(mktemp -d)
+    export MAT_VIS_CACHE="$cache"
+    cat > "$mockroot/$TAG/release-manifest.json" <<EOF
+{ "schema_version": 2, "release_tag": "$TAG", "tiers": { "1k": { "base_url": "https://example/" } } }
+EOF
+    assert_fails "pre-v3 manifest rejected" "$CLIENT" list
+    cat > "$mockroot/$TAG/release-manifest.json" <<EOF
+{
+  "schema_version": 3,
+  "release_tag": "$TAG",
+  "sources": {
+    "ambientcg": {
+      "catalog": "ambientcg.json",
+      "tiers": { "1k": { "complete": true } }
+    }
+  }
+}
+EOF
+
     unset MAT_VIS_HF_BASE MAT_VIS_TAG MAT_VIS_CACHE
 }
 

--- a/justfile.project
+++ b/justfile.project
@@ -83,11 +83,15 @@ clean-artifacts:
 # MAT_VIS_LIVE_TESTS=1 opts in to live tests; skipped by default since
 # v0.6 (per-file substrate, ADR-0012) — prod isn't rebaked yet.
 # Two invocations because the two `tests/` dirs both have __init__.py
-# and pytest's rootdir discovery conflates them in a single run.
+# and pytest's rootdir discovery conflates them in one run.
+# `--with clients/python` adds the mat-vis-client wheel to the same
+# env (tests/test_version_sync.py imports it). `--reinstall-package`
+# forces a rebuild from clients/python/ even when the cached archive
+# is stale, so signature drift catches pre-CI.
 [group('test')]
 test-all *args:
     MAT_VIS_LIVE_TESTS=1 uv run --reinstall-package mat-vis-client \
-        --with clients/python --with pytest pytest tests/ {{ args }}
+        --with clients/python pytest tests/ {{ args }}
     MAT_VIS_LIVE_TESTS=1 uv run --reinstall-package mat-vis-client \
         --with clients/python --with pytest pytest clients/python {{ args }}
 
@@ -95,7 +99,7 @@ test-all *args:
 [group('test')]
 test-fast *args:
     uv run --reinstall-package mat-vis-client \
-        --with clients/python --with pytest pytest tests/ {{ args }}
+        --with clients/python pytest tests/ {{ args }}
     uv run --reinstall-package mat-vis-client \
         --with clients/python --with pytest pytest clients/python {{ args }}
 


### PR DESCRIPTION
## Summary

Closes #188. Migrates the JS, shell, and Rust reference clients off the v0.4 GitHub-Releases tar+rowmap+Range substrate onto plain HTTPS GET on the per-file HF dataset (ADR-0012). Mirrors the contract that landed for the Python client in #196.

- **JS** (`clients/js/mat-vis-client.mjs`, `package.json` 0.1.0 → 0.6.0): drops `#rowmaps`/range reads; v3 manifest probe; `.tier_complete` sentinel cache; PNG → KTX2 fallback.
- **Shell** (`clients/mat-vis.sh`): drops jq rowmap parsing + Range tar reads; `cmd_fetch` collapses to one curl per attempt with magic-byte verification.
- **Rust** (`clients/rust/`, Cargo.toml 0.1.0 → 0.6.0): drops `Rowmap`/`ChannelRange`/`range_read`; v3-only manifest; sentinel probe; PNG → KTX2 fallback.
- **Tests** rewritten as structural suites (no network) with stubbed `fetch()` (JS), `file://` HF tree (shell), and unit tests + URL-shape contracts (Rust). Live tests opt-in via `MAT_VIS_LIVE_TESTS=1`, default-skipped until prod is rebaked under per-file (#179).

Independent review surfaced gaps where the suites passed without proving the substrate invariants — addressed in `550228c` (sentinel-ordering check, magic-byte rejection, KTX2 fallback, pre-v3 rejection). One follow-up filed: #199 (Rust httpmock-based offline coverage for the HTTP surface).

Filed pre-push test gate fix in `174e507` so future contributors hit the same `just test-fast` run that catches signature drift locally.

## Test plan

- [x] `node --test clients/js/test_client.mjs` — 7 structural tests (sentinel ordering, KTX2 fallback, sentinel rejection, v2 manifest rejection, magic rejection, materials filter, channels reader)
- [x] `bash clients/test_client.sh` — 10 structural tests against a stubbed `file://` HF tree
- [x] `cargo test` — 10 unit tests (URL shape, magic bytes, schema validation v2/v3, UA format, live-gated)
- [x] `just test-fast` — 347 + 211 = 558 passed, 32 skipped (pre-push gate green)
- [ ] CI: `Client tests (all languages)` runs the dagger `test-clients` matrix; live tests skipped (`MAT_VIS_LIVE_TESTS` unset)