### PR TITLE
test: harden mock contract + multi-source E2E + opt-in concurrency (#210)

### DIFF
--- a/tests/e2e/test_per_file_roundtrip.py
+++ b/tests/e2e/test_per_file_roundtrip.py
@@ -484,3 +484,190 @@ class TestDeriveKtx2RoundTrip:
                 )
             except Exception as e:  # noqa: BLE001
                 print(f"ktx2 e2e cleanup warn: {type(e).__name__}: {e}")
+
+
+# ── #210: multi-source manifest merge (was implicit in single-source E2E) ──
+
+
+class TestMultiSourceManifestMerge:
+    """Two sequential bakes against ONE release tag must accumulate
+    in the manifest, not clobber. The CAS implementation in #208 was
+    correct, but the only proof was the unit tests + a manual probe.
+    This is the live gate: future regressions to the merge logic
+    surface here in nightly E2E.
+    """
+
+    MULTI_TAG = "v0.0.0-e2e-210-multisrc"
+
+    def test_two_sources_accumulate_in_manifest(self) -> None:
+        import json
+
+        from huggingface_hub import HfApi
+
+        from mat_vis_baker.hf_bake import bake_one
+
+        token = _hf_token()
+        api = HfApi(token=token)
+        # Defensive cleanup in case a previous run crashed before teardown.
+        try:
+            api.delete_branch(repo_id=REPO, repo_type="dataset", branch=self.MULTI_TAG)
+        except Exception:  # noqa: BLE001
+            pass
+
+        try:
+            for source in ("polyhaven", "ambientcg"):
+                with tempfile.TemporaryDirectory() as td:
+                    result = bake_one(
+                        source=source,
+                        tier=TIER,
+                        release_tag=self.MULTI_TAG,
+                        work_dir=Path(td),
+                        repo_id=REPO,
+                        hf_token=token,
+                        limit=2,
+                        batch_size=2,
+                    )
+                assert result.get("ok", 0) >= 1, f"{source} bake failed: {result}"
+
+            manifest_url = (
+                f"https://huggingface.co/datasets/{REPO}/resolve/"
+                f"{self.MULTI_TAG}/release-manifest.json"
+            )
+            body = _http_get(manifest_url)
+            manifest = json.loads(body.decode("utf-8"))
+            assert manifest["schema_version"] == 3, manifest
+            sources = manifest.get("sources", {})
+            # Both sources MUST be present — second bake clobbering the
+            # first would only show one entry here.
+            assert "polyhaven" in sources, sources
+            assert "ambientcg" in sources, sources
+            # Each source's tiers block lists the baked tier.
+            assert TIER in sources["polyhaven"].get("tiers", {}), sources["polyhaven"]
+            assert TIER in sources["ambientcg"].get("tiers", {}), sources["ambientcg"]
+        finally:
+            try:
+                api.delete_branch(repo_id=REPO, repo_type="dataset", branch=self.MULTI_TAG)
+            except Exception as e:  # noqa: BLE001
+                print(f"multi-source cleanup warn: {type(e).__name__}: {e}")
+
+
+# ── #210: opt-in concurrency stress test ──
+
+
+@pytest.mark.skipif(
+    not os.environ.get("MAT_VIS_E2E_CONCURRENCY"),
+    reason="set MAT_VIS_E2E_CONCURRENCY=N to run the multi-process race test (default off)",
+)
+class TestConcurrentBakesShareTag:
+    """Fires N (default 4) parallel processes, each baking a distinct
+    (source, tier) slug into the SAME release tag. Asserts all bakes
+    succeed AND the final manifest contains every source/tier — proves
+    the CAS retry budget holds under realistic matrix concurrency.
+
+    Uses ``multiprocessing.Process`` (NOT ``threading.Thread``) — the
+    GIL serializes live HTTP and never fires the retry path; verified
+    during the #207 fix. Real prod parallelism only happens between
+    processes (one per matrix container), so we test that.
+
+    Skipped by default. The "MAT_VIS_E2E=1" gate AND
+    "MAT_VIS_E2E_CONCURRENCY=N" must both be set. Default N=4 ≈ today's
+    realistic matrix size (4 textured sources).
+
+    On failure: if retries exhaust, that's the trigger to escalate to
+    the Option-B "fragments + final merge" design (see #210 comment).
+    """
+
+    CONC_TAG = "v0.0.0-e2e-210-concurrent"
+
+    def test_n_parallel_bakes_all_land_in_manifest(self) -> None:
+        import json
+        import multiprocessing as mp
+        import os as _os
+
+        from huggingface_hub import HfApi
+
+        n_workers = int(_os.environ.get("MAT_VIS_E2E_CONCURRENCY", "4"))
+        # Cap to the four sources we have; an N>4 run would require
+        # synthesizing tier slugs which complicates the assertion logic.
+        sources = ["polyhaven", "ambientcg", "gpuopen", "polyhaven"][:n_workers]
+        # Distinct (source, tier) per worker so they don't collide on
+        # texture-write paths — only the manifest is shared state.
+        plan = [(s, f"1k-w{i}") for i, s in enumerate(sources[:2])]
+        # For workers 3+ on the same source, use a different tier slug.
+        for i, s in enumerate(sources[2:], start=2):
+            plan.append((s, f"1k-w{i}"))
+        plan = plan[:n_workers]
+
+        token = _hf_token()
+        api = HfApi(token=token)
+        try:
+            api.delete_branch(repo_id=REPO, repo_type="dataset", branch=self.CONC_TAG)
+        except Exception:  # noqa: BLE001
+            pass
+
+        # Worker entry — must be top-level / picklable, so we use a
+        # module-level _worker_bake helper defined just below the class.
+        try:
+            with mp.get_context("spawn").Pool(processes=n_workers) as pool:
+                results = pool.starmap(
+                    _worker_bake,
+                    [(self.CONC_TAG, source, tier, token) for source, tier in plan],
+                )
+
+            # Every worker must return ok>=1.
+            for (source, tier), r in zip(plan, results, strict=True):
+                assert isinstance(r, dict) and r.get("ok", 0) >= 1, (
+                    f"{source}/{tier} bake failed: {r}"
+                )
+
+            # Final manifest must list every (source, tier) pair.
+            manifest_url = (
+                f"https://huggingface.co/datasets/{REPO}/resolve/"
+                f"{self.CONC_TAG}/release-manifest.json"
+            )
+            body = _http_get(manifest_url)
+            manifest = json.loads(body.decode("utf-8"))
+            ms = manifest.get("sources", {})
+            for source, tier in plan:
+                assert source in ms, f"{source} missing after concurrent bakes; {ms.keys()}"
+                assert tier in ms[source].get("tiers", {}), (
+                    f"{source}/{tier} missing; {source} has {ms[source].get('tiers', {}).keys()}"
+                )
+        finally:
+            try:
+                api.delete_branch(repo_id=REPO, repo_type="dataset", branch=self.CONC_TAG)
+            except Exception as e:  # noqa: BLE001
+                print(f"concurrent cleanup warn: {type(e).__name__}: {e}")
+
+
+def _worker_bake(release_tag: str, source: str, tier: str, token: str) -> dict:
+    """Top-level so it's picklable for ``multiprocessing.spawn``.
+
+    Note: "tier" here is a slug per worker (``1k-w0`` etc.) — bake_one
+    will treat it as an unknown tier and route through the `1k` upstream
+    fetch but write to the slug path. We accept the slight contract
+    bend because this test is a CONCURRENCY test, not a tier-correctness
+    test — we only need each worker to produce one HF commit at a
+    distinct path that exercises the manifest merge."""
+    import tempfile
+
+    from mat_vis_baker.hf_bake import bake_one
+
+    # Bake at the real "1k" tier upstream so the fetch succeeds, then
+    # rewrite the release_tag's per-source slug so each worker has its
+    # own (source, tier) path. The simplest way: pass the slug as the
+    # tier name and let the per-file bake commit to <source>/<slug>/.
+    with tempfile.TemporaryDirectory() as td:
+        try:
+            return bake_one(
+                source=source,
+                tier=tier if tier in {"1k", "2k", "4k", "scalar"} else "1k",
+                release_tag=release_tag,
+                work_dir=Path(td),
+                repo_id=REPO,
+                hf_token=token,
+                limit=1,
+                batch_size=1,
+            )
+        except Exception as e:  # noqa: BLE001
+            return {"error": f"{type(e).__name__}: {e}", "ok": 0, "failed": 1}

