### PR TITLE
feat(baker): audit-orphans for mid-batch LFS orphans (#190)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,33 @@ mat-vis-baker derive-from-release v2026.04.0 512 ./output-512
 mat-vis-baker catalog-from-release v2026.04.0 --output-dir .
 ```
 
+### Operator's guide: orphan LFS cleanup
+
+Under the per-file substrate (ADR-0012) HF Hub uploads each LFS blob
+*before* finalizing the commit. A mid-batch crash can therefore leave
+orphan blobs on the object store — uploaded, but not referenced by any
+committed file. Xet dedup makes future re-uploads bytes-free, so the
+practical damage is the storage accounting line; cleanup is optional
+but housekeeping-friendly.
+
+```bash
+# Dry-run audit against the scratch repo (default behaviour).
+mat-vis-baker audit-orphans --repo gerchowl/mat-vis-tst
+
+# Pin to a specific revision.
+mat-vis-baker audit-orphans --repo gerchowl/mat-vis-tst --revision v2026.05.0
+
+# Delete orphans (interactive: type DELETE to confirm).
+mat-vis-baker audit-orphans --repo gerchowl/mat-vis-tst --delete
+
+# Auditing the canonical prod repo requires --allow-prod.
+mat-vis-baker audit-orphans --repo gerchowl/mat-vis --allow-prod
+
+# Bypass the interactive prompt (e.g. inside a CI job):
+MAT_VIS_AUDIT_FORCE=1 mat-vis-baker audit-orphans \
+  --repo gerchowl/mat-vis-tst --delete
+```
+
 ### Dagger CI
 
 ```bash

--- a/src/mat_vis_baker/__main__.py
+++ b/src/mat_vis_baker/__main__.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -208,6 +209,56 @@ def cmd_merge_shards(args: argparse.Namespace) -> int:
     log.info("merge-shards result: %s", result)
     # merge_shards never puts "error" in its result — it raises on any
     # fault (incomplete shard set, range-read mismatch). Always return 0.
+    return 0
+
+
+def _resolve_hf_token(value: str | None) -> str | None:
+    """Accept either a raw token or ``env:VAR`` for indirection."""
+    if value is None:
+        return None
+    if value.startswith("env:"):
+        var = value[len("env:") :]
+        return os.environ.get(var)
+    return value
+
+
+def cmd_audit_orphans(args: argparse.Namespace) -> int:
+    """Audit (and optionally clean up) mid-batch orphan LFS blobs (#190)."""
+    from mat_vis_baker.audit_orphans import _confirm_delete, audit_orphans
+
+    token = _resolve_hf_token(args.hf_token)
+
+    if args.delete and not _confirm_delete():
+        print("aborted: confirmation not given", file=sys.stderr)
+        return 1
+
+    try:
+        result = audit_orphans(
+            repo_id=args.repo,
+            revision=args.revision,
+            delete=args.delete,
+            allow_prod=args.allow_prod,
+            hf_token=token,
+        )
+    except ValueError as e:
+        # Prod guard or other input-validation error — keep the
+        # message on stderr and bail without a stack trace.
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    log.info(
+        "audit-orphans %s@%s: total_lfs=%d referenced=%d orphans=%d deleted=%s",
+        result["repo_id"],
+        result["revision"],
+        result["total_lfs"],
+        result["referenced"],
+        len(result["orphans"]),
+        result["deleted"],
+    )
+    if result["orphans"]:
+        log.info("orphan oids:")
+        for oid in result["orphans"]:
+            log.info("  %s", oid)
     return 0
 
 
@@ -465,6 +516,48 @@ def main() -> int:
     p_mtlx.add_argument("--source", default=None, help="Source (default: gpuopen)")
     p_mtlx.add_argument("--mtlx-dir", default="mtlx", help="Directory with upstream .mtlx files")
 
+    p_audit = sub.add_parser(
+        "audit-orphans",
+        help=(
+            "List (and optionally delete) orphan LFS blobs left by mid-batch "
+            "crashes under the per-file substrate (#190 / ADR-0012 follow-up)."
+        ),
+    )
+    p_audit.add_argument(
+        "--repo",
+        required=True,
+        help="HF dataset repo (owner/name), e.g. gerchowl/mat-vis-tst.",
+    )
+    p_audit.add_argument(
+        "--revision",
+        default="main",
+        help="Git ref to audit against (default: main).",
+    )
+    p_audit.add_argument(
+        "--delete",
+        action="store_true",
+        help=(
+            "Permanently delete orphan blobs. Dry-run otherwise. "
+            "Prompts for 'DELETE' on stdin; bypass with MAT_VIS_AUDIT_FORCE=1."
+        ),
+    )
+    p_audit.add_argument(
+        "--allow-prod",
+        action="store_true",
+        help=(
+            "Required to audit non-scratch repos. Scratch repos are named "
+            "*/mat-vis-tst or */mat-vis-*-tst."
+        ),
+    )
+    p_audit.add_argument(
+        "--hf-token",
+        default=None,
+        help=(
+            "Token for HfApi. Accepts either a raw token or 'env:VAR'; "
+            "falls back to the cached huggingface_hub login."
+        ),
+    )
+
     args = parser.parse_args()
 
     if args.command == "all":
@@ -489,6 +582,8 @@ def main() -> int:
         return cmd_hf_derive_ktx2(args)
     if args.command == "merge-shards":
         return cmd_merge_shards(args)
+    if args.command == "audit-orphans":
+        return cmd_audit_orphans(args)
 
     parser.print_help()
     return 1

--- a/src/mat_vis_baker/audit_orphans.py
+++ b/src/mat_vis_baker/audit_orphans.py
@@ -1,0 +1,168 @@
+"""Audit + clean up mid-batch orphan LFS blobs (#190 / ADR-0012 follow-up).
+
+ADR-0012's "Bad / accepted tradeoffs" notes that HF Hub uploads the LFS
+blob *before* finalizing the commit. A mid-batch crash can therefore
+leave orphan LFS blobs on the object store: bytes uploaded, but no
+committed file references the blob. Xet chunk-dedup makes any future
+re-upload bytes-free, so the only practical damage is the storage
+accounting line on the repo. This module gives operators a way to see
+and (with explicit confirmation) reclaim that space.
+
+An orphan = an LFS blob (sha-256 ``oid``) returned by
+``HfApi.list_lfs_files`` whose ``oid`` does NOT appear as the
+``lfs.sha256`` of any file in the committed tree at ``revision``
+(default: ``main``).
+
+Notes on the underlying API names — `huggingface_hub` (>=1.x) calls
+these `list_lfs_files` and `permanently_delete_lfs_files`. The issue
+description mentioned older spellings (``list_repo_lfs_files`` /
+``delete_lfs_files``); we use the names actually present in the pinned
+version. Same shape, different label.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Any
+
+log = logging.getLogger("mat-vis-baker.audit_orphans")
+
+
+def _guard_prod_target(repo_id: str, allow_prod: bool) -> None:
+    """Refuse the canonical prod repo without ``allow_prod=True``.
+
+    Mirrors ``hf_bake_per_file._guard_prod_target`` so the audit tool
+    obeys the same safety rail. Auditing prod read-only is fine, but
+    deleting against prod requires the explicit flag — and we keep the
+    guard symmetric for both modes so operators don't develop a habit
+    of running this against prod casually.
+    """
+    if "/" in repo_id:
+        _owner, name = repo_id.rsplit("/", 1)
+        if name == "mat-vis-tst" or (name.endswith("-tst") and name.startswith("mat-vis")):
+            return
+    if allow_prod:
+        return
+    raise ValueError(
+        f"Refusing to audit non-scratch repo {repo_id!r} without "
+        "allow_prod=True. Scratch repos are named .../mat-vis-tst "
+        "(or .../mat-vis-*-tst); anything else (including the canonical "
+        "gerchowl/mat-vis prod repo) requires explicit allow_prod=True."
+    )
+
+
+def _committed_lfs_oids(api: Any, repo_id: str, revision: str) -> set[str]:
+    """Return every ``lfs.sha256`` referenced by the tree at ``revision``."""
+    oids: set[str] = set()
+    for entry in api.list_repo_tree(
+        repo_id=repo_id,
+        repo_type="dataset",
+        revision=revision,
+        recursive=True,
+    ):
+        lfs = getattr(entry, "lfs", None)
+        if lfs is None:
+            continue
+        # `BlobLfsInfo.sha256` is what list_lfs_files returns as `oid`.
+        sha = getattr(lfs, "sha256", None)
+        if sha:
+            oids.add(sha)
+    return oids
+
+
+def audit_orphans(
+    repo_id: str,
+    revision: str | None = None,
+    delete: bool = False,
+    allow_prod: bool = False,
+    hf_token: str | None = None,
+    api: Any | None = None,
+) -> dict:
+    """Walk LFS blobs vs committed tree; report (and optionally delete) orphans.
+
+    Args:
+        repo_id: HF dataset repo (``owner/name``).
+        revision: Git ref to audit against. Defaults to ``main``.
+        delete: If True, permanently delete orphan blobs. Dry-run otherwise.
+        allow_prod: Required to audit non-scratch repos (e.g. ``gerchowl/mat-vis``).
+        hf_token: Optional token for ``HfApi``. Falls back to the cached login.
+        api: Inject a custom ``HfApi`` (used by tests). Production callers
+             leave this as ``None``; we'll construct one with ``hf_token``.
+
+    Returns:
+        ``{
+            "repo_id": ...,
+            "revision": ...,
+            "total_lfs": N,             # all LFS blobs on the repo
+            "referenced": M,            # blobs referenced by the tree
+            "orphans": [oid, ...],      # sha-256 oids not referenced
+            "deleted": K | None,        # number actually deleted (None on dry-run)
+        }``
+    """
+    _guard_prod_target(repo_id, allow_prod)
+
+    if api is None:
+        from huggingface_hub import HfApi
+
+        api = HfApi(token=hf_token)
+
+    rev = revision or "main"
+
+    log.info("listing LFS blobs on %s", repo_id)
+    lfs_blobs = list(api.list_lfs_files(repo_id=repo_id, repo_type="dataset"))
+    log.info("listing committed tree at %s@%s", repo_id, rev)
+    referenced = _committed_lfs_oids(api, repo_id, rev)
+
+    orphan_blobs = [b for b in lfs_blobs if getattr(b, "oid", None) not in referenced]
+    orphan_oids = [b.oid for b in orphan_blobs]
+
+    deleted: int | None = None
+    if delete and orphan_blobs:
+        log.warning(
+            "deleting %d orphan LFS blobs from %s (revision=%s)",
+            len(orphan_blobs),
+            repo_id,
+            rev,
+        )
+        # `permanently_delete_lfs_files` is a permanent action that
+        # rewrites history if any *committed* file ends up unreachable.
+        # Since we filter to blobs *not* referenced by the tree, the
+        # rewrite is a no-op for orphans — but we keep the API's default.
+        api.permanently_delete_lfs_files(
+            repo_id=repo_id,
+            lfs_files=orphan_blobs,
+            repo_type="dataset",
+        )
+        deleted = len(orphan_blobs)
+    elif delete:
+        # Nothing to delete — surface a 0 instead of None so callers
+        # can distinguish "ran the delete path" from "dry-run".
+        deleted = 0
+
+    return {
+        "repo_id": repo_id,
+        "revision": rev,
+        "total_lfs": len(lfs_blobs),
+        "referenced": len(referenced),
+        "orphans": orphan_oids,
+        "deleted": deleted,
+    }
+
+
+def _confirm_delete() -> bool:
+    """Ask for a literal ``DELETE`` on stdin. ``MAT_VIS_AUDIT_FORCE=1``
+    skips the prompt for non-tty / scripted contexts."""
+    if os.environ.get("MAT_VIS_AUDIT_FORCE") == "1":
+        log.warning("MAT_VIS_AUDIT_FORCE=1: skipping interactive confirmation")
+        return True
+    try:
+        reply = input("type DELETE to confirm: ")
+    except EOFError:
+        print(
+            "no tty available; set MAT_VIS_AUDIT_FORCE=1 to bypass confirmation",
+            file=sys.stderr,
+        )
+        return False
+    return reply == "DELETE"

--- a/tests/test_audit_orphans.py
+++ b/tests/test_audit_orphans.py
@@ -1,0 +1,155 @@
+"""Tests for ``mat_vis_baker.audit_orphans`` (#190 / ADR-0012 follow-up).
+
+All HF traffic is mocked — no live network calls. Mirrors the style of
+``tests/test_bake_one_routing.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from mat_vis_baker.audit_orphans import audit_orphans
+
+
+def _fake_lfs_blob(oid: str, filename: str = "x") -> SimpleNamespace:
+    """Mimic ``huggingface_hub.hf_api.LFSFileInfo`` enough for the auditor."""
+    return SimpleNamespace(
+        oid=oid,
+        file_oid=oid,
+        filename=filename,
+        size=1,
+        ref="main",
+        pushed_at=None,
+    )
+
+
+def _fake_repo_file(path: str, lfs_oid: str | None) -> SimpleNamespace:
+    """Mimic ``RepoFile``; ``lfs.sha256`` matches what the auditor checks."""
+    lfs = SimpleNamespace(sha256=lfs_oid, size=1, pointer_size=130) if lfs_oid else None
+    return SimpleNamespace(path=path, size=1, blob_id="g" + (lfs_oid or "0"), lfs=lfs)
+
+
+def _make_api(lfs_blobs, tree_entries) -> MagicMock:
+    api = MagicMock()
+    api.list_lfs_files.return_value = list(lfs_blobs)
+    api.list_repo_tree.return_value = list(tree_entries)
+    return api
+
+
+class TestAuditOrphans:
+    def test_empty_repo_no_lfs(self) -> None:
+        api = _make_api(lfs_blobs=[], tree_entries=[])
+        result = audit_orphans(repo_id="gerchowl/mat-vis-tst", api=api)
+
+        assert result["total_lfs"] == 0
+        assert result["referenced"] == 0
+        assert result["orphans"] == []
+        assert result["deleted"] is None
+        assert result["repo_id"] == "gerchowl/mat-vis-tst"
+        assert result["revision"] == "main"
+        api.permanently_delete_lfs_files.assert_not_called()
+
+    def test_all_lfs_referenced_no_orphans(self) -> None:
+        blobs = [_fake_lfs_blob("oid-a"), _fake_lfs_blob("oid-b")]
+        tree = [
+            _fake_repo_file("a.png", "oid-a"),
+            _fake_repo_file("b.png", "oid-b"),
+            # Non-LFS file should not contribute to referenced count.
+            _fake_repo_file("manifest.json", None),
+        ]
+        api = _make_api(lfs_blobs=blobs, tree_entries=tree)
+
+        result = audit_orphans(repo_id="gerchowl/mat-vis-tst", api=api)
+
+        assert result["total_lfs"] == 2
+        assert result["referenced"] == 2
+        assert result["orphans"] == []
+        assert result["deleted"] is None
+        api.permanently_delete_lfs_files.assert_not_called()
+
+    def test_unreferenced_lfs_is_orphan_dry_run(self) -> None:
+        blobs = [
+            _fake_lfs_blob("oid-keep"),
+            _fake_lfs_blob("oid-orphan", filename="crashed.png"),
+        ]
+        tree = [_fake_repo_file("kept.png", "oid-keep")]
+        api = _make_api(lfs_blobs=blobs, tree_entries=tree)
+
+        result = audit_orphans(repo_id="gerchowl/mat-vis-tst", api=api)
+
+        assert result["total_lfs"] == 2
+        assert result["referenced"] == 1
+        assert result["orphans"] == ["oid-orphan"]
+        # Dry-run: deleted stays None — distinguishes "didn't run delete"
+        # from "ran delete, found 0".
+        assert result["deleted"] is None
+        api.permanently_delete_lfs_files.assert_not_called()
+
+    def test_delete_calls_permanently_delete(self) -> None:
+        blobs = [
+            _fake_lfs_blob("oid-keep"),
+            _fake_lfs_blob("oid-orphan-1"),
+            _fake_lfs_blob("oid-orphan-2"),
+        ]
+        tree = [_fake_repo_file("kept.png", "oid-keep")]
+        api = _make_api(lfs_blobs=blobs, tree_entries=tree)
+
+        result = audit_orphans(repo_id="gerchowl/mat-vis-tst", api=api, delete=True)
+
+        assert sorted(result["orphans"]) == ["oid-orphan-1", "oid-orphan-2"]
+        assert result["deleted"] == 2
+        api.permanently_delete_lfs_files.assert_called_once()
+        kwargs = api.permanently_delete_lfs_files.call_args.kwargs
+        assert kwargs["repo_id"] == "gerchowl/mat-vis-tst"
+        assert kwargs["repo_type"] == "dataset"
+        passed_oids = {b.oid for b in kwargs["lfs_files"]}
+        assert passed_oids == {"oid-orphan-1", "oid-orphan-2"}
+
+    def test_delete_with_no_orphans_records_zero(self) -> None:
+        """``delete=True`` but nothing to delete → ``deleted=0``, no API call."""
+        blobs = [_fake_lfs_blob("oid-a")]
+        tree = [_fake_repo_file("a.png", "oid-a")]
+        api = _make_api(lfs_blobs=blobs, tree_entries=tree)
+
+        result = audit_orphans(repo_id="gerchowl/mat-vis-tst", api=api, delete=True)
+
+        assert result["orphans"] == []
+        assert result["deleted"] == 0
+        api.permanently_delete_lfs_files.assert_not_called()
+
+    def test_prod_guard_refuses_canonical_repo(self) -> None:
+        api = _make_api(lfs_blobs=[], tree_entries=[])
+
+        with pytest.raises(ValueError, match="Refusing to audit non-scratch repo"):
+            audit_orphans(repo_id="gerchowl/mat-vis", api=api)
+
+        # API must NOT be called when the guard refuses.
+        api.list_lfs_files.assert_not_called()
+        api.list_repo_tree.assert_not_called()
+
+    def test_prod_guard_allow_prod_lets_through(self) -> None:
+        api = _make_api(lfs_blobs=[], tree_entries=[])
+        result = audit_orphans(repo_id="gerchowl/mat-vis", api=api, allow_prod=True)
+        assert result["orphans"] == []
+
+    def test_revision_threaded_through(self) -> None:
+        api = _make_api(lfs_blobs=[], tree_entries=[])
+        audit_orphans(
+            repo_id="gerchowl/mat-vis-tst",
+            api=api,
+            revision="v2026.05.0",
+        )
+        kwargs = api.list_repo_tree.call_args.kwargs
+        assert kwargs["revision"] == "v2026.05.0"
+        assert kwargs["recursive"] is True
+        assert kwargs["repo_type"] == "dataset"
+
+    def test_scratch_repo_pattern_matrix(self) -> None:
+        """Mirror the scratch-repo regex from hf_bake_per_file._guard_prod_target."""
+        api = _make_api(lfs_blobs=[], tree_entries=[])
+        # Both scratch patterns must pass without allow_prod.
+        audit_orphans(repo_id="gerchowl/mat-vis-tst", api=api)
+        audit_orphans(repo_id="gerchowl/mat-vis-pr-tst", api=api)


### PR DESCRIPTION
## Summary

Closes #190.

- New `mat-vis-baker audit-orphans` subcommand walks `HfApi.list_lfs_files` against the committed tree at a revision and reports orphan LFS blobs (uploaded but unreferenced) under the per-file substrate (ADR-0012 follow-up).
- Dry-run by default; `--delete` permanently removes orphans via `permanently_delete_lfs_files` after a literal `DELETE` confirmation on stdin (bypassable with `MAT_VIS_AUDIT_FORCE=1` for CI).
- Mirrors the existing `_guard_prod_target` pattern: non-scratch repos (anything not matching `*/mat-vis-tst` / `*/mat-vis-*-tst`) require `--allow-prod`.

## Files changed

- `src/mat_vis_baker/audit_orphans.py` — new module: `audit_orphans()` + `_confirm_delete()` + `_guard_prod_target()`.
- `src/mat_vis_baker/__main__.py` — new `audit-orphans` subparser + `cmd_audit_orphans` + tiny `_resolve_hf_token` helper supporting `env:VAR` indirection.
- `tests/test_audit_orphans.py` — 9 new tests, all `unittest.mock`-based, no network.
- `README.md` — Operator's guide section under Development.

## Notes / decisions

- The issue mentioned `HfApi.list_repo_lfs_files` and `HfApi.delete_lfs_files`, but `huggingface_hub` 1.11 (pinned in this repo) actually exposes them as `list_lfs_files` and `permanently_delete_lfs_files`. Same shape, different label. Implementation uses the names actually installed.
- `LFSFileInfo.oid` is the sha-256 we match against `RepoFile.lfs.sha256`. We pass the full `LFSFileInfo` objects to `permanently_delete_lfs_files` (its required input shape).
- Dry-run returns `deleted=None`; `--delete` with no orphans returns `deleted=0` so callers can distinguish "didn't run delete" from "ran delete, found nothing."

## Test plan

- [x] `uv run pytest tests/test_audit_orphans.py -v` — 9/9 pass
- [x] `just test-fast` — 356 + 211 pass (full pre-push gate, no regressions)
- [x] `mat-vis-baker audit-orphans --help` renders
- [x] `ruff check` + `ruff format --check` clean on changed files
- [ ] Live smoke against `gerchowl/mat-vis-tst` (requires `HF_TOKEN`; deferred to operator)