### PR TITLE
fix(baker): per-file derive must update release-manifest.json (#207)

### DIFF
--- a/src/mat_vis_baker/hf_derive_per_file.py
+++ b/src/mat_vis_baker/hf_derive_per_file.py
@@ -544,36 +544,77 @@ def _derive_driver(
             "skipped_preflight": 0,
         }
 
-    # ── catalog update ────────────────────────────────────────
+    # ── catalog + manifest update (atomic, CAS-retried) ──────
+    # Mirror the bake's #207 fix: single commit covers catalog +
+    # release-manifest.json with parent_commit guarding against
+    # matrix-write races (multiple derives may run on the same tag).
+    from mat_vis_baker.hf_bake_per_file import (
+        _fetch_manifest_with_parent,
+        _merge_manifest_for_source,
+    )
+
     catalog = _fetch_catalog(repo_id, release_tag, source, hf_token)
     if catalog:
         _extend_available_tiers(catalog, derived_ids, target_tier)
         catalog_bytes = (json.dumps(catalog, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
         if dry_run:
             log.info(
-                "%s dry-run: would commit updated %s.json (%d entries touched)",
+                "%s dry-run: would commit updated %s.json + manifest (%d entries touched)",
                 label,
                 source,
                 len(derived_ids),
             )
         else:
-            commit = api.create_commit(
-                repo_id=repo_id,
-                repo_type="dataset",
-                operations=[
-                    CommitOperationAdd(
-                        path_in_repo=f"{source}.json",
-                        path_or_fileobj=catalog_bytes,
+            max_retries = 6
+            for attempt in range(max_retries):
+                manifest, parent_sha = _fetch_manifest_with_parent(api, repo_id, release_tag)
+                merged = _merge_manifest_for_source(manifest, source, target_tier, release_tag)
+                manifest_bytes = (json.dumps(merged, indent=2, ensure_ascii=False) + "\n").encode(
+                    "utf-8"
+                )
+                try:
+                    commit = api.create_commit(
+                        repo_id=repo_id,
+                        repo_type="dataset",
+                        operations=[
+                            CommitOperationAdd(
+                                path_in_repo=f"{source}.json",
+                                path_or_fileobj=catalog_bytes,
+                            ),
+                            CommitOperationAdd(
+                                path_in_repo="release-manifest.json",
+                                path_or_fileobj=manifest_bytes,
+                            ),
+                        ],
+                        commit_message=(
+                            f"feat(data): {release_tag} — {source} catalog + manifest "
+                            f"({target_tier} added)"
+                        ),
+                        revision=release_tag,
+                        parent_commit=parent_sha,
                     )
-                ],
-                commit_message=(
-                    f"feat(data): {release_tag} — {source}.json + available_tiers += {target_tier}"
-                ),
-                revision=release_tag,
-            )
-            last_commit_sha = (
-                getattr(commit, "oid", "") or getattr(commit, "commit_oid", "") or last_commit_sha
-            )
+                    last_commit_sha = (
+                        getattr(commit, "oid", "")
+                        or getattr(commit, "commit_oid", "")
+                        or last_commit_sha
+                    )
+                    break
+                except Exception as e:  # noqa: BLE001
+                    msg = str(e).lower()
+                    if "412" in msg or "precondition" in msg or "parent_commit" in msg:
+                        if attempt + 1 == max_retries:
+                            log.error(
+                                "%s manifest CAS exhausted after %d retries", label, max_retries
+                            )
+                            raise
+                        log.warning(
+                            "%s manifest CAS retry %d/%d — concurrent writer detected",
+                            label,
+                            attempt + 1,
+                            max_retries,
+                        )
+                        continue
+                    raise
     else:
         log.info("%s: no catalog fetched (empty or missing); skipping catalog update", label)
 

--- a/tests/test_hf_derive_per_file.py
+++ b/tests/test_hf_derive_per_file.py
@@ -187,17 +187,29 @@ class TestDeriveSmallerTier:
         assert len(last_ops) == 1
         assert last_ops[0].path_in_repo == "polyhaven/512/.tier_complete"
 
-        # Catalog commit is the second-to-last.
+        # Catalog commit is the second-to-last; it now also bundles the
+        # release-manifest update (#207-style atomicity, parent_commit
+        # CAS-retry).
         catalog_ops = calls[-2].kwargs["operations"]
-        assert len(catalog_ops) == 1
-        assert catalog_ops[0].path_in_repo == "polyhaven.json"
+        catalog_paths = {op.path_in_repo for op in catalog_ops}
+        assert catalog_paths == {"polyhaven.json", "release-manifest.json"}, catalog_paths
+        assert "parent_commit" in calls[-2].kwargs
 
         # And the catalog body has the new tier appended.
-        catalog_bytes = catalog_ops[0].path_or_fileobj
+        catalog_bytes = next(
+            op.path_or_fileobj for op in catalog_ops if op.path_in_repo == "polyhaven.json"
+        )
         catalog = json.loads(catalog_bytes)
         for entry in catalog:
             if entry["id"] in {"mat_0", "mat_1"}:
                 assert "512" in entry["available_tiers"], entry
+
+        # Manifest body lists the derived tier under the source.
+        manifest_bytes = next(
+            op.path_or_fileobj for op in catalog_ops if op.path_in_repo == "release-manifest.json"
+        )
+        manifest = json.loads(manifest_bytes)
+        assert manifest["sources"]["polyhaven"]["tiers"]["512"] == {"complete": True}
 
         # Texture batch commits should land target-tier paths.
         texture_paths = [op.path_in_repo for c in calls[:-2] for op in c.kwargs["operations"]]


### PR DESCRIPTION
## Summary

Live anvil-dev dagger smoke uncovered: after a successful per-file derive (1k → 512), the derived tier appeared in the source catalog's \`available_tiers\` but NOT in \`release-manifest.json\`'s \`sources.<src>.tiers\` block. JS / shell / Rust clients (which fetch the static manifest) couldn't see derived tiers until a re-bake; Python masked it with the tree-fallback.

Same root cause family as #208 (bake-side manifest emission). This PR mirrors that fix on the derive side.

### What changed

\`hf_derive_per_file.py\` now bundles the catalog update + manifest update into a single \`create_commit\` call with \`parent_commit\` for CAS retry (matrix derives won't trample each other). Reuses \`_fetch_manifest_with_parent\` and \`_merge_manifest_for_source\` from \`hf_bake_per_file.py\` for parity.

### Verified live (anvil-dev, gerchowl/mat-vis-tst)

| | Before | After |
|---|---|---|
| Bake polyhaven 1k | \`tiers: {1k}\` ✓ | \`tiers: {1k}\` ✓ |
| Derive 1k → 512 | catalog \`["1k","512"]\` ✓; manifest still \`{1k}\` ✗ | both correct |
| JS/shell/Rust visibility of 512 | invisible | visible |

### Test plan

- [x] \`just test-fast\` — 327 baker + 211 client = 538 pass
- [x] \`TestDeriveSmallerTier\` updated to assert the bundled commit + parent_commit + manifest body
- [x] Live anvil-dev re-run after fix
- [ ] CI: matrix tests + integration test