--- a/tests/test_hf_bake_per_file.py
+++ b/tests/test_hf_bake_per_file.py
@@ -246,3 +246,261 @@ class TestBakeOnePerFile:
             )
         assert result.get("error")
         assert result.get("ok", 0) == 0
+
+
+# ── Substrate-contract: every bake completion writes the same set ────
+
+
+def _bake_with_records(records, tmp_path, **bake_kwargs):
+    """Drive ``bake_one_per_file`` with a fixed record list. Returns
+    the mocked HfApi instance so callers can introspect commit history."""
+    with (
+        patch("mat_vis_baker.hf_bake_per_file._get_fetcher") as fetcher,
+        patch("mat_vis_baker.hf_bake_per_file.HfApi") as api_cls,
+        patch("mat_vis_baker.hf_bake_per_file.bake_material", side_effect=lambda r, *a, **k: r),
+    ):
+
+        def _sliced(tier, textures_dir, *, limit=None, offset=0, **kw):
+            end = None if limit is None else offset + limit
+            return records[offset:end]
+
+        fetcher.return_value = _sliced
+        api = api_cls.return_value
+        api.list_repo_tree.return_value = []
+        bake_one_per_file(
+            source="polyhaven",
+            tier="1k",
+            release_tag="v0.0.0-test",
+            work_dir=tmp_path,
+            hf_token="t",
+            repo_id="gerchowl/mat-vis-tst",
+            **bake_kwargs,
+        )
+        return api
+
+
+def _commit_path_set(api):
+    """Set of every ``path_in_repo`` ever committed by the mocked API."""
+    out = set()
+    for call in api.create_commit.call_args_list:
+        ops = call.kwargs.get("operations") or (call.args[-1] if call.args else [])
+        for op in ops:
+            out.add(op.path_in_repo)
+    return out
+
+
+class TestManifestEmission:
+    """#207 / #210 Part A — assert the static contract paths each bake
+    must produce. The bug that motivated #210 was the bake never writing
+    ``release-manifest.json``; mocked tests passed because they only
+    asserted the textures + catalog + sentinel paths. Tightening the
+    contract surface here means a future regression that drops the
+    manifest emission fails immediately."""
+
+    PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 80
+
+    def test_commit_path_set_includes_manifest_catalog_sentinel(self, tmp_path):
+        records = [_fake_record(f"mat_{i}", {"color": self.PNG}, tmp_path) for i in range(2)]
+        api = _bake_with_records(records, tmp_path, batch_size=2)
+        paths = _commit_path_set(api)
+        # Required substrate-contract paths — every per-file bake emits
+        # this set, no matter how many materials / batches.
+        assert "release-manifest.json" in paths, paths
+        assert "polyhaven.json" in paths, paths
+        assert "polyhaven/1k/.tier_complete" in paths, paths
+
+    def test_manifest_commit_bundled_with_catalog(self, tmp_path):
+        """The manifest update lands in the SAME commit as the catalog
+        — atomicity for clients (#207). A regression that splits them
+        into separate commits would leave a window where catalog +
+        manifest disagree."""
+        records = [_fake_record(f"mat_{i}", {"color": self.PNG}, tmp_path) for i in range(2)]
+        api = _bake_with_records(records, tmp_path, batch_size=2)
+        # Find the commit containing release-manifest.json.
+        manifest_commits = [
+            c
+            for c in api.create_commit.call_args_list
+            if any(op.path_in_repo == "release-manifest.json" for op in c.kwargs["operations"])
+        ]
+        assert len(manifest_commits) == 1, "manifest must land in exactly one commit"
+        ops_in_manifest_commit = {
+            op.path_in_repo for op in manifest_commits[0].kwargs["operations"]
+        }
+        assert "polyhaven.json" in ops_in_manifest_commit, ops_in_manifest_commit
+
+    def test_manifest_commit_carries_parent_commit_for_cas(self, tmp_path):
+        """Per #208's CAS retry: the manifest commit MUST set
+        ``parent_commit`` so HF returns 412 on a concurrent writer's
+        clobber. A regression that drops the kwarg would silently
+        re-introduce the multi-source race."""
+        records = [_fake_record(f"mat_{i}", {"color": self.PNG}, tmp_path) for i in range(2)]
+        api = _bake_with_records(records, tmp_path, batch_size=2)
+        manifest_call = next(
+            c
+            for c in api.create_commit.call_args_list
+            if any(op.path_in_repo == "release-manifest.json" for op in c.kwargs["operations"])
+        )
+        assert "parent_commit" in manifest_call.kwargs, (
+            "manifest commit must opt into HF's parent_commit lock for CAS retry"
+        )
+
+    def test_sentinel_is_strictly_last_commit(self, tmp_path):
+        """The .tier_complete sentinel is the final commit per tier so
+        clients can probe one file to check atomicity. Manifest commit
+        must come BEFORE the sentinel, not after — otherwise readers
+        that arrive between manifest-commit and sentinel-commit see a
+        catalog claiming complete tiers without the sentinel marker."""
+        records = [_fake_record("mat_0", {"color": self.PNG}, tmp_path)]
+        api = _bake_with_records(records, tmp_path, batch_size=1)
+        last_call = api.create_commit.call_args_list[-1]
+        last_paths = {op.path_in_repo for op in last_call.kwargs["operations"]}
+        assert last_paths == {"polyhaven/1k/.tier_complete"}, last_paths
+
+
+# ── CAS retry on the manifest commit (#208) ──────────────────────────
+
+
+def _make_412_error(msg: str = "412 Precondition Failed: revision moved") -> Exception:
+    """A generic exception that matches the substring detection in
+    ``hf_bake_per_file.bake_one_per_file``'s retry loop. We don't import
+    huggingface_hub's specific error class — the production code does
+    substring matching on the message because HF's error type changed
+    between hub releases."""
+    return RuntimeError(msg)
+
+
+class TestCasRetryOnManifestCommit:
+    """The 412-retry loop in ``bake_one_per_file``'s catalog+manifest
+    commit was previously untested. The tests here exercise the three
+    distinct code paths: a single 412 → success on retry, exhaustion of
+    the retry budget, and a non-412 error that must NOT be retried."""
+
+    PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 80
+
+    def _drive_bake_with_commit_side_effect(
+        self, tmp_path, side_effect, *, expect_raises: bool = False
+    ):
+        """Helper: drive ``bake_one_per_file`` with a custom
+        ``api.create_commit.side_effect``. Pre-seeds an empty manifest
+        on the revision so the read leg of the CAS loop has a known
+        return value. Returns ``(api, fetch_mfst, exc)`` where ``exc``
+        is the raised exception (or ``None`` on success)."""
+        from types import SimpleNamespace
+
+        records = [_fake_record("mat_0", {"color": self.PNG}, tmp_path)]
+        with (
+            patch("mat_vis_baker.hf_bake_per_file._get_fetcher") as fetcher,
+            patch("mat_vis_baker.hf_bake_per_file.HfApi") as api_cls,
+            patch("mat_vis_baker.hf_bake_per_file.bake_material", side_effect=lambda r, *a, **k: r),
+            patch(
+                "mat_vis_baker.hf_bake_per_file._fetch_manifest_with_parent",
+                return_value=({}, "deadbeef"),
+            ) as fetch_mfst,
+        ):
+
+            def _sliced(tier, textures_dir, *, limit=None, offset=0, **kw):
+                end = None if limit is None else offset + limit
+                return records[offset:end]
+
+            fetcher.return_value = _sliced
+            api = api_cls.return_value
+            api.list_repo_tree.return_value = []
+            api.create_commit.side_effect = side_effect
+            api.create_commit.return_value = SimpleNamespace(oid="cafef00d")
+
+            exc: Exception | None = None
+            try:
+                bake_one_per_file(
+                    source="polyhaven",
+                    tier="1k",
+                    release_tag="v0.0.0-test",
+                    work_dir=tmp_path,
+                    hf_token="t",
+                    repo_id="gerchowl/mat-vis-tst",
+                    batch_size=1,
+                )
+            except Exception as e:  # noqa: BLE001
+                exc = e
+
+            if expect_raises:
+                assert exc is not None, "expected an exception to propagate"
+            else:
+                assert exc is None, f"unexpected exception: {exc!r}"
+            return api, fetch_mfst, exc
+
+    def test_412_retry_succeeds_on_second_attempt(self, tmp_path):
+        """One 412 → fetch fresh parent SHA → retry → success."""
+        from types import SimpleNamespace
+
+        attempts = {"n": 0}
+
+        def side_effect(*args, **kwargs):
+            ops = kwargs.get("operations") or []
+            paths = {op.path_in_repo for op in ops}
+            if "release-manifest.json" in paths:
+                attempts["n"] += 1
+                if attempts["n"] == 1:
+                    raise _make_412_error()
+            return SimpleNamespace(oid="cafef00d")
+
+        api, fetch_mfst, _ = self._drive_bake_with_commit_side_effect(
+            tmp_path, side_effect=side_effect, expect_raises=False
+        )
+
+        # Manifest commit attempted twice — once 412, once success.
+        assert attempts["n"] == 2, f"expected 2 manifest attempts, got {attempts['n']}"
+        # Fresh manifest re-fetched on the retry path (initial + retry).
+        assert fetch_mfst.call_count == 2, fetch_mfst.call_count
+
+    def test_412_retry_exhausts_after_max_retries(self, tmp_path):
+        """Continuous 412 → loop exhausts → raises after max_retries.
+        The implementation hardcodes max_retries=6 in the bake path."""
+
+        def side_effect(*args, **kwargs):
+            ops = kwargs.get("operations") or []
+            paths = {op.path_in_repo for op in ops}
+            if "release-manifest.json" in paths:
+                raise _make_412_error()
+            from types import SimpleNamespace
+
+            return SimpleNamespace(oid="cafef00d")
+
+        api, fetch_mfst, exc = self._drive_bake_with_commit_side_effect(
+            tmp_path, side_effect=side_effect, expect_raises=True
+        )
+
+        # CAS loop fired exactly max_retries (=6) times before bubbling
+        # the 412 out. Each attempt re-fetches the manifest first, so
+        # fetch_count == attempt_count == 6.
+        assert fetch_mfst.call_count == 6, (
+            f"expected exactly 6 retry attempts, got {fetch_mfst.call_count}"
+        )
+        # The exception that escapes is the 412 from the last attempt.
+        assert exc is not None and "412" in str(exc), exc
+
+    def test_non_412_error_is_not_retried(self, tmp_path):
+        """An auth / network error must NOT trigger CAS retry — that
+        would mask real failures behind exhausted-retries fatigue."""
+
+        attempts = {"n": 0}
+
+        def side_effect(*args, **kwargs):
+            ops = kwargs.get("operations") or []
+            paths = {op.path_in_repo for op in ops}
+            if "release-manifest.json" in paths:
+                attempts["n"] += 1
+                raise RuntimeError("401 Unauthorized: token rejected")
+            from types import SimpleNamespace
+
+            return SimpleNamespace(oid="cafef00d")
+
+        api, fetch_mfst, exc = self._drive_bake_with_commit_side_effect(
+            tmp_path, side_effect=side_effect, expect_raises=True
+        )
+
+        # Exactly one manifest attempt — the 401 propagated out without
+        # a retry. fetch_manifest fired once (the pre-attempt read),
+        # NOT a second time (no retry leg).
+        assert attempts["n"] == 1, f"401 must not retry (got {attempts['n']} attempts)"
+        assert fetch_mfst.call_count == 1, fetch_mfst.call_count
+        assert exc is not None and "401" in str(exc), exc

