### PR TITLE
test(e2e): mat-vis-tst smoke tests — multi-language round-trip per ADR-0012

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -18,6 +18,7 @@ Usage:
     dagger call test-client-shell    # bash tests for shell reference client
     dagger call test-client-rust     # cargo test for Rust reference client
     dagger call test-clients         # all 4 client tests in parallel
+    dagger call test-e2e             # nightly E2E against mat-vis-tst (#193)
     dagger call validate-release      # verify release assets are complete
     dagger call preflight            # verify GHCR auth before push
     dagger call push                 # preflight + build + push to GHCR
@@ -564,6 +565,73 @@ class MatVisCi:
             allow_prod=allow_prod,
         )
         return await ctr.with_exec(argv).stdout()
+
+    @function
+    async def test_e2e(
+        self,
+        hf_token: Annotated[dagger.Secret, Doc("HF write token for the round-trip bake")],
+        context: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
+        repo_id: Annotated[
+            str, Doc("Target HF dataset repo (must be a *-tst scratch namespace)")
+        ] = "gerchowl/mat-vis-tst",
+    ) -> str:
+        """Run the live MAT_VIS_E2E=1 round-trip suite against mat-vis-tst (#193).
+
+        Spins up a python:3.12-slim container, syncs project deps with
+        the baker + dev extras, installs the Python reference client, and
+        runs ``pytest tests/e2e/ -v`` with ``MAT_VIS_E2E=1`` and
+        ``HF_TOKEN`` injected from the Dagger secret. Returns stdout.
+
+        Refuses to run against any non-scratch ``repo_id`` — there is no
+        ``--allow-prod`` escape hatch here because the E2E suite makes
+        and deletes a throwaway tag (``v0.0.0-e2e-184-perfile``); doing
+        that on prod would churn the public dataset history. If you
+        need to E2E against prod, fork the suite into its own function.
+        """
+        if "/" in repo_id:
+            _owner, name = repo_id.rsplit("/", 1)
+            scratch = name == "mat-vis-tst" or (
+                name.startswith("mat-vis") and name.endswith("-tst")
+            )
+        else:
+            scratch = False
+        if not scratch:
+            raise ValueError(
+                f"test_e2e refuses to target non-scratch repo {repo_id!r}; "
+                "this function only runs against .../mat-vis-tst (or "
+                ".../mat-vis-*-tst). E2E bakes a throwaway tag and "
+                "deletes it on teardown — that's not safe on prod."
+            )
+
+        ctx = context or dag.host().directory(".")
+        uv_cache = dag.cache_volume("uv-cache")
+        apt_cache = dag.cache_volume("apt-cache")
+        return await (
+            dag.container()
+            .from_("python:3.12-slim")
+            .with_env_variable("DEBIAN_FRONTEND", "noninteractive")
+            .with_mounted_cache("/var/cache/apt", apt_cache)
+            .with_exec(["apt-get", "update", "-qq"])
+            .with_exec(["apt-get", "install", "-y", "-qq", "git", "curl", "ca-certificates"])
+            .with_exec(
+                [
+                    "sh",
+                    "-c",
+                    "curl -LsSf https://astral.sh/uv/install.sh | sh && "
+                    "install -m 0755 /root/.local/bin/uv /usr/local/bin/uv",
+                ]
+            )
+            .with_env_variable("PYTHONUNBUFFERED", "1")
+            .with_mounted_cache("/root/.cache/uv", uv_cache)
+            .with_mounted_directory("/app", ctx)
+            .with_workdir("/app")
+            .with_exec(["uv", "sync", "--all-extras"])
+            .with_exec(["uv", "pip", "install", "-e", "./clients/python"])
+            .with_secret_variable("HF_TOKEN", hf_token)
+            .with_env_variable("MAT_VIS_E2E", "1")
+            .with_exec(["uv", "run", "pytest", "tests/e2e/", "-v"])
+            .stdout()
+        )
 
     @function
     async def smoke_bake(

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,60 @@
+---
+# E2E workflow — live MAT_VIS_E2E=1 round-trip against mat-vis-tst (#193).
+#
+# Bakes a throwaway tag on `gerchowl/mat-vis-tst`, fetches it back via
+# the per-file HF substrate (ADR-0012), then deletes the tag on
+# teardown. Targets the scratch namespace exclusively — the dagger
+# function refuses any non-`*-tst` repo_id, with no --allow-prod
+# escape hatch.
+#
+# Reproduce locally with:
+#   dagger call test-e2e --hf-token=env:HF_TOKEN --context=.
+
+name: E2E
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch: {}
+  schedule:
+    # 06:00 UTC daily — well off-peak for HF and inside the GH-hosted
+    # runner free tier window. Bake takes ~3 min for 2 polyhaven 1k
+    # materials so this is cheap.
+    - cron: '0 6 * * *'
+
+permissions:
+  contents: read
+  issues: write          # needed by notify-on-failure composite action
+
+jobs:
+  e2e:
+    name: live round-trip against mat-vis-tst
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: test-e2e
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          verb: call
+          module: .dagger
+          args: >-
+            test-e2e
+            --context=.
+            --hf-token=env:HF_TOKEN
+            --repo-id=gerchowl/mat-vis-tst
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-on-failure
+        with:
+          label-prefix: "[e2e-failed]"
+          workflow-name: "e2e"
+          target: "gerchowl/mat-vis-tst"
+          context: >-
+            Likely causes: HF transient (rate-limit or 5xx), upstream
+            polyhaven API hiccup, or a regression in the per-file
+            substrate. The Python E2E suite cleans up its throwaway
+            tag on teardown — failed runs may leave the tag behind on
+            mat-vis-tst; safe to delete manually.

--- a/clients/js/test_client.mjs
+++ b/clients/js/test_client.mjs
@@ -245,3 +245,56 @@ liveDescribe('live (set MAT_VIS_LIVE_TESTS=1; needs per-file prod tag)', () => {
     assert.ok(buf.byteLength > 1000);
   });
 });
