### PR TITLE
chore: gitignore local agent/editor state and scratch artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -248,3 +248,19 @@ result
 # the repo's user-facing documentation. ADRs + GH issues are the
 # canonical, tracked specification.
 docs/HANDOFF.md
+
+# Local agent / editor / tooling state (per-user, never committed)
+.claude/
+.cursor/
+.direnv/
+.playwright-mcp/
+
+# One-shot org bootstrap helper — explicitly local (header in file says so)
+scripts/bootstrap.sh
+
+# Local scratch material downloads (e.g. Rock064/ from ambientcg probes)
+/Rock064/
+
+# Per-language client lockfiles — generated fresh by their own dev workflows
+clients/python/uv.lock
+clients/rust/Cargo.lock


### PR DESCRIPTION
## Summary
- Adds local-only paths to `.gitignore` so a working checkout with normal tooling activity is clean: `.claude/`, `.cursor/`, `.direnv/`, `.playwright-mcp/`.
- Adds `scripts/bootstrap.sh` (the file's own header already declares it ignored) and the `Rock064/` scratch material download.
- Adds the per-language client lockfiles (`clients/python/uv.lock`, `clients/rust/Cargo.lock`) — they're regenerated by each client's own dev workflow and aren't part of the published library's reproducibility surface.

## Test plan
- [x] `git status` clean on a fresh `dev` checkout after adding these dirs locally.
- [x] Pre-commit hooks pass.