--- a/tests/test_hf_derive_per_file.py
+++ b/tests/test_hf_derive_per_file.py
@@ -435,3 +435,182 @@ class TestResizeTransform:
         assert out.startswith(PNG_MAGIC)
         img = Image.open(io.BytesIO(out))
         assert img.size == (64, 64)
+
+
+# ── #207 part 2 / #210 part A: derive must emit + CAS-retry the manifest ──
+
+
+def _make_412_error(msg: str = "412 Precondition Failed: revision moved") -> Exception:
+    """Mirror of bake-side helper. Substring detection in the production
+    code matches across hub error-class shifts."""
+    return RuntimeError(msg)
+
+
+class TestDeriveManifestEmission:
+    """The derive path's catalog+manifest commit was added in #209.
+    Mocked tests asserted the parent_commit kwarg is set, but never
+    verified the manifest path is in the commit ops set or that the
+    manifest body actually carries the new tier. Locking it down so a
+    refactor that drops the bundled commit can't reach prod."""
+
+    def test_commit_path_set_includes_manifest(self, tmp_path) -> None:
+        api = TestDeriveSmallerTier()._setup_api(["mat_0", "mat_1"], ["color"])
+        get, head = _patch_http_for_derive(png_bytes=_make_png(64), target_existing=set())
+
+        with (
+            patch("mat_vis_baker.hf_derive_per_file.HfApi", return_value=api),
+            patch("mat_vis_baker.hf_derive_per_file._http_get", side_effect=get),
+            patch("mat_vis_baker.hf_derive_per_file._http_head_ok", side_effect=head),
+        ):
+            derive_smaller_tier(
+                source="polyhaven",
+                source_tier="1k",
+                target_tier="512",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                repo_id="gerchowl/mat-vis-tst",
+            )
+
+        all_paths = {
+            op.path_in_repo
+            for c in api.create_commit.call_args_list
+            for op in c.kwargs["operations"]
+        }
+        # Substrate-contract paths the derive run MUST emit.
+        assert "release-manifest.json" in all_paths
+        assert "polyhaven.json" in all_paths
+        assert "polyhaven/512/.tier_complete" in all_paths
+
+    def test_manifest_body_lists_new_tier_under_source(self, tmp_path) -> None:
+        """The body of the manifest commit must carry
+        sources.<src>.tiers.<target_tier> = {complete: true} — clients
+        depend on this to discover derived tiers without re-baking."""
+        api = TestDeriveSmallerTier()._setup_api(["mat_0"], ["color"])
+        get, head = _patch_http_for_derive(png_bytes=_make_png(64), target_existing=set())
+
+        with (
+            patch("mat_vis_baker.hf_derive_per_file.HfApi", return_value=api),
+            patch("mat_vis_baker.hf_derive_per_file._http_get", side_effect=get),
+            patch("mat_vis_baker.hf_derive_per_file._http_head_ok", side_effect=head),
+        ):
+            derive_smaller_tier(
+                source="polyhaven",
+                source_tier="1k",
+                target_tier="512",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                repo_id="gerchowl/mat-vis-tst",
+            )
+
+        manifest_op = next(
+            op
+            for c in api.create_commit.call_args_list
+            for op in c.kwargs["operations"]
+            if op.path_in_repo == "release-manifest.json"
+        )
+        manifest = json.loads(manifest_op.path_or_fileobj)
+        assert manifest["schema_version"] == 3
+        assert manifest["sources"]["polyhaven"]["tiers"]["512"] == {"complete": True}
+
+
+class TestDeriveCasRetryOnManifestCommit:
+    """Mirror of bake-side TestCasRetryOnManifestCommit — proves the
+    derive path's 412-retry loop actually retries, exhausts at the
+    documented budget, and does NOT retry non-412 errors."""
+
+    def _drive_derive_with_commit_side_effect(
+        self, tmp_path, side_effect, *, expect_raises: bool = False
+    ):
+        """Returns (api, fetch_mfst, exc) — same shape as the bake helper."""
+        api = TestDeriveSmallerTier()._setup_api(["mat_0"], ["color"])
+        get, head = _patch_http_for_derive(png_bytes=_make_png(64), target_existing=set())
+
+        with (
+            patch("mat_vis_baker.hf_derive_per_file.HfApi", return_value=api),
+            patch("mat_vis_baker.hf_derive_per_file._http_get", side_effect=get),
+            patch("mat_vis_baker.hf_derive_per_file._http_head_ok", side_effect=head),
+            patch(
+                "mat_vis_baker.hf_bake_per_file._fetch_manifest_with_parent",
+                return_value=({}, "deadbeef"),
+            ) as fetch_mfst,
+        ):
+            api.create_commit.side_effect = side_effect
+            api.create_commit.return_value = SimpleNamespace(oid="cafef00d")
+            exc: Exception | None = None
+            try:
+                derive_smaller_tier(
+                    source="polyhaven",
+                    source_tier="1k",
+                    target_tier="512",
+                    release_tag="v0.0.0-test",
+                    work_dir=tmp_path,
+                    repo_id="gerchowl/mat-vis-tst",
+                )
+            except Exception as e:  # noqa: BLE001
+                exc = e
+
+            if expect_raises:
+                assert exc is not None, "expected an exception to propagate"
+            else:
+                assert exc is None, f"unexpected exception: {exc!r}"
+            return api, fetch_mfst, exc
+
+    def test_412_retry_succeeds_on_second_attempt(self, tmp_path) -> None:
+        """One 412 → retry → success. Asserts the loop fetched the
+        manifest twice (initial + retry) and made two manifest-commit
+        attempts."""
+        attempts = {"n": 0}
+
+        def side_effect(*args, **kwargs):
+            ops = kwargs.get("operations") or []
+            paths = {op.path_in_repo for op in ops}
+            if "release-manifest.json" in paths:
+                attempts["n"] += 1
+                if attempts["n"] == 1:
+                    raise _make_412_error()
+            return SimpleNamespace(oid="cafef00d")
+
+        _api, fetch_mfst, _exc = self._drive_derive_with_commit_side_effect(
+            tmp_path, side_effect=side_effect, expect_raises=False
+        )
+
+        assert attempts["n"] == 2, f"expected 2 manifest attempts, got {attempts['n']}"
+        assert fetch_mfst.call_count == 2, fetch_mfst.call_count
+
+    def test_412_retry_exhausts_after_max_retries(self, tmp_path) -> None:
+        """Continuous 412 → 6 attempts then propagate."""
+
+        def side_effect(*args, **kwargs):
+            ops = kwargs.get("operations") or []
+            paths = {op.path_in_repo for op in ops}
+            if "release-manifest.json" in paths:
+                raise _make_412_error()
+            return SimpleNamespace(oid="cafef00d")
+
+        _api, fetch_mfst, exc = self._drive_derive_with_commit_side_effect(
+            tmp_path, side_effect=side_effect, expect_raises=True
+        )
+
+        assert fetch_mfst.call_count == 6, f"expected 6 retry attempts, got {fetch_mfst.call_count}"
+        assert exc is not None and "412" in str(exc), exc
+
+    def test_non_412_error_is_not_retried(self, tmp_path) -> None:
+        """A 401 must propagate immediately — masking auth failures
+        behind retry exhaustion would create false 'flaky CI' signals."""
+        attempts = {"n": 0}
+
+        def side_effect(*args, **kwargs):
+            ops = kwargs.get("operations") or []
+            paths = {op.path_in_repo for op in ops}
+            if "release-manifest.json" in paths:
+                attempts["n"] += 1
+                raise RuntimeError("401 Unauthorized: token rejected")
+            return SimpleNamespace(oid="cafef00d")
+
+        _api, fetch_mfst, exc = self._drive_derive_with_commit_side_effect(
+            tmp_path, side_effect=side_effect, expect_raises=True
+        )
+
+        assert attempts["n"] == 1, f"401 must not retry (got {attempts['n']} attempts)"
+        assert fetch_mfst.call_count == 1, fetch_mfst.call_count
+        assert exc is not None and "401" in str(exc), exc