+
+// ── e2e (mat-vis-tst per-file substrate, #193) ─────────────────────
+//
+// Round-trip against the throwaway scratch dataset
+// `gerchowl/mat-vis-tst`. Gated on MAT_VIS_E2E=1.
+//
+// Ordering contract (see issue #193): the Python E2E suite at
+// tests/e2e/test_per_file_roundtrip.py owns the bake/cleanup
+// lifecycle for the throwaway tag (default `v0.0.0-e2e-184-perfile`).
+// This block presumes that suite has already run (or is running in
+// the same CI job) so the tag exists. Operators run:
+//
+//   MAT_VIS_E2E=1 pytest tests/e2e/      # bakes the tag
+//   MAT_VIS_E2E=1 node --test clients/js/test_client.mjs  # rides on it
+//
+// We do NOT bake from JS — keeping the bake side-effect single-owner
+// avoids racy commits to mat-vis-tst.
+
+const E2E_ENABLED = process.env.MAT_VIS_E2E === '1';
+const E2E_TAG = process.env.MAT_VIS_E2E_TAG || 'v0.0.0-e2e-184-perfile';
+const E2E_REPO = 'gerchowl/mat-vis-tst';
+const E2E_HF_BASE = `https://huggingface.co/datasets/${E2E_REPO}/resolve`;
+
+const e2eDescribe = E2E_ENABLED ? describe : describe.skip;
+
+e2eDescribe('e2e (set MAT_VIS_E2E=1; needs per-file mat-vis-tst tag)', () => {
+  // The exported MatVisClient module captures HF_BASE at import time.
+  // Re-import it dynamically with MAT_VIS_HF_BASE set so the URL
+  // prefix points at mat-vis-tst for this block only.
+  let TstClient;
+
+  before(async () => {
+    process.env.MAT_VIS_HF_BASE = E2E_HF_BASE;
+    // Bust ESM cache by appending a query so we get a fresh module
+    // with the env var read at module init.
+    const mod = await import(`./mat-vis-client.mjs?e2e=${Date.now()}`);
+    TstClient = mod.MatVisClient;
+  });
+
+  it('round-trips a polyhaven 1k color PNG via per-file URL', async () => {
+    const client = new TstClient({ tag: E2E_TAG });
+    const mats = await client.materials('polyhaven', '1k');
+    assert.ok(mats.length >= 1, `expected baked polyhaven materials, got ${mats}`);
+    const buf = await client.fetchTexture('polyhaven', mats[0], 'color', '1k');
+    const magic = new Uint8Array(buf, 0, 4);
+    assert.deepStrictEqual(
+      [...magic],
+      [0x89, 0x50, 0x4e, 0x47],
+      'must be a real PNG',
+    );
+    assert.ok(buf.byteLength > 1000, `PNG too small: ${buf.byteLength}`);
+  });
+});

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -538,4 +538,73 @@ mod tests {
             .expect_err("404 sentinel must produce an error");
         assert!(err.contains("not atomically complete"), "error: {err}");
     }
