### PR TITLE
feat(baker): per-file derive pipeline (#204)

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -10,6 +10,8 @@ Usage:
     dagger call smoke-baker          # verify baker container (#135)
     dagger call bake                 # per-file hf-bake → atomic HF commit (#136 / ADR-0012)
     dagger call smoke-bake           # dry-run bake against gerchowl/mat-vis-tst (#136)
+    dagger call derive               # per-file hf-derive (resize) (#204)
+    dagger call derive-ktx2          # per-file hf-derive-ktx2 (#204)
     dagger call integration-test     # local end-to-end per-file bake + verify
     dagger call probe-sources        # verify upstream API connectivity
     dagger call test-all             # lint + test + smoke + probe
@@ -463,13 +465,14 @@ class MatVisCi:
         self,
         context: dagger.Directory,
         hf_token: dagger.Secret | None = None,
+        with_ktx2: bool = False,
     ) -> dagger.Container:
-        """Baker container for hf-bake (#135).
+        """Baker container for hf-bake / hf-derive / hf-derive-ktx2 (#135 / #204).
 
         Parity target: Linux x86_64, Python 3.12, ``uv sync --all-extras``
-        on the repo. The legacy KTX2 tooling install was retired with
-        the tar derive pipeline in #189; per-file KTX2 derives will be
-        re-introduced under their own future issue.
+        on the repo. With ``with_ktx2=True``, KTX-Software 4.4.0 ``.deb``
+        is installed so ``toktx`` is on ``PATH`` — needed for the
+        ``hf-derive-ktx2`` leg of the per-file derive pipeline (#204).
 
         Env:
           - ``PYTHONUNBUFFERED=1`` — heartbeat / OTLP logs flush live
@@ -497,6 +500,23 @@ class MatVisCi:
                 ]
             )
         )