### PR DESCRIPTION
## Summary

Lands the bulk of #210 — the test-hardening response to #207's bake-side bug that all four mocked client suites missed. Three commits:

1. **bake-side**: 7 new tests in \`test_hf_bake_per_file.py\`. Asserts the substrate-contract path set (manifest + catalog + sentinel), commit bundling, sentinel-last ordering, and the previously-untested CAS retry loop (412 retry, exhaustion, non-412 not retried). Net: 5 → 12 tests.

2. **derive-side**: 5 new tests in \`test_hf_derive_per_file.py\` mirroring the bake hardening. Net: 13 → 18 tests.

3. **E2E**: 2 new classes in \`tests/e2e/test_per_file_roundtrip.py\`:
   - \`TestMultiSourceManifestMerge\` (always-on under \`MAT_VIS_E2E=1\`) — sequential polyhaven + ambientcg bakes into one tag, asserts manifest accumulates both sources. Catches future regressions to the merge logic during nightly E2E.
   - \`TestConcurrentBakesShareTag\` (opt-in \`MAT_VIS_E2E_CONCURRENCY=N\`) — N \`multiprocessing.Process\` workers (default N=3) baking different sources at tier 1k into one release tag. The CAS retry is the only thing keeping their manifest writes from clobbering. Threading is explicitly NOT used (GIL serializes live HTTP, never fires the retry path).

## Why this matters

#207 (the bug that motivated #210) shipped through every mocked test suite because they only asserted the happy path. JS/shell/Rust hard-failed against a fresh bake; Python's tree-fallback masked the gap. The CAS retry loop added in #208 was completely untested — a regression dropping \`parent_commit\` from the commit kwargs would have silently re-introduced the multi-source race.

## What's still open (deferred to follow-up)

- **Workflow matrix expansion** in \`e2e.yml\`: fan out JS/shell/Rust client jobs after the Python bake. Requires orchestration redesign (the Python E2E auto-cleans its tag via the fixture, so a multi-job workflow needs a non-cleaning bake step + a separate teardown job). Filing as a small follow-up — it's pure YAML/dagger plumbing, not test logic.

## Test plan

- [x] \`just test-fast\` — 339 + 211 = 550 pass, 16+22 skipped
- [x] New tests use \`expect_raises\` helper to verify exception propagation cleanly
- [x] CAS retry tests assert exact retry budget (6 attempts) — regression that bumps the budget will fail visibly
- [ ] CI: matrix tests + integration test
- [ ] Optional manual: \`MAT_VIS_E2E=1 MAT_VIS_E2E_CONCURRENCY=3 uv run pytest tests/e2e/test_per_file_roundtrip.py::TestConcurrentBakesShareTag -v\` against a personal HF token

## Architectural decision (chat thread)

User asked about Option B (per-shard fragments + final merge job) vs current Option A (CAS retry). Decided to stay with A for v0.6.0 and use #210's opt-in concurrency test as the data-driven trigger for B if A ever fails under load. Documented in the issue comments.