+
+    // ── e2e (mat-vis-tst per-file substrate, #193) ─────────────────
+    //
+    // Round-trip against the throwaway scratch dataset
+    // `gerchowl/mat-vis-tst`. Gated on MAT_VIS_E2E=1.
+    //
+    // Ordering contract (#193): the Python E2E suite at
+    // tests/e2e/test_per_file_roundtrip.py owns the bake/cleanup
+    // lifecycle for the throwaway tag (default
+    // `v0.0.0-e2e-184-perfile`). This test presumes that suite has
+    // already run (or is running in the same CI job) so the tag
+    // exists. Operators run:
+    //
+    //   MAT_VIS_E2E=1 pytest tests/e2e/      # bakes the tag
+    //   MAT_VIS_E2E=1 cargo test --manifest-path clients/rust/Cargo.toml
+    //
+    // We do NOT bake from Rust — keeping the bake side-effect
+    // single-owner avoids racy commits to mat-vis-tst.
+
+    fn e2e_enabled() -> bool {
+        std::env::var("MAT_VIS_E2E").as_deref() == Ok("1")
+    }
+
+    fn e2e_tag() -> String {
+        std::env::var("MAT_VIS_E2E_TAG").unwrap_or_else(|_| "v0.0.0-e2e-184-perfile".to_string())
+    }
+
+    #[test]
+    fn e2e_fetch_color_png() {
+        if !e2e_enabled() {
+            eprintln!("(skipped: set MAT_VIS_E2E=1)");
+            return;
+        }
+        let _guard = ENV_LOCK.lock().unwrap();
+        // Point the client at the scratch dataset for the duration
+        // of this test only — ENV_LOCK serialises with the httpmock
+        // tests above so they don't see this URL.
+        let prev = std::env::var("MAT_VIS_HF_BASE").ok();
+        set_hf_base("https://huggingface.co/datasets/gerchowl/mat-vis-tst/resolve");
+
+        let result = (|| -> Result<(), String> {
+            let tag = e2e_tag();
+            let m = fetch_manifest(&tag);
+            assert_eq!(m.schema_version, 3);
+            let cat = fetch_catalog(&tag, "polyhaven", &m);
+            let mid = cat
+                .iter()
+                .find(|e| e.available_tiers.iter().any(|t| t == "1k"))
+                .map(|e| e.id.clone())
+                .ok_or_else(|| {
+                    "no 1k-staged polyhaven material in mat-vis-tst — did the Python E2E suite bake the tag?".to_string()
+                })?;
+            assert_tier_complete(&tag, "polyhaven", "1k")?;
+            let bytes = fetch_texture_bytes(&tag, "polyhaven", &mid, "color", "1k")?;
+            assert!(bytes.starts_with(PNG_MAGIC), "must be a real PNG");
+            assert!(bytes.len() > 1000, "PNG too small: {}", bytes.len());
+            Ok(())
+        })();
+
+        // Restore env (best-effort) before propagating any failure.
+        // SAFETY: ENV_LOCK is held for the duration of the test.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("MAT_VIS_HF_BASE", v),
+                None => std::env::remove_var("MAT_VIS_HF_BASE"),
+            }
+        }
+        result.expect("e2e round-trip");
+    }
 }