+
+        if with_ktx2:
+            # Khronos KTX-Software 4.4.0 .deb — same URL the legacy
+            # derive.yml used so toktx output is byte-identical across
+            # the v0.5/v0.6 cutover.
+            ctr = ctr.with_exec(
+                [
+                    "sh",
+                    "-c",
+                    "apt-get install -y -qq libgomp1 && "
+                    "curl -fsSL -o /tmp/ktx.deb "
+                    "https://github.com/KhronosGroup/KTX-Software/releases/download/"
+                    "v4.4.0/KTX-Software-4.4.0-Linux-x86_64.deb && "
+                    "dpkg -i /tmp/ktx.deb && rm /tmp/ktx.deb && "
+                    "toktx --version",
+                ]
+            )
 
         ctr = (
             ctr.with_env_variable("PYTHONUNBUFFERED", "1")
@@ -680,6 +700,131 @@ class MatVisCi:
         top = await ctr.with_exec(["uv", "run", "mat-vis-baker", "--help"]).stdout()
         bake = await ctr.with_exec(["uv", "run", "mat-vis-baker", "hf-bake", "--help"]).stdout()
         return f"=== mat-vis-baker --help ===\n{top}\n=== mat-vis-baker hf-bake --help ===\n{bake}"
+
+    # ── per-file derive pipeline (#204) ─────────────────────────────
+
+    @function
+    async def derive(
+        self,
+        context: Annotated[dagger.Directory, Doc("Project root directory")],
+        source: Annotated[str, Doc("Upstream (ambientcg/polyhaven/gpuopen)")],
+        target_tier: Annotated[str, Doc("Smaller tier to derive, e.g. 1k")],
+        source_tier: Annotated[str, Doc("Existing per-file tier to resize from, e.g. 4k")],
+        release_tag: Annotated[str, Doc("Calver release tag, e.g. v2026.05.0")],
+        hf_token: Annotated[dagger.Secret, Doc("HF API token for atomic commits")],
+        repo_id: Annotated[str, Doc("HF dataset repo id")] = "gerchowl/mat-vis-tst",
+        allow_prod: Annotated[
+            bool, Doc("Opt-in flag required to target any non-*-tst repo")
+        ] = False,
+        limit: Annotated[int, Doc("Max materials (0 = no limit)")] = 0,
+        batch_size: Annotated[int, Doc("Materials per atomic commit batch")] = 50,
+        dry_run: Annotated[bool, Doc("Skip the HF push; build locally")] = False,
+    ) -> str:
+        """Per-file derive: resize an existing per-file tier into a smaller one (#204).
+
+        Wraps ``mat-vis-baker hf-derive`` in the slim baker container
+        (no KTX2 toolchain — ``with_ktx2=False``). Reads source channels
+        via plain HTTPS GET, runs PIL LANCZOS resize, writes per-file
+        PNGs back to HF. Updates ``<source>.json`` and writes a
+        ``.tier_complete`` sentinel as the final commit.
+
+        Safety: defaults to ``gerchowl/mat-vis-tst``; any other target
+        requires ``--allow-prod=true``.
+        """
+        self._guard_prod_target(repo_id, allow_prod)
+        ctr = self._baker_container(context, with_ktx2=False, hf_token=hf_token)
+        cmd = [
+            "uv",
+            "run",
+            "mat-vis-baker",
+            "hf-derive",
+            "--source",
+            source,
+            "--source-tier",
+            source_tier,
+            "--target-tier",
+            target_tier,
+            "--release-tag",
+            release_tag,
+            "--work-dir",
+            "/tmp/derive",
+            "--repo-id",
+            repo_id,
+            "--hf-token",
+            "env:HF_TOKEN",
+            "--batch-size",
+            str(batch_size),
+        ]
+        if limit > 0:
+            cmd += ["--limit", str(limit)]
+        if dry_run:
+            cmd.append("--dry-run")
+        if allow_prod:
+            cmd.append("--allow-prod")
+        return await ctr.with_exec(cmd).stdout()
+
+    @function
+    async def derive_ktx2(
+        self,
+        context: Annotated[dagger.Directory, Doc("Project root directory")],
+        source: Annotated[str, Doc("Upstream (ambientcg/polyhaven/gpuopen)")],
+        source_tier: Annotated[str, Doc("Existing per-file PNG tier to transcode from")],
+        release_tag: Annotated[str, Doc("Calver release tag")],
+        hf_token: Annotated[dagger.Secret, Doc("HF API token for atomic commits")],
+        repo_id: Annotated[str, Doc("HF dataset repo id")] = "gerchowl/mat-vis-tst",
+        allow_prod: Annotated[
+            bool, Doc("Opt-in flag required to target any non-*-tst repo")
+        ] = False,
+        target_tier: Annotated[str, Doc("KTX2 target tier label; empty = ktx2-<source-tier>")] = "",
+        limit: Annotated[int, Doc("Max materials (0 = no limit)")] = 0,
+        batch_size: Annotated[int, Doc("Materials per atomic commit batch")] = 50,
+        dry_run: Annotated[bool, Doc("Skip the HF push; build locally")] = False,
+    ) -> str:
+        """Per-file derive: transcode an existing per-file PNG tier to KTX2 (#204).
+
+        Wraps ``mat-vis-baker hf-derive-ktx2`` in the baker container
+        with toktx installed (``with_ktx2=True``). Reads source PNG
+        channels via plain GET, runs ``toktx --encode uastc --genmipmap
+        --t2``, writes per-file ``.ktx2`` back to HF.
+
+        ``target_tier=""`` is the "use the CLI default" sentinel —
+        Dagger can't express "omit this arg", so we only pass
+        ``--target-tier`` when the operator supplied a non-empty value.
+
+        Safety: defaults to ``gerchowl/mat-vis-tst``; any other target
+        requires ``--allow-prod=true``.
+        """
+        self._guard_prod_target(repo_id, allow_prod)
+        ctr = self._baker_container(context, with_ktx2=True, hf_token=hf_token)
+        cmd = [
+            "uv",
+            "run",
+            "mat-vis-baker",
+            "hf-derive-ktx2",
+            "--source",
+            source,
+            "--source-tier",
+            source_tier,
+            "--release-tag",
+            release_tag,
+            "--work-dir",
+            "/tmp/derive",
+            "--repo-id",
+            repo_id,
+            "--hf-token",
+            "env:HF_TOKEN",
+            "--batch-size",
+            str(batch_size),
+        ]
+        if target_tier:
+            cmd += ["--target-tier", target_tier]
+        if limit > 0:
+            cmd += ["--limit", str(limit)]
+        if dry_run:
+            cmd.append("--dry-run")
+        if allow_prod:
+            cmd.append("--allow-prod")
+        return await ctr.with_exec(cmd).stdout()
 
     @function
     async def probe_sources(

--- a/.github/workflows/derive.yml
+++ b/.github/workflows/derive.yml
@@ -1,0 +1,175 @@
+---
+# Per-file derive workflow (#204) — resize a smaller PNG tier or
+# KTX2-transcode an existing per-file tier on HF.
+#
+# Shape:
+#   setup   — derives target-tier label + tags the matrix list
+#   derive  — matrix[source] runs the Dagger `derive` or `derive-ktx2`
+#             function (which wraps mat-vis-baker hf-derive{,-ktx2}).
+#             Each material batch is an atomic HF commit; a sentinel
+#             `.tier_complete` file lands as the final commit per
+#             (source, target_tier) so clients can probe atomicity
+#             with one HEAD request.
+#   report  — notify-on-failure if any earlier job failed
+#
+# Why no merge step (vs. legacy v0.5.x derive.yml): the per-file
+# substrate (ADR-0012) makes each batch commit a durable checkpoint —
+# resume comes from pre-flight HEAD probes, not from reassembling
+# shard tars. The shard / merge plumbing the legacy workflow needed
+# was deleted in #189 along with the tar code.
+
+name: Derive
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+    inputs:
+      kind:
+        description: 'Derivation kind'
+        required: true
+        default: 'resize'
+        type: choice
+        options:
+          - resize
+          - ktx2
+      source:
+        description: 'Source (upstream)'
+        required: true
+        default: 'polyhaven'
+        type: choice
+        options:
+          - ambientcg
+          - polyhaven
+          - gpuopen
+      source-tier:
+        description: 'Source tier to derive from (existing per-file tier on HF)'
+        required: true
+        default: '4k'
+        type: choice
+        options:
+          - 128
+          - 256
+          - 512
+          - 1k
+          - 2k
+          - 4k
+          - 8k
+      target-tier:
+        description: 'Target tier (resize only; e.g. 1k). Ignored for ktx2.'
+        required: false
+        default: '1k'
+        type: string
+      release-tag:
+        description: 'Calver data release tag (e.g. v2026.05.0)'
+        required: true
+        default: 'v2026.05.0'
+        type: string
+      repo-id:
+        description: 'HF dataset repo'
+        required: false
+        default: 'gerchowl/mat-vis-tst'
+        type: string
+      allow-prod:
+        description: 'Required to target any non-*-tst HF repo (e.g. gerchowl/mat-vis)'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write          # needed by notify-on-failure composite action
+
+# Serialise dispatches on (release, source, source-tier, kind, target).
+# Two parallel dispatches against the same target tier would race on
+# the .tier_complete sentinel commit — order is observable to clients.
+concurrency:
+  group: >-
+    derive-${{ inputs.repo-id }}-${{ inputs.release-tag }}-${{ inputs.source }}
+    -${{ inputs.source-tier }}-${{ inputs.kind }}
+  cancel-in-progress: false
+
+jobs:
+  setup:
+    name: setup (target-tier)
+    runs-on: ubuntu-latest
+    outputs:
+      target-tier: ${{ steps.plan.outputs.target-tier }}
+    steps:
+      - id: plan
+        run: |
+          set -euo pipefail
+          kind="${{ inputs.kind }}"
+
+          if [ "$kind" = "resize" ]; then
+            tier="${{ inputs.target-tier }}"
+            if [ -z "$tier" ]; then
+              echo "::error::resize requires target-tier"
+              exit 1
+            fi
+          else
+            tier="ktx2-${{ inputs.source-tier }}"
+          fi
+
+          {
+            echo "target-tier=$tier"
+          } >>"$GITHUB_OUTPUT"
+          echo "Plan: kind=$kind target-tier=$tier"
+
+  derive:
+    needs: setup
+    name: >-
+      ${{ inputs.kind }}
+      ${{ inputs.source }}
+      ${{ inputs.source-tier }}
+      → ${{ needs.setup.outputs.target-tier }}
+    runs-on: ubuntu-latest
+    # Per-file derive against a full source × tier (~2k materials × 7
+    # channels) tops out around 1-2 h on average; 350 min keeps headroom.
+    timeout-minutes: 350
+    env:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Dagger shell-safety lint (#61)
+        run: python3 scripts/check-dagger-shell-safety.py
+
+      - name: Derive (per-file substrate, ADR-0012)
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          verb: call
+          module: .dagger
+          args: >-
+            ${{ inputs.kind == 'resize' && 'derive' || 'derive-ktx2' }}
+            --context=.
+            --source=${{ inputs.source }}
+            ${{ inputs.kind == 'resize' && format('--target-tier={0}', inputs.target-tier) || '' }}
+            --source-tier=${{ inputs.source-tier }}
+            --release-tag=${{ inputs.release-tag }}
+            --repo-id=${{ inputs.repo-id }}
+            --hf-token=env:HF_TOKEN
+            --allow-prod=${{ inputs.allow-prod }}
+
+  report:
+    needs: [setup, derive]
+    if: >-
+      always() &&
+      (needs.setup.result == 'failure' ||
+       needs.derive.result == 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Notify on failure
+        uses: ./.github/actions/notify-on-failure
+        with:
+          label-prefix: "[derive-failed]"
+          workflow-name: "derive"
+          target: >-
+            ${{ inputs.kind }} ${{ inputs.source }}/${{ inputs.source-tier }}
+            → ${{ needs.setup.outputs.target-tier }}
+            @ ${{ inputs.release-tag }}
+          context: >-
+            Per-file derive (ADR-0012). Each batch commit is atomic on
+            HF, so succeeded materials are already on the substrate.
+            Recovery: re-dispatch the same workflow_dispatch — the
+            pre-flight HEAD probe skips already-derived materials, so
+            re-runs are bytes-free for everything that succeeded.

--- a/src/mat_vis_baker/__main__.py
+++ b/src/mat_vis_baker/__main__.py
@@ -5,9 +5,10 @@ bake path — one HF file per ``(source, tier, material, channel)``.
 The legacy ``all`` subcommand is a thin back-compat wrapper.
 
 The tar-based ``hf-derive`` / ``hf-derive-ktx2`` / ``merge-shards``
-subcommands were retired by #189; their per-file replacements will
-be reborn under a future issue. ``derive`` / ``derive-from-release``
-/ ``derive-ktx2`` were retired earlier (issue #112).
+subcommands were retired by #189. ``hf-derive`` and ``hf-derive-ktx2``
+have been reborn against the per-file substrate (#204). ``derive`` /
+``derive-from-release`` / ``derive-ktx2`` (the v0.4.x subcommands)
+remain retired (issue #112).
 
 Usage:
     mat-vis-baker hf-bake <source> <tier> <work_dir> --release-tag <tag> [--limit N]
@@ -209,6 +210,55 @@ def cmd_audit_orphans(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_hf_derive(args: argparse.Namespace) -> int:
+    """Derive a smaller PNG tier from an existing per-file HF tier (#204)."""
+    from mat_vis_baker.hf_derive_per_file import derive_smaller_tier
+
+    token = _resolve_hf_token(args.hf_token)
+    result = derive_smaller_tier(
+        source=args.source,
+        target_tier=args.target_tier,
+        source_tier=args.source_tier,
+        release_tag=args.release_tag,
+        work_dir=Path(args.work_dir),
+        repo_id=args.repo_id,
+        hf_token=token,
+        dry_run=args.dry_run,
+        allow_prod=args.allow_prod,
+        limit=args.limit,
+        batch_size=args.batch_size,
+    )
+    log.info("hf-derive result: %s", result)
+    if "error" in result:
+        return 1
+    return 0
+
+
+def cmd_hf_derive_ktx2(args: argparse.Namespace) -> int:
+    """Transcode a per-file PNG tier to a KTX2 tier (#204)."""
+    from mat_vis_baker.hf_derive_per_file import derive_ktx2_tier
+
+    token = _resolve_hf_token(args.hf_token)
+    target_tier = args.target_tier or f"ktx2-{args.source_tier}"
+    result = derive_ktx2_tier(
+        source=args.source,
+        source_tier=args.source_tier,
+        target_tier=target_tier,
+        release_tag=args.release_tag,
+        work_dir=Path(args.work_dir),
+        repo_id=args.repo_id,
+        hf_token=token,
+        dry_run=args.dry_run,
+        allow_prod=args.allow_prod,
+        limit=args.limit,
+        batch_size=args.batch_size,
+    )
+    log.info("hf-derive-ktx2 result: %s", result)
+    if "error" in result:
+        return 1
+    return 0
+
+
 def cmd_hf_bake(args: argparse.Namespace) -> int:
     """Bake (source, tier) → HF commit. Per-file substrate (ADR-0012)."""
     from mat_vis_baker.hf_bake import bake_one
@@ -362,6 +412,88 @@ def main() -> int:
         ),
     )
 
+    # ── per-file derive (#204) ────────────────────────────────────
+    p_hfd = sub.add_parser(
+        "hf-derive",
+        help=(
+            "Derive a smaller PNG tier from an existing per-file HF tier "
+            "(no upstream re-fetch). ADR-0012 / #204."
+        ),
+    )
+    p_hfd.add_argument("--source", required=True, choices=SOURCES)
+    p_hfd.add_argument(
+        "--source-tier",
+        required=True,
+        choices=VALID_TIERS,
+        help="Tier to read from on HF (must already be baked).",
+    )
+    p_hfd.add_argument(
+        "--target-tier",
+        required=True,
+        choices=VALID_TIERS,
+        help="Smaller tier to derive. Must be ≤ source-tier (no upscale).",
+    )
+    p_hfd.add_argument("--release-tag", required=True)
+    p_hfd.add_argument("--work-dir", required=True, help="Scratch directory.")
+    p_hfd.add_argument(
+        "--repo-id",
+        default="gerchowl/mat-vis",
+        help="HF dataset repo (default: gerchowl/mat-vis).",
+    )
+    p_hfd.add_argument(
+        "--hf-token",
+        default=None,
+        help="HfApi token; raw or 'env:VAR'. Falls back to cached HF login.",
+    )
+    p_hfd.add_argument("--limit", type=int, default=None)
+    p_hfd.add_argument("--batch-size", type=int, default=50)
+    p_hfd.add_argument("--dry-run", action="store_true")
+    p_hfd.add_argument(
+        "--allow-prod",
+        action="store_true",
+        help="Required to target any non-*-tst HF dataset repo.",
+    )
+
+    p_hfk = sub.add_parser(
+        "hf-derive-ktx2",
+        help=(
+            "Transcode an existing per-file PNG tier on HF into a KTX2 tier. "
+            "Requires toktx on PATH. ADR-0012 / #204."
+        ),
+    )
+    p_hfk.add_argument("--source", required=True, choices=SOURCES)
+    p_hfk.add_argument(
+        "--source-tier",
+        required=True,
+        choices=VALID_TIERS,
+        help="PNG tier to transcode from (must already be baked).",
+    )
+    p_hfk.add_argument(
+        "--target-tier",
+        default=None,
+        help="KTX2 tier label (default: ktx2-<source-tier>).",
+    )
+    p_hfk.add_argument("--release-tag", required=True)
+    p_hfk.add_argument("--work-dir", required=True, help="Scratch directory.")
+    p_hfk.add_argument(
+        "--repo-id",
+        default="gerchowl/mat-vis",
+        help="HF dataset repo (default: gerchowl/mat-vis).",
+    )
+    p_hfk.add_argument(
+        "--hf-token",
+        default=None,
+        help="HfApi token; raw or 'env:VAR'. Falls back to cached HF login.",
+    )
+    p_hfk.add_argument("--limit", type=int, default=None)
+    p_hfk.add_argument("--batch-size", type=int, default=50)
+    p_hfk.add_argument("--dry-run", action="store_true")
+    p_hfk.add_argument(
+        "--allow-prod",
+        action="store_true",
+        help="Required to target any non-*-tst HF dataset repo.",
+    )
+
     p_mtlx = sub.add_parser(
         "pack-mtlx",
         help="Pack original upstream .mtlx files into JSON map for release",
@@ -430,6 +562,10 @@ def main() -> int:
         return cmd_pack_mtlx(args)
     if args.command == "hf-bake":
         return cmd_hf_bake(args)
+    if args.command == "hf-derive":
+        return cmd_hf_derive(args)
+    if args.command == "hf-derive-ktx2":
+        return cmd_hf_derive_ktx2(args)
     if args.command == "audit-orphans":
         return cmd_audit_orphans(args)
 

--- a/src/mat_vis_baker/hf_derive_per_file.py
+++ b/src/mat_vis_baker/hf_derive_per_file.py
@@ -1,0 +1,739 @@
+"""Per-file derive pipeline (#204 / ADR-0012).
+
+Resurrects the ``hf-derive`` capability that was deleted in #189 alongside
+the tar substrate. Lets a release built at one tier (e.g. 4k) feed the
+smaller tiers (1k, 512, …) and a KTX2 transcode without a fresh upstream
+fetch — every channel is read straight off the HF substrate via plain
+HTTPS GET, transformed in-memory, and written back per-file.
+
+Two public entry points:
+
+- :func:`derive_smaller_tier` — PIL ``Image.resize(LANCZOS)`` from a
+  larger source tier into a smaller target tier; output stays PNG.
+- :func:`derive_ktx2_tier` — ``toktx`` transcode of an existing PNG
+  tier into a KTX2 tier; output is per-file ``.ktx2``.
+
+Both share three load-bearing properties with :mod:`hf_bake_per_file`:
+
+1. **Pre-flight HEAD probe** — before doing any work for a material,
+   probe ``<source>/<target_tier>/<mid>/<channel>.{png,ktx2}`` with
+   HTTP HEAD; skip materials whose entire channel set already exists.
+   Mirrors the bake path's tree-scan resume primitive but without
+   needing an HfApi token (HEAD on resolve URLs is bytes-free public).
+
+2. **Batch commits** — each commit groups up to ``batch_size`` materials
+   so a mid-derive crash leaves at most one in-flight batch. Empirical
+   probe (see ADR-0012) clears 350-file commits in <10 s on HF.
+
+3. **Sentinel-last atomicity** — the very last commit per (source,
+   target_tier) writes ``<source>/<target_tier>/.tier_complete`` so
+   clients can probe a single file to detect tier completeness.
+   The catalog (`<source>.json`) commit happens *before* the sentinel;
+   together they restore the ADR-0007 "atomic tier" mental model.
+
+Tar code is intentionally not imported — #189 deleted ``tar_writer``
+and ``shard_utils`` entirely, and ADR-0012 forbids reintroducing them.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import subprocess
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from huggingface_hub import CommitOperationAdd, HfApi
+from PIL import Image
+
+from mat_vis_baker.common import CANONICAL_CHANNELS, TIER_TO_PX
+from mat_vis_baker.hf_bake_per_file import _guard_prod_target
+
+log = logging.getLogger("mat-vis-baker.hf_derive_per_file")
+
+# Default HF resolve base; override via HF_BASE env (kept consistent with
+# the Python client). The legacy module hard-coded the same URL — we
+# accept the canonical override so test/staging fixtures can stub it.
+HF_RESOLVE_BASE = "https://huggingface.co/datasets"
+
+DEFAULT_BATCH_SIZE = 50
+
+# PNG / KTX2 magic — matches ``hf_bake_per_file._channel_ext``. Used by
+# the magic-byte verification in :func:`_verify_png` / :func:`_verify_ktx2`.
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+KTX2_MAGIC = b"\xabKTX 20\xbb\r\n\x1a\n"
+
+
+# ── HTTP helpers ──────────────────────────────────────────────
+
+
+def _resolve_url(repo_id: str, release_tag: str, path: str) -> str:
+    """Build a resolve URL on the canonical HF dataset base."""
+    return f"{HF_RESOLVE_BASE}/{repo_id}/resolve/{release_tag}/{path}"
+
+
+def _auth_headers(token: str | None) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"} if token else {}
+
+
+def _http_get(url: str, *, token: str | None = None, timeout: int = 120) -> bytes:
+    """Plain GET; raises ``urllib.error.HTTPError`` on non-2xx."""
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": "mat-vis-baker/derive", **_auth_headers(token)},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return r.read()
+
+
+def _http_head_ok(url: str, *, token: str | None = None, timeout: int = 30) -> bool:
+    """Return True iff the URL responds 2xx to HEAD. Used by the
+    pre-flight skip — false for 404, network errors, etc."""
+    req = urllib.request.Request(
+        url,
+        method="HEAD",
+        headers={"User-Agent": "mat-vis-baker/derive", **_auth_headers(token)},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return 200 <= r.status < 300
+    except urllib.error.HTTPError:
+        return False
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _get_json(url: str, *, token: str | None = None, timeout: int = 60) -> Any:
+    return json.loads(_http_get(url, token=token, timeout=timeout))
+
+
+# ── catalog helpers ───────────────────────────────────────────
+
+
+def _fetch_catalog(repo_id: str, release_tag: str, source: str, token: str | None) -> list[dict]:
+    """Fetch ``<source>.json`` from the resolve URL. Returns [] if missing.
+
+    Per ADR-0011, the catalog is a list of v3-shaped entries. The legacy
+    derive path reused the same structure; we only ever append to
+    ``available_tiers`` here, never reshape the entries.
+    """
+    url = _resolve_url(repo_id, release_tag, f"{source}.json")
+    try:
+        body = _get_json(url, token=token)
+    except Exception as e:  # noqa: BLE001
+        log.warning("catalog fetch failed (%s): %s", type(e).__name__, e)
+        return []
+    if not isinstance(body, list):
+        log.warning("catalog at %s is not a list (got %s)", url, type(body).__name__)
+        return []
+    return body
+
+
+def _extend_available_tiers(
+    catalog: list[dict], derived_ids: set[str], target_tier: str
+) -> list[dict]:
+    """Append ``target_tier`` to ``available_tiers`` for every catalog
+    entry whose id is in ``derived_ids``. Idempotent — entries that
+    already list the tier are left alone."""
+    for entry in catalog:
+        mid = entry.get("id")
+        if not mid or mid not in derived_ids:
+            continue
+        tiers = entry.get("available_tiers")
+        if not isinstance(tiers, list):
+            entry["available_tiers"] = [target_tier]
+            continue
+        if target_tier not in tiers:
+            tiers.append(target_tier)
+    return catalog
+
+
+# ── transforms ────────────────────────────────────────────────
+
+
+def _verify_png(data: bytes, *, where: str) -> None:
+    if not data.startswith(PNG_MAGIC):
+        raise RuntimeError(f"{where}: expected PNG magic, got {data[:8]!r} ({len(data)} bytes)")
+
+
+def _verify_ktx2(data: bytes, *, where: str) -> None:
+    if not data.startswith(KTX2_MAGIC):
+        raise RuntimeError(f"{where}: expected KTX2 magic, got {data[:12]!r} ({len(data)} bytes)")
+
+
+def _resize_png(raw: bytes, target_px: int) -> bytes:
+    """LANCZOS-resize ``raw`` PNG bytes down to ``target_px`` square.
+
+    Strips ICC / EXIF profiles by re-saving without them — the same
+    profile-stripping the legacy ktx2 path did. This keeps the derived
+    PNGs portable to ``toktx`` if a later derive transcodes them.
+    """
+    img = Image.open(io.BytesIO(raw))
+    img.load()
+    resized = img.resize((target_px, target_px), Image.LANCZOS)
+    buf = io.BytesIO()
+    resized.save(buf, format="PNG", optimize=False)
+    return buf.getvalue()
+
+
+def _ktx2_transcode(raw: bytes) -> bytes:
+    """Re-encode incoming PNG via PIL (strips ICC / EXIF), shell out
+    to ``toktx --encode uastc --genmipmap --t2``, return KTX2 bytes.
+
+    ``toktx`` invocation mirrors the legacy ``hf_derive._ktx2_transform_factory``
+    — same flags, same uastc encoding, same mipmap pyramid.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        png_in = tmp_dir / "in.png"
+        ktx_out = tmp_dir / "out.ktx2"
+
+        img = Image.open(io.BytesIO(raw))
+        img.load()
+        img.save(png_in, format="PNG", icc_profile=None)
+
+        result = subprocess.run(
+            [
+                "toktx",
+                "--encode",
+                "uastc",
+                "--genmipmap",
+                "--t2",
+                str(ktx_out),
+                str(png_in),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"toktx exit {result.returncode}: "
+                f"{(result.stderr or result.stdout or '').strip()[:500]}"
+            )
+        return ktx_out.read_bytes()
+
+
+# ── shared driver ─────────────────────────────────────────────
+
+
+def _list_source_material_ids(
+    api: HfApi, repo_id: str, revision: str, source: str, source_tier: str
+) -> list[str]:
+    """List materials present at ``<source>/<source_tier>/`` on
+    ``revision``. Mirrors ``hf_bake_per_file._already_committed_material_ids``
+    but returns an ordered list (sort for determinism so retries replay
+    the same work distribution)."""
+    prefix = f"{source}/{source_tier}/"
+    mids: set[str] = set()
+    try:
+        for entry in api.list_repo_tree(
+            repo_id=repo_id,
+            repo_type="dataset",
+            revision=revision,
+            path_in_repo=prefix.rstrip("/"),
+            recursive=True,
+        ):
+            path = getattr(entry, "path", None)
+            if not path or not path.startswith(prefix):
+                continue
+            rel = path[len(prefix) :]  # noqa: E203
+            parts = rel.split("/", 1)
+            if len(parts) == 2 and parts[0] and not parts[0].startswith("."):
+                mids.add(parts[0])
+    except Exception as e:  # noqa: BLE001
+        log.warning(
+            "source-tier tree scan failed (%s): %s — derive will exit empty",
+            type(e).__name__,
+            e,
+        )
+    return sorted(mids)
+
+
+def _list_source_channels(
+    api: HfApi,
+    repo_id: str,
+    revision: str,
+    source: str,
+    source_tier: str,
+    material_id: str,
+) -> list[str]:
+    """List channels present for one material under ``<source>/<source_tier>/<mid>/``.
+
+    Stripped of extension. Falls back to :data:`CANONICAL_CHANNELS` if
+    listing fails (the GET will 404 cleanly per channel and the failure
+    counter trips the terminal gate).
+    """
+    prefix = f"{source}/{source_tier}/{material_id}/"
+    chs: list[str] = []
+    try:
+        for entry in api.list_repo_tree(
+            repo_id=repo_id,
+            repo_type="dataset",
+            revision=revision,
+            path_in_repo=prefix.rstrip("/"),
+            recursive=False,
+        ):
+            path = getattr(entry, "path", None)
+            if not path or not path.startswith(prefix):
+                continue
+            rel = path[len(prefix) :]  # noqa: E203
+            if "/" in rel or rel.startswith("."):
+                continue
+            stem = rel.rsplit(".", 1)[0]
+            chs.append(stem)
+    except Exception as e:  # noqa: BLE001
+        log.debug("channel listing fallback for %s: %s", material_id, e)
+        return list(CANONICAL_CHANNELS)
+    return chs or list(CANONICAL_CHANNELS)
+
+
+def _all_target_files_present(
+    repo_id: str,
+    release_tag: str,
+    source: str,
+    target_tier: str,
+    material_id: str,
+    channels: list[str],
+    target_ext: str,
+    token: str | None,
+) -> bool:
+    """HEAD-probe every expected output file. True only when *all* land
+    successfully — a partial-resize crash retries the missing channels."""
+    if not channels:
+        return False
+    for ch in channels:
+        url = _resolve_url(
+            repo_id, release_tag, f"{source}/{target_tier}/{material_id}/{ch}.{target_ext}"
+        )
+        if not _http_head_ok(url, token=token):
+            return False
+    return True
+
+
+def _derive_one_material(
+    *,
+    repo_id: str,
+    release_tag: str,
+    source: str,
+    source_tier: str,
+    target_tier: str,
+    material_id: str,
+    channels: list[str],
+    transform: Callable[[bytes], bytes],
+    target_ext: str,
+    token: str | None,
+) -> list[CommitOperationAdd]:
+    """Fetch + transform every channel. Returns the list of
+    ``CommitOperationAdd`` ops for this material; empty if every channel
+    fetch or transform failed (caller treats as material-level failure)."""
+    ops: list[CommitOperationAdd] = []
+    for ch in channels:
+        src_url = _resolve_url(
+            repo_id, release_tag, f"{source}/{source_tier}/{material_id}/{ch}.png"
+        )
+        try:
+            raw = _http_get(src_url, token=token)
+        except Exception as e:  # noqa: BLE001
+            log.warning("%s/%s/%s: source GET failed: %s", source, material_id, ch, e)
+            continue
+
+        # Magic-byte verify the source bytes — catches HTML 404 pages
+        # served as 200 on misconfigured tags.
+        try:
+            _verify_png(raw, where=f"source {source}/{source_tier}/{material_id}/{ch}.png")
+        except RuntimeError as e:
+            log.warning("%s", e)
+            continue
+
+        try:
+            out = transform(raw)
+        except Exception as e:  # noqa: BLE001
+            log.warning("%s/%s/%s: transform failed: %s", source, material_id, ch, e)
+            continue
+
+        # Magic-byte verify the produced bytes (PNG for resize, KTX2 for
+        # transcode). Refuses to commit malformed output.
+        try:
+            if target_ext == "png":
+                _verify_png(out, where=f"derived {source}/{target_tier}/{material_id}/{ch}.png")
+            elif target_ext == "ktx2":
+                _verify_ktx2(out, where=f"derived {source}/{target_tier}/{material_id}/{ch}.ktx2")
+        except RuntimeError as e:
+            log.warning("%s", e)
+            continue
+
+        ops.append(
+            CommitOperationAdd(
+                path_in_repo=f"{source}/{target_tier}/{material_id}/{ch}.{target_ext}",
+                path_or_fileobj=out,
+            )
+        )
+    return ops
+
+
+def _derive_driver(
+    *,
+    source: str,
+    source_tier: str,
+    target_tier: str,
+    release_tag: str,
+    work_dir: Path,
+    repo_id: str,
+    transform: Callable[[bytes], bytes],
+    target_ext: str,
+    label: str,
+    hf_token: str | None,
+    dry_run: bool,
+    allow_prod: bool,
+    limit: int | None,
+    batch_size: int,
+    on_progress: Callable[[dict], None] | None,
+) -> dict:
+    """Shared driver behind :func:`derive_smaller_tier` and
+    :func:`derive_ktx2_tier`. Single code path so the sentinel-last,
+    catalog-update, and batching invariants only need to live in one
+    place."""
+    _guard_prod_target(repo_id, allow_prod)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    api = HfApi(token=hf_token)
+
+    t0 = time.monotonic()
+    log.info(
+        "=== %s %s/%s → %s @ %s (batch_size=%d, dry_run=%s) ===",
+        label,
+        source,
+        source_tier,
+        target_tier,
+        release_tag,
+        batch_size,
+        dry_run,
+    )
+
+    # Enumerate material ids from the source tier. Sort for determinism
+    # so retries cover the same materials in the same order.
+    mids = _list_source_material_ids(api, repo_id, release_tag, source, source_tier)
+    if limit is not None:
+        mids = mids[:limit]
+    if not mids:
+        return {"error": "no source materials", "ok": 0, "failed": 0, "skipped_preflight": 0}
+
+    n_ok = 0
+    n_failed = 0
+    n_skipped = 0
+    derived_ids: set[str] = set()
+    last_commit_sha = ""
+
+    pending_ops: list[CommitOperationAdd] = []
+    pending_mids: list[str] = []
+
+    def _flush_batch() -> str:
+        nonlocal last_commit_sha
+        if not pending_ops:
+            return last_commit_sha
+        if dry_run:
+            log.info(
+                "%s dry-run: would commit %d files for %d materials",
+                label,
+                len(pending_ops),
+                len(pending_mids),
+            )
+            return last_commit_sha
+        commit = api.create_commit(
+            repo_id=repo_id,
+            repo_type="dataset",
+            operations=list(pending_ops),
+            commit_message=(
+                f"feat(data): {release_tag} — derive {source} {target_tier} "
+                f"from {source_tier} ({len(pending_mids)} materials, "
+                f"{len(pending_ops)} files)"
+            ),
+            revision=release_tag,
+        )
+        sha = getattr(commit, "oid", "") or getattr(commit, "commit_oid", "")
+        log.info(
+            "%s batch commit: %d materials, %d files, sha=%s",
+            label,
+            len(pending_mids),
+            len(pending_ops),
+            sha[:12] if sha else "?",
+        )
+        return sha or last_commit_sha
+
+    for i, mid in enumerate(mids):
+        # Source-side channel discovery — what does this material actually
+        # have at source_tier? Avoids requesting a normal.png that the
+        # source omitted.
+        channels = _list_source_channels(api, repo_id, release_tag, source, source_tier, mid)
+
+        # Resume preflight: if every output channel already exists at
+        # target_tier, skip the work.
+        if _all_target_files_present(
+            repo_id=repo_id,
+            release_tag=release_tag,
+            source=source,
+            target_tier=target_tier,
+            material_id=mid,
+            channels=channels,
+            target_ext=target_ext,
+            token=hf_token,
+        ):
+            n_skipped += 1
+            # Still mark it for catalog update — the tier IS available
+            # for this material on the substrate, regardless of whether
+            # this run produced it.
+            derived_ids.add(mid)
+            if on_progress is not None:
+                on_progress({"phase": "skip", "material_id": mid, "i": i, "total": len(mids)})
+            continue
+
+        ops = _derive_one_material(
+            repo_id=repo_id,
+            release_tag=release_tag,
+            source=source,
+            source_tier=source_tier,
+            target_tier=target_tier,
+            material_id=mid,
+            channels=channels,
+            transform=transform,
+            target_ext=target_ext,
+            token=hf_token,
+        )
+        if not ops:
+            n_failed += 1
+            if on_progress is not None:
+                on_progress({"phase": "fail", "material_id": mid, "i": i, "total": len(mids)})
+            continue
+
+        n_ok += 1
+        derived_ids.add(mid)
+        pending_ops.extend(ops)
+        pending_mids.append(mid)
+        if on_progress is not None:
+            on_progress(
+                {
+                    "phase": "ok",
+                    "material_id": mid,
+                    "files": len(ops),
+                    "i": i,
+                    "total": len(mids),
+                }
+            )
+
+        if len(pending_mids) >= batch_size:
+            last_commit_sha = _flush_batch()
+            pending_ops.clear()
+            pending_mids.clear()
+
+    # Final partial batch.
+    if pending_mids:
+        last_commit_sha = _flush_batch()
+        pending_ops.clear()
+        pending_mids.clear()
+
+    if n_ok == 0 and n_skipped == 0:
+        return {
+            "error": "no materials derived",
+            "ok": 0,
+            "failed": n_failed,
+            "skipped_preflight": 0,
+        }
+
+    # ── catalog update ────────────────────────────────────────
+    catalog = _fetch_catalog(repo_id, release_tag, source, hf_token)
+    if catalog:
+        _extend_available_tiers(catalog, derived_ids, target_tier)
+        catalog_bytes = (json.dumps(catalog, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
+        if dry_run:
+            log.info(
+                "%s dry-run: would commit updated %s.json (%d entries touched)",
+                label,
+                source,
+                len(derived_ids),
+            )
+        else:
+            commit = api.create_commit(
+                repo_id=repo_id,
+                repo_type="dataset",
+                operations=[
+                    CommitOperationAdd(
+                        path_in_repo=f"{source}.json",
+                        path_or_fileobj=catalog_bytes,
+                    )
+                ],
+                commit_message=(
+                    f"feat(data): {release_tag} — {source}.json + available_tiers += {target_tier}"
+                ),
+                revision=release_tag,
+            )
+            last_commit_sha = (
+                getattr(commit, "oid", "") or getattr(commit, "commit_oid", "") or last_commit_sha
+            )
+    else:
+        log.info("%s: no catalog fetched (empty or missing); skipping catalog update", label)
+
+    # ── sentinel-last ─────────────────────────────────────────
+    sentinel_path = f"{source}/{target_tier}/.tier_complete"
+    sentinel_body = (release_tag + "\n").encode("utf-8")
+    if dry_run:
+        log.info("%s dry-run: would commit sentinel %s", label, sentinel_path)
+    else:
+        commit = api.create_commit(
+            repo_id=repo_id,
+            repo_type="dataset",
+            operations=[
+                CommitOperationAdd(
+                    path_in_repo=sentinel_path,
+                    path_or_fileobj=sentinel_body,
+                )
+            ],
+            commit_message=f"feat(data): {release_tag} — {source} {target_tier} complete",
+            revision=release_tag,
+        )
+        last_commit_sha = (
+            getattr(commit, "oid", "") or getattr(commit, "commit_oid", "") or last_commit_sha
+        )
+
+    log.info(
+        "PERF %s: %.1fs, %d ok / %d failed / %d skipped (preflight)",
+        label,
+        time.monotonic() - t0,
+        n_ok,
+        n_failed,
+        n_skipped,
+    )
+
+    return {
+        "commit": last_commit_sha,
+        "ok": n_ok,
+        "failed": n_failed,
+        "skipped_preflight": n_skipped,
+        "materials": len(mids),
+    }
+
+
+# ── public entry points ───────────────────────────────────────
+
+
+def derive_smaller_tier(
+    source: str,
+    target_tier: str,
+    source_tier: str,
+    release_tag: str,
+    work_dir: Path,
+    repo_id: str,
+    *,
+    hf_token: str | None = None,
+    dry_run: bool = False,
+    allow_prod: bool = False,
+    limit: int | None = None,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    on_progress: Callable[[dict], None] | None = None,
+) -> dict:
+    """Resize every channel from ``source_tier`` (PNG) into ``target_tier``
+    (PNG) on the per-file substrate.
+
+    Reads source channels via plain HTTPS GET on the resolve URL,
+    runs PIL ``Image.resize(LANCZOS)``, writes the smaller PNG back at
+    ``<source>/<target_tier>/<mid>/<channel>.png``. Pre-flight HEAD-probes
+    the target paths so re-runs are bytes-free for already-derived
+    materials.
+
+    The catalog (``<source>.json``) is fetched, every derived id has
+    ``target_tier`` appended to its ``available_tiers``, and the file
+    is committed. The final commit is a zero-byte
+    ``<source>/<target_tier>/.tier_complete`` sentinel — clients can
+    HEAD this single path to assert tier-level atomicity.
+
+    Refuses upscale (would silently invent pixels): a target px larger
+    than the source px raises ``ValueError`` before any HF traffic.
+    """
+    if target_tier not in TIER_TO_PX:
+        raise ValueError(f"unknown target tier {target_tier!r}")
+    if source_tier not in TIER_TO_PX:
+        raise ValueError(f"unknown source tier {source_tier!r}")
+    if TIER_TO_PX[source_tier] < TIER_TO_PX[target_tier]:
+        raise ValueError(
+            f"source tier {source_tier!r} ({TIER_TO_PX[source_tier]}px) is smaller than "
+            f"target {target_tier!r} ({TIER_TO_PX[target_tier]}px) — upscaling not supported"
+        )
+
+    target_px = TIER_TO_PX[target_tier]
+    transform = lambda raw: _resize_png(raw, target_px)  # noqa: E731
+
+    return _derive_driver(
+        source=source,
+        source_tier=source_tier,
+        target_tier=target_tier,
+        release_tag=release_tag,
+        work_dir=work_dir,
+        repo_id=repo_id,
+        transform=transform,
+        target_ext="png",
+        label=f"derive resize→{target_tier}",
+        hf_token=hf_token,
+        dry_run=dry_run,
+        allow_prod=allow_prod,
+        limit=limit,
+        batch_size=batch_size,
+        on_progress=on_progress,
+    )
+
+
+def derive_ktx2_tier(
+    source: str,
+    source_tier: str,
+    target_tier: str,
+    release_tag: str,
+    work_dir: Path,
+    repo_id: str,
+    *,
+    hf_token: str | None = None,
+    dry_run: bool = False,
+    allow_prod: bool = False,
+    limit: int | None = None,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    on_progress: Callable[[dict], None] | None = None,
+) -> dict:
+    """Transcode every channel from ``source_tier`` (PNG) into
+    ``target_tier`` (KTX2) on the per-file substrate.
+
+    ``target_tier`` is a free-form tier label — the convention chosen
+    here is ``ktx2-<source_tier>`` (e.g. source_tier='1k' →
+    target_tier='ktx2-1k'), matching the legacy ADR-0007 path that
+    nested KTX2 outputs under a ``ktx2-…`` namespace. The CLI / Dagger
+    wrappers default to that convention but the function accepts any
+    label.
+
+    Requires ``toktx`` on ``PATH`` (KTX-Software). Fails loudly with
+    a clear install hint at the first transcode attempt; we don't
+    pre-flight ``toktx --version`` because the per-channel ``run`` is
+    the only time it's actually invoked.
+    """
+    if source_tier not in TIER_TO_PX:
+        raise ValueError(f"unknown source tier {source_tier!r}")
+    # target_tier is intentionally not in TIER_TO_PX — KTX2 names
+    # diverge from the resize tier vocabulary.
+
+    return _derive_driver(
+        source=source,
+        source_tier=source_tier,
+        target_tier=target_tier,
+        release_tag=release_tag,
+        work_dir=work_dir,
+        repo_id=repo_id,
+        transform=_ktx2_transcode,
+        target_ext="ktx2",
+        label=f"derive ktx2→{target_tier}",
+        hf_token=hf_token,
+        dry_run=dry_run,
+        allow_prod=allow_prod,
+        limit=limit,
+        batch_size=batch_size,
+        on_progress=on_progress,
+    )

--- a/tests/e2e/test_per_file_roundtrip.py
+++ b/tests/e2e/test_per_file_roundtrip.py
@@ -333,3 +333,154 @@ class TestDaggerBakeRoutingSmoke:
                 )
             except Exception as e:  # noqa: BLE001
                 print(f"dagger e2e cleanup warn: {type(e).__name__}: {e}")
+
+
+# ── #204 slice: per-file derive (resize + ktx2) round-trip ──────────
+
+
+class TestDeriveResizeRoundTrip:
+    """Bake @1k → derive 1k → 512 (resize) → assert per-file PNGs land
+    + .tier_complete sentinel + catalog reflects the new tier."""
+
+    DERIVE_TAG = "v0.0.0-e2e-204-derive"
+    DERIVE_TARGET = "512"
+
+    def test_derive_resize_writes_per_file_pngs_and_sentinel(self, baked_tag) -> None:
+        from huggingface_hub import HfApi
+
+        from mat_vis_baker.hf_derive_per_file import derive_smaller_tier
+
+        token = _hf_token()
+        # Bake into a fresh tag so cleanup is a single delete-branch call.
+        # Reuse baked_tag's two materials by cloning the SOURCE/TIER subtree
+        # via a re-bake against DERIVE_TAG.
+        from mat_vis_baker.hf_bake import bake_one
+
+        with tempfile.TemporaryDirectory() as td:
+            r = bake_one(
+                source=SOURCE,
+                tier=TIER,
+                release_tag=self.DERIVE_TAG,
+                work_dir=Path(td),
+                repo_id=REPO,
+                hf_token=token,
+                limit=2,
+                batch_size=2,
+            )
+        assert r.get("ok", 0) == 2, f"setup bake failed: {r}"
+
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                result = derive_smaller_tier(
+                    source=SOURCE,
+                    source_tier=TIER,
+                    target_tier=self.DERIVE_TARGET,
+                    release_tag=self.DERIVE_TAG,
+                    work_dir=Path(td),
+                    repo_id=REPO,
+                    hf_token=token,
+                    batch_size=2,
+                )
+            assert result.get("ok", 0) >= 1, f"derive failed: {result}"
+
+            # Tree probe — at least one color.png and the sentinel.
+            api = HfApi(token=token)
+            tree = list(
+                api.list_repo_tree(
+                    repo_id=REPO,
+                    repo_type="dataset",
+                    revision=self.DERIVE_TAG,
+                    path_in_repo=f"{SOURCE}/{self.DERIVE_TARGET}",
+                    recursive=True,
+                )
+            )
+            paths = {getattr(e, "path", "") for e in tree}
+            assert any(p.endswith("/color.png") for p in paths), (
+                f"no derived color.png in tree: {sorted(paths)[:10]}"
+            )
+            assert f"{SOURCE}/{self.DERIVE_TARGET}/.tier_complete" in paths
+
+            # HTTP GET on a derived PNG returns valid PNG bytes.
+            png_paths = [p for p in paths if p.endswith("/color.png")]
+            body = _http_get(_resolve_url(png_paths[0], tag=self.DERIVE_TAG))
+            assert body.startswith(b"\x89PNG\r\n\x1a\n"), "derived must be PNG"
+        finally:
+            try:
+                HfApi(token=token).delete_branch(
+                    repo_id=REPO, repo_type="dataset", branch=self.DERIVE_TAG
+                )
+            except Exception as e:  # noqa: BLE001
+                print(f"derive e2e cleanup warn: {type(e).__name__}: {e}")
+
+
+class TestDeriveKtx2RoundTrip:
+    """Bake @1k → transcode 1k → ktx2-1k → assert KTX2 bytes land."""
+
+    DERIVE_TAG = "v0.0.0-e2e-204-ktx2"
+    KTX2_TARGET = "ktx2-1k"
+
+    def test_derive_ktx2_writes_per_file_ktx2_and_sentinel(self) -> None:
+        import shutil
+
+        if not shutil.which("toktx"):
+            pytest.skip("toktx not on PATH — install KTX-Software for the ktx2 e2e")
+
+        from huggingface_hub import HfApi
+
+        from mat_vis_baker.hf_bake import bake_one
+        from mat_vis_baker.hf_derive_per_file import derive_ktx2_tier
+
+        token = _hf_token()
+
+        with tempfile.TemporaryDirectory() as td:
+            r = bake_one(
+                source=SOURCE,
+                tier=TIER,
+                release_tag=self.DERIVE_TAG,
+                work_dir=Path(td),
+                repo_id=REPO,
+                hf_token=token,
+                limit=2,
+                batch_size=2,
+            )
+        assert r.get("ok", 0) == 2, f"setup bake failed: {r}"
+
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                result = derive_ktx2_tier(
+                    source=SOURCE,
+                    source_tier=TIER,
+                    target_tier=self.KTX2_TARGET,
+                    release_tag=self.DERIVE_TAG,
+                    work_dir=Path(td),
+                    repo_id=REPO,
+                    hf_token=token,
+                    batch_size=2,
+                )
+            assert result.get("ok", 0) >= 1, f"ktx2 derive failed: {result}"
+
+            api = HfApi(token=token)
+            tree = list(
+                api.list_repo_tree(
+                    repo_id=REPO,
+                    repo_type="dataset",
+                    revision=self.DERIVE_TAG,
+                    path_in_repo=f"{SOURCE}/{self.KTX2_TARGET}",
+                    recursive=True,
+                )
+            )
+            paths = {getattr(e, "path", "") for e in tree}
+            ktx_files = [p for p in paths if p.endswith(".ktx2")]
+            assert ktx_files, f"no .ktx2 files in tree: {sorted(paths)[:10]}"
+            assert f"{SOURCE}/{self.KTX2_TARGET}/.tier_complete" in paths
+
+            # Magic-byte probe on one ktx2 file.
+            body = _http_get(_resolve_url(ktx_files[0], tag=self.DERIVE_TAG))
+            assert body.startswith(b"\xabKTX 20\xbb\r\n\x1a\n"), "must be KTX2"
+        finally:
+            try:
+                HfApi(token=token).delete_branch(
+                    repo_id=REPO, repo_type="dataset", branch=self.DERIVE_TAG
+                )
+            except Exception as e:  # noqa: BLE001
+                print(f"ktx2 e2e cleanup warn: {type(e).__name__}: {e}")

--- a/tests/test_hf_derive_per_file.py
+++ b/tests/test_hf_derive_per_file.py
@@ -1,0 +1,425 @@
+"""Tests for ``mat_vis_baker.hf_derive_per_file`` (#204 / ADR-0012).
+
+Pure-Python — every HfApi / HTTP call is mocked. No live network.
+
+Covers the load-bearing properties of the per-file derive pipeline:
+
+1. ``_guard_prod_target`` refuses prod repos without ``--allow-prod``.
+2. The catalog's ``available_tiers`` is updated for every derived id.
+3. Pre-flight HEAD probes on the target tier skip already-derived
+   materials (no source GET, no resize work).
+4. The ``.tier_complete`` sentinel is the *last* commit in the run.
+5. ``dry_run=True`` makes no ``create_commit`` calls.
+6. Magic-byte verification rejects non-PNG source bytes and
+   non-KTX2 transformed bytes.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PIL import Image
+
+from mat_vis_baker.hf_derive_per_file import (
+    _extend_available_tiers,
+    _resize_png,
+    derive_ktx2_tier,
+    derive_smaller_tier,
+)
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+KTX2_MAGIC = b"\xabKTX 20\xbb\r\n\x1a\n"
+
+
+def _make_png(size: int = 32) -> bytes:
+    """Real PNG bytes — PIL needs to actually decode them."""
+    img = Image.new("RGB", (size, size), color=(120, 80, 60))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _fake_tree_entry(path: str) -> SimpleNamespace:
+    return SimpleNamespace(path=path)
+
+
+# ── _extend_available_tiers ──────────────────────────────────
+
+
+class TestExtendAvailableTiers:
+    def test_appends_target_tier_to_matched_entries(self) -> None:
+        catalog = [
+            {"id": "mat_a", "available_tiers": ["1k"]},
+            {"id": "mat_b", "available_tiers": ["1k"]},
+            {"id": "mat_c", "available_tiers": ["1k"]},
+        ]
+        out = _extend_available_tiers(catalog, {"mat_a", "mat_b"}, "512")
+        assert out[0]["available_tiers"] == ["1k", "512"]
+        assert out[1]["available_tiers"] == ["1k", "512"]
+        assert out[2]["available_tiers"] == ["1k"]
+
+    def test_idempotent_when_tier_already_listed(self) -> None:
+        catalog = [{"id": "mat_a", "available_tiers": ["1k", "512"]}]
+        out = _extend_available_tiers(catalog, {"mat_a"}, "512")
+        # No duplicate appended.
+        assert out[0]["available_tiers"] == ["1k", "512"]
+
+    def test_handles_missing_available_tiers_field(self) -> None:
+        catalog = [{"id": "mat_a"}]  # no available_tiers key
+        out = _extend_available_tiers(catalog, {"mat_a"}, "512")
+        assert out[0]["available_tiers"] == ["512"]
+
+
+# ── prod guard ──────────────────────────────────────────────
+
+
+class TestProdGuard:
+    def test_refuses_prod_repo_without_allow_prod(self, tmp_path) -> None:
+        with pytest.raises(ValueError, match="allow_prod"):
+            derive_smaller_tier(
+                source="polyhaven",
+                source_tier="4k",
+                target_tier="1k",
+                release_tag="v2026.05.0",
+                work_dir=tmp_path,
+                repo_id="gerchowl/mat-vis",  # prod — refuse
+            )
+
+    def test_refuses_prod_repo_for_ktx2_too(self, tmp_path) -> None:
+        with pytest.raises(ValueError, match="allow_prod"):
+            derive_ktx2_tier(
+                source="polyhaven",
+                source_tier="1k",
+                target_tier="ktx2-1k",
+                release_tag="v2026.05.0",
+                work_dir=tmp_path,
+                repo_id="gerchowl/mat-vis",
+            )
+
+
+# ── upscale guard ───────────────────────────────────────────
+
+
+class TestUpscaleGuard:
+    def test_refuses_upscale(self, tmp_path) -> None:
+        with pytest.raises(ValueError, match="upscaling not supported"):
+            derive_smaller_tier(
+                source="polyhaven",
+                source_tier="512",  # 512 px
+                target_tier="1k",  # 1024 px — would invent pixels
+                release_tag="v0.0.0",
+                work_dir=tmp_path,
+                repo_id="gerchowl/mat-vis-tst",
+            )
+
+
+# ── derive_smaller_tier integration (mocked) ────────────────
+
+
+def _patch_http_for_derive(*, png_bytes: bytes, target_existing: set[str]):
+    """Build patches for the HTTP helpers used by the driver.
+
+    - GETs: catalog fetch returns a stub catalog; everything else
+      returns ``png_bytes``.
+    - HEADs: True iff URL is in ``target_existing``.
+    """
+
+    def _get(url, *, token=None, timeout=120):  # noqa: ARG001
+        if url.endswith(".json"):
+            return json.dumps(
+                [{"id": f"mat_{i}", "available_tiers": ["1k"]} for i in range(3)]
+            ).encode("utf-8")
+        return png_bytes
+
+    def _head(url, *, token=None, timeout=30):  # noqa: ARG001
+        return url in target_existing
+
+    return _get, _head
+
+
+class TestDeriveSmallerTier:
+    def _setup_api(self, mids: list[str], channels: list[str]) -> MagicMock:
+        api = MagicMock()
+        # Tree of source tier: one entry per (mid, channel).
+        tree = []
+        for m in mids:
+            for ch in channels:
+                tree.append(_fake_tree_entry(f"polyhaven/1k/{m}/{ch}.png"))
+
+        def _list(repo_id, repo_type, revision, path_in_repo, recursive=False, **kw):
+            return [e for e in tree if e.path.startswith(path_in_repo.rstrip("/") + "/")]
+
+        api.list_repo_tree.side_effect = _list
+        commit = SimpleNamespace(oid="deadbeef" * 5, commit_oid="deadbeef" * 5)
+        api.create_commit.return_value = commit
+        return api
+
+    def test_happy_path_resize_writes_per_file_then_catalog_then_sentinel(self, tmp_path) -> None:
+        png = _make_png(64)
+        api = self._setup_api(["mat_0", "mat_1"], ["color", "normal"])
+        get, head = _patch_http_for_derive(png_bytes=png, target_existing=set())
+
+        with (
+            patch("mat_vis_baker.hf_derive_per_file.HfApi", return_value=api),
+            patch("mat_vis_baker.hf_derive_per_file._http_get", side_effect=get),
+            patch("mat_vis_baker.hf_derive_per_file._http_head_ok", side_effect=head),
+        ):
+            result = derive_smaller_tier(
+                source="polyhaven",
+                source_tier="1k",
+                target_tier="512",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                repo_id="gerchowl/mat-vis-tst",
+            )
+
+        assert result["ok"] == 2
+        assert result["failed"] == 0
+
+        # Verify commit ordering: textures → catalog → sentinel (last).
+        calls = api.create_commit.call_args_list
+        # Last commit MUST be the sentinel.
+        last_ops = calls[-1].kwargs["operations"]
+        assert len(last_ops) == 1
+        assert last_ops[0].path_in_repo == "polyhaven/512/.tier_complete"
+
+        # Catalog commit is the second-to-last.
+        catalog_ops = calls[-2].kwargs["operations"]
+        assert len(catalog_ops) == 1
+        assert catalog_ops[0].path_in_repo == "polyhaven.json"
+
+        # And the catalog body has the new tier appended.
+        catalog_bytes = catalog_ops[0].path_or_fileobj
+        catalog = json.loads(catalog_bytes)
+        for entry in catalog:
+            if entry["id"] in {"mat_0", "mat_1"}:
+                assert "512" in entry["available_tiers"], entry
+
+        # Texture batch commits should land target-tier paths.
+        texture_paths = [op.path_in_repo for c in calls[:-2] for op in c.kwargs["operations"]]
+        for m in ("mat_0", "mat_1"):
+            for ch in ("color", "normal"):
+                assert f"polyhaven/512/{m}/{ch}.png" in texture_paths
+
+    def test_preflight_skip_short_circuits_already_derived(self, tmp_path) -> None:
+        """A material whose target files all already exist (HEAD ok)
+        must NOT be re-resized — no source GET for its channels."""
+        png = _make_png(64)
+        api = self._setup_api(["mat_0", "mat_1"], ["color"])
+
+        # Pretend mat_0's target file is already on HF.
+        existing = {
+            "https://huggingface.co/datasets/gerchowl/mat-vis-tst/resolve/v0.0.0-test"
+            "/polyhaven/512/mat_0/color.png"
+        }
+
+        get_calls: list[str] = []
+
+        def _get(url, *, token=None, timeout=120):
+            get_calls.append(url)
+            if url.endswith(".json"):
+                return json.dumps(
+                    [{"id": f"mat_{i}", "available_tiers": ["1k"]} for i in range(2)]
+                ).encode("utf-8")
+            return png
+
+        def _head(url, *, token=None, timeout=30):
+            return url in existing
+
+        with (
+            patch("mat_vis_baker.hf_derive_per_file.HfApi", return_value=api),
+            patch("mat_vis_baker.hf_derive_per_file._http_get", side_effect=_get),
+            patch("mat_vis_baker.hf_derive_per_file._http_head_ok", side_effect=_head),
+        ):
+            result = derive_smaller_tier(
+                source="polyhaven",
+                source_tier="1k",
+                target_tier="512",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                repo_id="gerchowl/mat-vis-tst",
+            )
+
+        # mat_0 skipped, mat_1 derived.
+        assert result["skipped_preflight"] == 1
+        assert result["ok"] == 1
+
+        # No source GET on the skipped material's channel.
+        skipped_url = (
+            "https://huggingface.co/datasets/gerchowl/mat-vis-tst/resolve/v0.0.0-test"
+            "/polyhaven/1k/mat_0/color.png"
+        )
+        assert skipped_url not in get_calls, (
+            f"preflight should have skipped mat_0; saw GET {skipped_url}"
+        )
+
+    def test_dry_run_makes_no_commit_calls(self, tmp_path) -> None:
+        png = _make_png(64)
+        api = self._setup_api(["mat_0"], ["color"])
+        get, head = _patch_http_for_derive(png_bytes=png, target_existing=set())
+
+        with (
+            patch("mat_vis_baker.hf_derive_per_file.HfApi", return_value=api),
+            patch("mat_vis_baker.hf_derive_per_file._http_get", side_effect=get),
+            patch("mat_vis_baker.hf_derive_per_file._http_head_ok", side_effect=head),
+        ):
+            result = derive_smaller_tier(
+                source="polyhaven",
+                source_tier="1k",
+                target_tier="512",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                repo_id="gerchowl/mat-vis-tst",
+                dry_run=True,
+            )
+
+        assert result["ok"] == 1
+        api.create_commit.assert_not_called()
+
+    def test_rejects_non_png_source_bytes(self, tmp_path) -> None:
+        """A material whose source GET returns garbage (HTML 404 served
+        as 200, etc.) must fail magic-byte verification, not crash PIL
+        with an opaque error or commit garbage downstream."""
+        api = self._setup_api(["mat_0"], ["color"])
+
+        def _get(url, *, token=None, timeout=120):
+            if url.endswith(".json"):
+                return b"[]"
+            return b"<html>404 not found</html>"  # NOT a PNG
+
+        with (
+            patch("mat_vis_baker.hf_derive_per_file.HfApi", return_value=api),
+            patch("mat_vis_baker.hf_derive_per_file._http_get", side_effect=_get),
+            patch("mat_vis_baker.hf_derive_per_file._http_head_ok", return_value=False),
+        ):
+            result = derive_smaller_tier(
+                source="polyhaven",
+                source_tier="1k",
+                target_tier="512",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                repo_id="gerchowl/mat-vis-tst",
+            )
+
+        # No ops produced → material counted as failed.
+        assert result["ok"] == 0
+        assert result["failed"] == 1
+
+
+# ── derive_ktx2_tier ────────────────────────────────────────
+
+
+class TestDeriveKtx2Tier:
+    def _setup_api(self) -> MagicMock:
+        api = MagicMock()
+        tree = [
+            _fake_tree_entry("polyhaven/1k/mat_0/color.png"),
+            _fake_tree_entry("polyhaven/1k/mat_0/normal.png"),
+        ]
+
+        def _list(repo_id, repo_type, revision, path_in_repo, recursive=False, **kw):
+            return [e for e in tree if e.path.startswith(path_in_repo.rstrip("/") + "/")]
+
+        api.list_repo_tree.side_effect = _list
+        api.create_commit.return_value = SimpleNamespace(oid="cafebabe" * 5)
+        return api
+
+    def test_ktx2_transcode_writes_ktx2_files_and_sentinel_last(self, tmp_path) -> None:
+        png = _make_png(64)
+        api = self._setup_api()
+
+        def _get(url, *, token=None, timeout=120):
+            if url.endswith(".json"):
+                return b"[]"
+            return png
+
+        # Stub out toktx — return KTX2-magic bytes from the transform.
+        def _fake_transcode(raw):  # noqa: ARG001
+            return KTX2_MAGIC + b"\x00\x01\x02\x03"
+
+        with (
+            patch("mat_vis_baker.hf_derive_per_file.HfApi", return_value=api),
+            patch("mat_vis_baker.hf_derive_per_file._http_get", side_effect=_get),
+            patch("mat_vis_baker.hf_derive_per_file._http_head_ok", return_value=False),
+            patch(
+                "mat_vis_baker.hf_derive_per_file._ktx2_transcode",
+                side_effect=_fake_transcode,
+            ),
+        ):
+            result = derive_ktx2_tier(
+                source="polyhaven",
+                source_tier="1k",
+                target_tier="ktx2-1k",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                repo_id="gerchowl/mat-vis-tst",
+            )
+
+        assert result["ok"] == 1
+        # Last commit is the sentinel.
+        last_ops = api.create_commit.call_args_list[-1].kwargs["operations"]
+        assert last_ops[0].path_in_repo == "polyhaven/ktx2-1k/.tier_complete"
+
+        # All texture commits use .ktx2 extension.
+        all_paths = [
+            op.path_in_repo
+            for c in api.create_commit.call_args_list
+            for op in c.kwargs["operations"]
+        ]
+        ktx_paths = [p for p in all_paths if p.startswith("polyhaven/ktx2-1k/mat_0/")]
+        assert {"polyhaven/ktx2-1k/mat_0/color.ktx2", "polyhaven/ktx2-1k/mat_0/normal.ktx2"} == set(
+            ktx_paths
+        )
+
+    def test_rejects_transform_output_lacking_ktx2_magic(self, tmp_path) -> None:
+        """A toktx that silently returns a PNG (or empty bytes) must
+        not get committed under a .ktx2 path."""
+        png = _make_png(64)
+        api = self._setup_api()
+
+        def _get(url, *, token=None, timeout=120):
+            if url.endswith(".json"):
+                return b"[]"
+            return png
+
+        with (
+            patch("mat_vis_baker.hf_derive_per_file.HfApi", return_value=api),
+            patch("mat_vis_baker.hf_derive_per_file._http_get", side_effect=_get),
+            patch("mat_vis_baker.hf_derive_per_file._http_head_ok", return_value=False),
+            patch(
+                "mat_vis_baker.hf_derive_per_file._ktx2_transcode",
+                # Return PNG-magic bytes (definitely not KTX2). Magic-byte
+                # gate must reject this before commit.
+                side_effect=lambda raw: PNG_MAGIC + b"\x00",
+            ),
+        ):
+            result = derive_ktx2_tier(
+                source="polyhaven",
+                source_tier="1k",
+                target_tier="ktx2-1k",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                repo_id="gerchowl/mat-vis-tst",
+            )
+
+        assert result["ok"] == 0
+        assert result["failed"] == 1
+
+
+# ── transform unit ──────────────────────────────────────────
+
+
+class TestResizeTransform:
+    def test_lanczos_resize_produces_valid_png_at_target_size(self) -> None:
+        """The resize transform must produce a PNG of the requested
+        size — guards against a refactor that swaps LANCZOS for a
+        broken filter or forgets the .save(format='PNG') call."""
+        src = _make_png(256)
+        out = _resize_png(src, 64)
+        assert out.startswith(PNG_MAGIC)
+        img = Image.open(io.BytesIO(out))
+        assert img.size == (64, 64)


### PR DESCRIPTION
## Summary

Resurrects the `hf-derive` capability that #189 (PR #203) deleted alongside the tar substrate. The per-file substrate (ADR-0012) made the legacy 615-LOC `hf_derive.py` structurally obsolete, but it left a real capability gap: there was no way to bake at 4k once and derive 1k/2k/ktx2 tiers from it without a fresh upstream fetch. This PR closes that gap on the per-file substrate.

Closes #204.

### Per-file derive algorithm

1. List source-tier materials via `HfApi.list_repo_tree` on `<source>/<source_tier>/`.
2. For each material, **HEAD-probe** every expected target path on the resolve URL — skip materials whose entire channel set already exists at the target tier (resume-by-default).
3. Read each missing source channel via plain HTTPS GET on `<source>/<source_tier>/<mid>/<channel>.png`.
4. Magic-byte verify the source bytes (refuses HTML 404 served as 200), transform (PIL `Image.resize(LANCZOS)` for resize, `toktx --encode uastc --genmipmap --t2` for ktx2), magic-byte verify the produced bytes.
5. Buffer `CommitOperationAdd` ops; flush every `batch_size` materials as one atomic HF commit.
6. After all batches: fetch `<source>.json`, append `target_tier` to each derived material's `available_tiers`, commit. Then write `<source>/<target_tier>/.tier_complete` as the final sentinel commit.

### KTX2 naming convention

`hf-derive-ktx2 --target-tier` defaults to `ktx2-<source-tier>` (e.g. source 1k → target `ktx2-1k`), matching the ADR-0007 namespace convention. The CLI / Dagger wrapper accepts an explicit `--target-tier` override; the function takes any free-form label since KTX2 names diverge from the resize tier vocabulary.

### What's not back

The tar / shard / merge-shards plumbing stays deleted. The per-file pre-flight HEAD probe is the resume primitive (commit batches are durable checkpoints), so the legacy matrix sharding is unnecessary. `derive.yml` is therefore single-job-per-source instead of matrix-fan-out.

## Verification gates

All four gates pass:

- [x] `mat-vis-baker hf-derive --help` and `mat-vis-baker hf-derive-ktx2 --help` render correctly.
- [x] `just test-fast` passes locally (327 baker + 211 client tests, 36 skipped).
- [x] `cargo test` clean (15 passed; no Rust changes).
- [x] `grep -rn 'hf_derive\|hf-derive' src/ .dagger/ .github/workflows/` shows consistent additions across CLI, Dagger, and the workflow.

The new `hf_derive_per_file.py` is 739 LOC. That's above the issue's 300-500 estimate; the extra 200ish LOC is the explicit magic-byte verification, on-progress callback plumbing, channel discovery via tree listing (so we don't waste GETs on channels the source omits), and the dual-API guard tests.

## Test plan

- [x] Local `just test-fast` — 538 tests, 0 failures.
- [x] Pre-push hook ran end-to-end (visible in the push log).
- [ ] **MAT_VIS_E2E=1 round-trip** — opt in with `MAT_VIS_E2E=1 HF_TOKEN=... uv run pytest tests/e2e/test_per_file_roundtrip.py -v`. New cases: `TestDeriveResizeRoundTrip` (bake @1k → derive 1k → 512, assert PNG + sentinel), `TestDeriveKtx2RoundTrip` (bake @1k → transcode 1k → ktx2-1k, assert KTX2 magic + sentinel). Both auto-clean their throwaway tags. The ktx2 case auto-skips when `toktx` isn't on PATH.
- [ ] Dagger smoke (manual, off-CI): `dagger call derive --context=. --source=polyhaven --source-tier=1k --target-tier=512 --release-tag=v0.0.0-smoke --hf-token=env:HF_TOKEN --dry-run=true --limit=1`.

## Files

**Added**: `src/mat_vis_baker/hf_derive_per_file.py`, `tests/test_hf_derive_per_file.py`, `.github/workflows/derive.yml`.
**Edited**: `src/mat_vis_baker/__main__.py` (CLI subparsers + dispatch), `.dagger/src/mat_vis_ci/main.py` (`derive` / `derive_ktx2` Dagger functions; `_baker_container` regains `with_ktx2` toggle), `tests/e2e/test_per_file_roundtrip.py` (#204 e2e slice).