### PR TITLE
bugfix(bake): install uv so the schema-drift gate can actually run (#214)

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -95,6 +95,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # `uv` is needed by the schema-drift gate below; install once up-front
+      # so the gate doesn't fail with `uv: command not found` (latent since
+      # #170 — gate had never fired against a non-dry-run bake until #214).
+      - uses: astral-sh/setup-uv@v6
+
       - name: Dagger shell-safety lint (#61)
         run: python3 scripts/check-dagger-shell-safety.py
 


### PR DESCRIPTION
## Summary
- The schema-drift gate added in #170 calls \`uv run python scripts/check_upstream_schema_drift.py …\` but \`bake.yml\` never installed \`uv\`. Latent because no full (non-dry-run) bake had reached the gate until #214 phase 2 fired.
- Mirrors the pattern already in \`pypi.yml\` and \`watch.yml\`: \`astral-sh/setup-uv@v6\` right after checkout.

Polyhaven phase-2 dispatch ([run 25051196184](https://github.com/MorePET/mat-vis/actions/runs/25051196184)) hit it: \`hf-bake\` succeeded fully (1247 materials baked + catalog + manifest landed at \`v0.0.0-phase2\` on \`mat-vis-tst\`), only the gate crashed with \`uv: command not found\`. Once this lands the gate runs as intended; preflight will skip already-baked materials so a re-dispatch is cheap.

## Test plan
- [x] yamllint passes (pre-commit)
- [ ] Re-dispatch polyhaven phase-2 → workflow exits 0 (preflight short-circuits the bake; gate runs cleanly)