--- a/clients/test_client.sh
+++ b/clients/test_client.sh
@@ -250,8 +250,79 @@ live_tests() {
     esac
 }
 
+# ── e2e: opt-in via MAT_VIS_E2E=1 (mat-vis-tst per-file substrate, #193)
+#
+# Round-trips against the throwaway scratch dataset
+# `gerchowl/mat-vis-tst`. Gated on MAT_VIS_E2E=1.
+#
+# Ordering contract (#193): the Python E2E suite at
+# tests/e2e/test_per_file_roundtrip.py owns the bake/cleanup lifecycle
+# for the throwaway tag (default `v0.0.0-e2e-184-perfile`). This block
+# presumes that suite has already run (or is running in the same CI
+# job) so the tag exists. Operators run:
+#
+#   MAT_VIS_E2E=1 pytest tests/e2e/      # bakes the tag
+#   MAT_VIS_E2E=1 bash clients/test_client.sh   # rides on it
+#
+# We do NOT bake from shell — keeping the bake side-effect single-owner
+# avoids racy commits to mat-vis-tst.
+
+cmd_e2e() {
+    if [ "${MAT_VIS_E2E:-0}" != "1" ]; then
+        echo "=== e2e (skipped; set MAT_VIS_E2E=1 + a per-file mat-vis-tst tag) ==="
+        return
+    fi
+    echo "=== e2e (mat-vis-tst HF round-trip, #193) ==="
+
+    local repo="gerchowl/mat-vis-tst"
+    export MAT_VIS_HF_BASE="https://huggingface.co/datasets/$repo/resolve"
+    export MAT_VIS_TAG="${MAT_VIS_E2E_TAG:-v0.0.0-e2e-184-perfile}"
+    local cache
+    cache=$(mktemp -d)
+    export MAT_VIS_CACHE="$cache"
+    trap 'rm -rf "$cache"' RETURN
+
+    local mats first
+    if ! mats=$("$CLIENT" materials polyhaven 1k 2>&1); then
+        echo "  FAIL materials lookup failed: $mats"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    first=$(echo "$mats" | head -1)
+    if [ -z "$first" ]; then
+        echo "  FAIL polyhaven materials list empty (did the Python E2E suite bake the tag?)"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    echo "  PASS polyhaven materials non-empty (first=$first)"
+    PASS=$((PASS + 1))
+
+    local out="$cache/e2e.png"
+    if ! "$CLIENT" fetch polyhaven "$first" color 1k -o "$out" 2>&1; then
+        echo "  FAIL fetch failed for $first"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    local size
+    size=$(wc -c < "$out" | tr -d ' ')
+    if [ "$size" -gt 1000 ]; then
+        echo "  PASS fetch wrote PNG bytes ($size B)"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL fetch produced too-small file ($size B)"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    local magic
+    magic=$(head -c4 "$out" | od -An -tx1 | tr -d ' \n')
+    assert_eq "fetch emits PNG magic" "$magic" "89504e47"
+
+    unset MAT_VIS_HF_BASE MAT_VIS_TAG MAT_VIS_CACHE
+}
+
 structural_tests
 live_tests
+cmd_e2e
 
 echo ""
 echo "$PASS passed, $FAIL failed"


### PR DESCRIPTION
Closes #193 (once #204 lands the per-file derive — see note below).

## Summary

