### PR TITLE
docs(baker/ambientcg): note non-uniform channel sets are upstream truth

### DIFF
--- a/src/mat_vis_baker/sources/ambientcg.py
+++ b/src/mat_vis_baker/sources/ambientcg.py
@@ -223,6 +223,15 @@ def _extract_maps_from_zip(
             out_path.write_bytes(zf.read(name))
             result[channel] = out_path
 
+    # Per-material channel set is intentionally non-uniform across the
+    # ambientcg catalog. Materials with creationMethod=PBRPhotogrammetry
+    # (e.g. Rock064) ship an AmbientOcclusion map; PBRApproximated assets
+    # (e.g. Wood095) do not, because there's no real height field to bake
+    # AO from. We mirror upstream truth — the catalog's `maps` field
+    # records exactly the channels the ZIP actually contains. Clients
+    # read `maps` per-entry and never assume a uniform channel set, so
+    # this is fine end-to-end. Verified 2026-04-28 against ambientcg's
+    # 1k+2k zips for both materials.
     return result
 
 


### PR DESCRIPTION
## Summary

Final verification for #210 surfaced: ambientcg's Rock064 baked with 5 channels (incl. AO), Wood095 with only 4 (no AO). Investigated and confirmed upstream truth — ambientcg only ships AmbientOcclusion maps for \`creationMethod: PBRPhotogrammetry\` materials (real height fields). PBRApproximated assets like Wood095 don't get AO because there's no geometry to bake from.

Adding a 9-line note at the channel-extraction call site so a future contributor running the same investigation lands directly on the answer.

## Verified end-to-end

- ambientcg's \`Wood095_1K-PNG.zip\` and \`Wood095_2K-PNG.zip\` both ship 10 files, none contain "AmbientOcclusion" (rules out tier-specific behavior)
- ambientcg's \`Rock064_1K-PNG.zip\` ships 11 files including \`Rock064_1K-PNG_AmbientOcclusion.png\`
- API metadata corroborates: "AmbientOcclusion" appears in Rock064's \`previewLinks\`, not in Wood095's
- Baker code path is identical for both materials (no allowlist, no error swallowing)
- Clients read \`maps\` per-entry and never assume a uniform channel set across materials

## What changed

`src/mat_vis_baker/sources/ambientcg.py` — 9 LOC of comment, no behavior change.

## Test plan

- [x] \`just test-fast\` (pre-push gate) — green
- [ ] CI: lint passes (no logic changed)