- Extends `clients/js/test_client.mjs`, `clients/test_client.sh`, and `clients/rust/src/main.rs` with a `MAT_VIS_E2E=1`-gated round-trip block that points the client at `gerchowl/mat-vis-tst`, fetches one polyhaven 1k color PNG via the per-file substrate (ADR-0012), and asserts PNG magic + size > 1000.
- Adds a new `test_e2e()` Dagger function in `.dagger/src/mat_vis_ci/main.py` that runs the Python E2E suite with `MAT_VIS_E2E=1` + `HF_TOKEN` injected. Hard-coded to refuse any non-`*-tst` `repo_id` (no `--allow-prod` escape hatch — the E2E suite makes/deletes a throwaway tag, that's not safe on prod).
- Adds `.github/workflows/e2e.yml`: `workflow_dispatch` + `cron: '0 6 * * *'` (06:00 UTC daily), invokes `test-e2e` via `dagger/dagger-for-github@v8.4.1`.

## Operator-run ordering — chose option (a)

The throwaway tag `v0.0.0-e2e-184-perfile` is owned by the Python E2E suite (`tests/e2e/test_per_file_roundtrip.py::baked_tag`) — it bakes on setup and deletes on teardown. The JS/shell/Rust E2E blocks ride on that live tag. Each test file's e2e block documents this. Operators run:

```
MAT_VIS_E2E=1 pytest tests/e2e/      # bakes the tag
MAT_VIS_E2E=1 node --test clients/js/test_client.mjs
MAT_VIS_E2E=1 bash clients/test_client.sh
MAT_VIS_E2E=1 cargo test --manifest-path clients/rust/Cargo.toml
```

Keeping the bake side-effect single-owner avoids racy commits to `mat-vis-tst`.

## Closing note

Closing #193 should wait until #204 lands the per-file derive — at that point the E2E suite can also exercise the derive→fetch round-trip, which is a follow-up extension (not a blocker for this PR).

## Verification gates (six)

| # | Gate | Result |
|---|------|--------|
| 1 | `MAT_VIS_E2E=0 pytest tests/e2e/ -v` → all skipped | 7 skipped |
| 2 | `MAT_VIS_E2E=0 node --test clients/js/test_client.mjs` → e2e block skipped, structural tests pass | 7 pass, e2e/live skipped |
| 3 | `bash clients/test_client.sh` (no env) → e2e section prints `skipped`, structural tests pass | 10 pass, 0 fail; e2e/live skipped |
| 4 | `cargo test` → e2e_fetch_color_png prints `(skipped)` when MAT_VIS_E2E unset; passes | 16 pass, 0 fail (e2e + 2 live show "(skipped)") |
| 5 | `just test-fast` (pre-push gate) green | 211 pass + 22 skipped twice (unit-test side + client-side) |
| 6 | `e2e.yml` lints clean | `yamllint .github/workflows/e2e.yml` exits 0 |

## Test plan

Local quick sanity (no network):

- [ ] `MAT_VIS_E2E=0 pytest tests/e2e/ -v` → all 7 tests skipped
- [ ] `node --test clients/js/test_client.mjs` → 7 pass, e2e + live both SKIP
- [ ] `bash clients/test_client.sh` → 10 pass; e2e + live print `skipped` lines
- [ ] `cd clients/rust && cargo test` → 16 pass; e2e + live tests print `(skipped: ...)`
- [ ] `just test-fast` → all green
- [ ] `yamllint .github/workflows/e2e.yml` → no output

Live round-trip (needs HF_TOKEN with write to `gerchowl/mat-vis-tst`):

- [ ] `MAT_VIS_E2E=1 pytest tests/e2e/ -v` → bakes throwaway tag, all 7 pass, deletes tag
- [ ] After the Python suite runs and the tag exists, ride the language suites:
  - `MAT_VIS_E2E=1 node --test clients/js/test_client.mjs`
  - `MAT_VIS_E2E=1 bash clients/test_client.sh`
  - `MAT_VIS_E2E=1 cargo test --manifest-path clients/rust/Cargo.toml`
- [ ] CI: trigger `e2e.yml` via workflow_dispatch in GitHub UI; expect it to pick up `secrets.HF_TOKEN` and round-trip end-to-end through Dagger.

Env vars used:

- `MAT_VIS_E2E=1` — gates the new round-trip blocks (separate from the existing `MAT_VIS_LIVE_TESTS=1` gate that targets prod)
- `MAT_VIS_E2E_TAG` — overrides the throwaway tag name (default `v0.0.0-e2e-184-perfile`)
- `HF_TOKEN` — required for the bake side of the Python suite; the language E2E blocks only need anonymous read access to mat-vis-tst (which is public)