### PR TITLE
feat(baker): stream live bake/derive progress (#217)

### DIFF
--- a/src/mat_vis_baker/__main__.py
+++ b/src/mat_vis_baker/__main__.py
@@ -290,6 +290,15 @@ def cmd_hf_bake(args: argparse.Namespace) -> int:
 def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
 
+    # #217: line-buffered stdout so structured `bake_plan` / `bake_progress`
+    # / `bake_done` lines reach the parent process (GitHub Actions live
+    # log) within the OS pipe-flush window. `PYTHONUNBUFFERED=1` is set
+    # on the Dagger baker container, but this is the belt to that
+    # suspenders for non-Dagger callers.
+    from mat_vis_baker.progress import enable_line_buffering
+
+    enable_line_buffering()
+
     parser = argparse.ArgumentParser(prog="mat-vis-baker")
     sub = parser.add_subparsers(dest="command", required=True)
 

--- a/src/mat_vis_baker/hf_bake_per_file.py
+++ b/src/mat_vis_baker/hf_bake_per_file.py
@@ -45,6 +45,7 @@ from mat_vis_baker.common import (
     hash_textures,
 )
 from mat_vis_baker.index_builder import build_index
+from mat_vis_baker.progress import ProgressTracker, emit_bake_plan
 from mat_vis_baker.source_tiers import is_supported, unsupported_tier_message
 
 log = logging.getLogger("mat-vis-baker.hf_bake_per_file")
@@ -85,6 +86,31 @@ def _get_fetcher(source: str):
     else:
         raise NotImplementedError(f"Source {source!r} not yet implemented")
     return fetch
+
+
+def _discover_total_materials(source: str) -> int:
+    """Count materials on the upstream catalog for ``bake_plan``.
+
+    Best-effort: failures return 0 so we still emit the plan line (with
+    ``total_materials=0``) rather than crashing the bake. The real count
+    surfaces in ``bake_done`` either way.
+    """
+    try:
+        if source == "ambientcg":
+            from mat_vis_baker.sources.ambientcg import discover
+
+            return len(discover())
+        if source == "polyhaven":
+            from mat_vis_baker.sources.polyhaven import discover
+
+            return len(discover())
+        if source == "gpuopen":
+            from mat_vis_baker.sources.gpuopen import discover
+
+            return len(discover())
+    except Exception as e:  # noqa: BLE001
+        log.warning("bake_plan total_materials lookup failed (%s): %s", type(e).__name__, e)
+    return 0
 
 
 def _already_committed_material_ids(
@@ -276,6 +302,30 @@ def bake_one_per_file(
         len(already),
     )
 
+    # #217: structured plan line — first non-init log entry of the bake
+    # step. Emitted even when total_materials lookup fails (best-effort
+    # discover() falls back to 0). expected_files is a rough estimate:
+    # total_materials × len(CANONICAL_CHANNELS). Per-source channel sets
+    # are non-uniform (see ambientcg.py), so this is "≈" not exact —
+    # which the line shape (`expected_files≈<M>`) reflects.
+    total_materials = _discover_total_materials(source)
+    expected_files = total_materials * len(CANONICAL_CHANNELS)
+    emit_bake_plan(
+        source=source,
+        tier=tier,
+        total_materials=total_materials,
+        expected_files=expected_files,
+        release_tag=release_tag,
+        repo_id=repo_id,
+        kind="bake",
+    )
+    progress = ProgressTracker(
+        source=source,
+        tier=tier,
+        total_materials=total_materials,
+        kind="bake",
+    )
+
     pending_batch: list[MaterialRecord] = []
 
     def _flush_batch(batch: list[MaterialRecord]) -> str:
@@ -290,8 +340,15 @@ def bake_one_per_file(
             ops.extend(_build_commit_ops_for_record(rec, source, tier))
         if not ops:
             return last_commit_sha
+        # Account bytes by reading the same in-memory payload the
+        # CommitOperationAdd holds — avoids a second disk read and
+        # matches the actual upload size.
+        batch_bytes = sum(
+            len(op.path_or_fileobj) for op in ops if isinstance(op.path_or_fileobj, bytes)
+        )
         if dry_run:
             log.info("dry-run: would commit %d files for %d materials", len(ops), len(batch))
+            sha = ""
         else:
             commit = api.create_commit(
                 repo_id=repo_id,
@@ -311,6 +368,11 @@ def bake_one_per_file(
                 len(ops),
                 sha[:12] if sha else "?",
             )
+        # #217: structured progress line — emit AFTER the commit lands so
+        # a crash mid-commit doesn't credit the operator with progress
+        # the substrate doesn't actually hold.
+        progress.record_batch(materials=len(batch), bytes_added=batch_bytes)
+        progress.emit_progress()
         # Free per-rec files now the commit is durable.
         for rec in batch:
             for p in list(rec.texture_paths.values()):
@@ -318,7 +380,7 @@ def bake_one_per_file(
                     Path(p).unlink(missing_ok=True)
                 except OSError:
                     pass
-        return sha if not dry_run else ""
+        return sha
 
     while True:
         batch_limit = batch_size
@@ -468,6 +530,9 @@ def bake_one_per_file(
         n_failed,
         n_skipped_preflight,
     )
+    # #217: structured terminal line — single-line summary that closes
+    # the (plan, progress, …, done) triple a parser can lock onto.
+    progress.emit_done(ok=n_ok, failed=n_failed, skipped_preflight=n_skipped_preflight)
 
     return {
         "commit": last_commit_sha,

--- a/src/mat_vis_baker/hf_derive_per_file.py
+++ b/src/mat_vis_baker/hf_derive_per_file.py
@@ -54,6 +54,7 @@ from PIL import Image
 
 from mat_vis_baker.common import CANONICAL_CHANNELS, TIER_TO_PX
 from mat_vis_baker.hf_bake_per_file import _guard_prod_target
+from mat_vis_baker.progress import ProgressTracker, emit_bake_plan
 
 log = logging.getLogger("mat-vis-baker.hf_derive_per_file")
 
@@ -423,6 +424,27 @@ def _derive_driver(
     if not mids:
         return {"error": "no source materials", "ok": 0, "failed": 0, "skipped_preflight": 0}
 
+    # #217: structured plan line. derive_plan mirrors bake_plan exactly
+    # except for the leading token. expected_files is materials × the
+    # canonical channel count (a rough estimate; per-source channel
+    # sets are non-uniform, hence the `≈` in the format).
+    expected_files = len(mids) * len(CANONICAL_CHANNELS)
+    emit_bake_plan(
+        source=source,
+        tier=target_tier,
+        total_materials=len(mids),
+        expected_files=expected_files,
+        release_tag=release_tag,
+        repo_id=repo_id,
+        kind="derive",
+    )
+    progress = ProgressTracker(
+        source=source,
+        tier=target_tier,
+        total_materials=len(mids),
+        kind="derive",
+    )
+
     n_ok = 0
     n_failed = 0
     n_skipped = 0
@@ -436,6 +458,11 @@ def _derive_driver(
         nonlocal last_commit_sha
         if not pending_ops:
             return last_commit_sha
+        # Bytes accounting: the ops we built carry the transformed
+        # bytes inline, so summing len() avoids a second pass.
+        batch_bytes = sum(
+            len(op.path_or_fileobj) for op in pending_ops if isinstance(op.path_or_fileobj, bytes)
+        )
         if dry_run:
             log.info(
                 "%s dry-run: would commit %d files for %d materials",
@@ -443,26 +470,30 @@ def _derive_driver(
                 len(pending_ops),
                 len(pending_mids),
             )
-            return last_commit_sha
-        commit = api.create_commit(
-            repo_id=repo_id,
-            repo_type="dataset",
-            operations=list(pending_ops),
-            commit_message=(
-                f"feat(data): {release_tag} — derive {source} {target_tier} "
-                f"from {source_tier} ({len(pending_mids)} materials, "
-                f"{len(pending_ops)} files)"
-            ),
-            revision=release_tag,
-        )
-        sha = getattr(commit, "oid", "") or getattr(commit, "commit_oid", "")
-        log.info(
-            "%s batch commit: %d materials, %d files, sha=%s",
-            label,
-            len(pending_mids),
-            len(pending_ops),
-            sha[:12] if sha else "?",
-        )
+            sha = ""
+        else:
+            commit = api.create_commit(
+                repo_id=repo_id,
+                repo_type="dataset",
+                operations=list(pending_ops),
+                commit_message=(
+                    f"feat(data): {release_tag} — derive {source} {target_tier} "
+                    f"from {source_tier} ({len(pending_mids)} materials, "
+                    f"{len(pending_ops)} files)"
+                ),
+                revision=release_tag,
+            )
+            sha = getattr(commit, "oid", "") or getattr(commit, "commit_oid", "")
+            log.info(
+                "%s batch commit: %d materials, %d files, sha=%s",
+                label,
+                len(pending_mids),
+                len(pending_ops),
+                sha[:12] if sha else "?",
+            )
+        # #217: structured progress line — emit AFTER the commit lands.
+        progress.record_batch(materials=len(pending_mids), bytes_added=batch_bytes)
+        progress.emit_progress()
         return sha or last_commit_sha
 
     for i, mid in enumerate(mids):
@@ -648,6 +679,8 @@ def _derive_driver(
         n_failed,
         n_skipped,
     )
+    # #217: closing line of the (plan, progress, …, done) triple.
+    progress.emit_done(ok=n_ok, failed=n_failed, skipped_preflight=n_skipped)
 
     return {
         "commit": last_commit_sha,

--- a/src/mat_vis_baker/progress.py
+++ b/src/mat_vis_baker/progress.py
@@ -1,0 +1,178 @@
+"""Streaming progress lines for ``hf-bake`` / ``hf-derive`` (#217).
+
+Surface live "should-vs-is" progress as single-line, structured stdout
+records that GitHub Actions can render in the live tail of a step (not
+just after step exit). The format is a public contract — downstream
+consumers grep / parse these lines, so the field order and key names
+must stay stable.
+
+Three line shapes:
+
+- ``bake_plan`` / ``derive_plan`` — emitted once, at the top of a run,
+  after the catalog has been resolved. Tells the operator how big the
+  job is up front: ``total_materials``, ``expected_files``, the target
+  repo, the release tag.
+
+- ``bake_progress`` / ``derive_progress`` — emitted at the end of every
+  successful batch commit. Contains a rolling 3-batch rate to smooth
+  out first-batch warm-up bias, plus an ETA derived from the same
+  rolling rate.
+
+- ``bake_done`` / ``derive_done`` — final summary line.
+
+All emit through ``print(..., flush=True)`` so the line reaches the
+parent process / GitHub Actions live log within the OS pipe-flush
+window (~milliseconds), not buffered until the Python process exits.
+The Dagger baker container additionally sets ``PYTHONUNBUFFERED=1``;
+this module's flush is the belt to that suspenders.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from collections import deque
+from dataclasses import dataclass, field
+
+# Rolling-rate window: smooth over the last N batches. Three is enough
+# to dampen first-batch warm-up (cold caches, branch creation, etc.)
+# without lagging meaningfully behind real throughput changes.
+_RATE_WINDOW = 3
+
+
+def _format_elapsed(seconds: float) -> str:
+    """Render seconds as ``<H>m<S>s`` — minutes always shown, seconds
+    rounded to int. Matches the format the issue specifies."""
+    total = int(seconds)
+    minutes, secs = divmod(total, 60)
+    return f"{minutes}m{secs}s"
+
+
+def emit_bake_plan(
+    *,
+    source: str,
+    tier: str,
+    total_materials: int,
+    expected_files: int,
+    release_tag: str,
+    repo_id: str,
+    kind: str = "bake",
+) -> None:
+    """Emit the one-shot ``<kind>_plan`` line. ``kind`` is ``bake`` or
+    ``derive``; the line shape is otherwise identical."""
+    print(
+        f"{kind}_plan source={source} tier={tier} "
+        f"total_materials={total_materials} expected_files≈{expected_files} "
+        f"release_tag={release_tag} repo={repo_id}",
+        flush=True,
+    )
+
+
+@dataclass
+class ProgressTracker:
+    """Rolling-window progress accountant.
+
+    One instance per run. ``record_batch`` is called at the end of every
+    successful batch commit; ``emit_progress`` writes a single structured
+    line to stdout using the rolling rate from the last ``_RATE_WINDOW``
+    batches. ``emit_done`` writes the final summary.
+    """
+
+    source: str
+    tier: str
+    total_materials: int
+    kind: str = "bake"  # "bake" | "derive"
+    started_monotonic: float = field(default_factory=time.monotonic)
+
+    done: int = 0
+    batches: int = 0
+    commits: int = 0
+    bytes_pushed: int = 0
+    # Rolling window: each entry is (monotonic_ts, materials_in_batch).
+    _window: deque[tuple[float, int]] = field(default_factory=lambda: deque(maxlen=_RATE_WINDOW))
+
+    def record_batch(self, *, materials: int, bytes_added: int, commits: int = 1) -> None:
+        """Record one durable batch commit. ``commits`` defaults to 1
+        (the common case — one HF commit per batch); callers that
+        bundle multiple commits in a single batch can override."""
+        self.done += materials
+        self.batches += 1
+        self.commits += commits
+        self.bytes_pushed += bytes_added
+        self._window.append((time.monotonic(), materials))
+
+    def _rolling_rate_per_min(self) -> float:
+        """Materials per minute over the rolling window. Returns 0.0
+        until at least two samples are available — a single sample
+        gives no time delta."""
+        if len(self._window) < 2:
+            return 0.0
+        oldest_ts, _ = self._window[0]
+        newest_ts, _ = self._window[-1]
+        # Sum materials EXCLUDING the oldest sample's count: rate over
+        # the interval [oldest_ts, newest_ts] is "what landed AFTER
+        # the oldest tick" / "elapsed since then".
+        materials_in_window = sum(m for _, m in list(self._window)[1:])
+        elapsed = newest_ts - oldest_ts
+        if elapsed <= 0:
+            return 0.0
+        return materials_in_window * 60.0 / elapsed
+
+    def _eta_minutes(self) -> int:
+        """Minutes remaining at the rolling rate. 0 if rate is 0 (avoid
+        divide-by-zero) or the run is already complete."""
+        rate = self._rolling_rate_per_min()
+        remaining = max(0, self.total_materials - self.done)
+        if rate <= 0 or remaining == 0:
+            return 0
+        return int(round(remaining / rate))
+
+    def emit_progress(self) -> None:
+        """Emit a single ``<kind>_progress`` line. Called at the end of
+        every successful batch commit."""
+        elapsed = time.monotonic() - self.started_monotonic
+        pct = 0
+        if self.total_materials > 0:
+            pct = int(round(100.0 * self.done / self.total_materials))
+        rate = self._rolling_rate_per_min()
+        eta_m = self._eta_minutes()
+        bytes_mib = self.bytes_pushed / (1024 * 1024)
+        print(
+            f"{self.kind}_progress source={self.source} "
+            f"done={self.done}/{self.total_materials} ({pct}%) "
+            f"batches={self.batches} commits={self.commits} "
+            f"bytes_pushed={bytes_mib:.1f}MiB "
+            f"elapsed={_format_elapsed(elapsed)} "
+            f"rate={rate:.1f}mat/min eta={eta_m}m",
+            flush=True,
+        )
+
+    def emit_done(
+        self,
+        *,
+        ok: int,
+        failed: int,
+        skipped_preflight: int,
+    ) -> None:
+        """Emit the final ``<kind>_done`` summary line."""
+        elapsed = time.monotonic() - self.started_monotonic
+        print(
+            f"{self.kind}_done source={self.source} tier={self.tier} "
+            f"ok={ok} failed={failed} skipped_preflight={skipped_preflight} "
+            f"elapsed={_format_elapsed(elapsed)}",
+            flush=True,
+        )
+
+
+def enable_line_buffering() -> None:
+    """Reconfigure ``sys.stdout`` for line buffering — defensive belt
+    on top of ``PYTHONUNBUFFERED=1``. Safe to call multiple times; a
+    no-op on streams that don't support ``reconfigure`` (e.g. some
+    pytest captures)."""
+    try:
+        sys.stdout.reconfigure(line_buffering=True)  # type: ignore[union-attr]
+    except (AttributeError, ValueError):
+        # ValueError can fire on already-detached streams; AttributeError
+        # on stdout objects that don't expose reconfigure (rare, but
+        # captured stdouts in some test runners).
+        pass

--- a/tests/test_progress_lines.py
+++ b/tests/test_progress_lines.py
@@ -1,0 +1,205 @@
+"""Format contract for the structured progress lines (#217).
+
+Downstream parsers (dashboards, GH Actions log scrapers) grep for the
+exact prefix tokens and key=value layout these lines emit. A regression
+that re-orders fields or renames a key would silently break them, so
+the format is asserted here against a fixed regex. Update both the
+producer in ``mat_vis_baker.progress`` and these tests in lock-step
+when the contract changes.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from mat_vis_baker.progress import ProgressTracker, emit_bake_plan
+
+
+_BAKE_PLAN_RE = re.compile(
+    r"^bake_plan source=(?P<source>\S+) tier=(?P<tier>\S+) "
+    r"total_materials=(?P<total>\d+) expected_files≈(?P<expected>\d+) "
+    r"release_tag=(?P<tag>\S+) repo=(?P<repo>\S+)$"
+)
+
+_BAKE_PROGRESS_RE = re.compile(
+    r"^bake_progress source=(?P<source>\S+) "
+    r"done=(?P<done>\d+)/(?P<total>\d+) \((?P<pct>\d+)%\) "
+    r"batches=(?P<batches>\d+) commits=(?P<commits>\d+) "
+    r"bytes_pushed=(?P<bytes>[\d.]+)MiB "
+    r"elapsed=(?P<elapsed>\d+m\d+s) "
+    r"rate=(?P<rate>[\d.]+)mat/min eta=(?P<eta>\d+)m$"
+)
+
+_DERIVE_PLAN_RE = re.compile(
+    r"^derive_plan source=\S+ tier=\S+ total_materials=\d+ "
+    r"expected_files≈\d+ release_tag=\S+ repo=\S+$"
+)
+
+_DERIVE_PROGRESS_RE = re.compile(
+    r"^derive_progress source=\S+ done=\d+/\d+ \(\d+%\) "
+    r"batches=\d+ commits=\d+ bytes_pushed=[\d.]+MiB "
+    r"elapsed=\d+m\d+s rate=[\d.]+mat/min eta=\d+m$"
+)
+
+
+class TestBakePlanFormat:
+    def test_emit_bake_plan_matches_contract(self, capsys):
+        emit_bake_plan(
+            source="polyhaven",
+            tier="1k",
+            total_materials=1234,
+            expected_files=8638,
+            release_tag="v0.0.0-phase2",
+            repo_id="gerchowl/mat-vis-tst",
+            kind="bake",
+        )
+        out = capsys.readouterr().out.strip().splitlines()
+        assert len(out) == 1, out
+        m = _BAKE_PLAN_RE.match(out[0])
+        assert m is not None, f"line did not match contract: {out[0]!r}"
+        assert m.group("source") == "polyhaven"
+        assert m.group("tier") == "1k"
+        assert m.group("total") == "1234"
+        assert m.group("expected") == "8638"
+        assert m.group("tag") == "v0.0.0-phase2"
+        assert m.group("repo") == "gerchowl/mat-vis-tst"
+
+    def test_derive_plan_uses_derive_prefix(self, capsys):
+        """``kind=derive`` flips the prefix token but keeps every other
+        field — same regex shape, different prefix."""
+        emit_bake_plan(
+            source="polyhaven",
+            tier="512",
+            total_materials=10,
+            expected_files=70,
+            release_tag="v0.0.0-test",
+            repo_id="gerchowl/mat-vis-tst",
+            kind="derive",
+        )
+        out = capsys.readouterr().out.strip().splitlines()
+        assert len(out) == 1, out
+        assert _DERIVE_PLAN_RE.match(out[0]) is not None, out[0]
+
+
+class TestBakeProgressFormat:
+    def test_emit_progress_matches_contract(self, capsys):
+        tracker = ProgressTracker(
+            source="polyhaven",
+            tier="1k",
+            total_materials=100,
+            kind="bake",
+        )
+        # Two batches so the rolling rate has two samples and renders
+        # a non-trivial number.
+        tracker.record_batch(materials=10, bytes_added=2 * 1024 * 1024)
+        tracker.record_batch(materials=15, bytes_added=3 * 1024 * 1024)
+        tracker.emit_progress()
+
+        out = capsys.readouterr().out.strip().splitlines()
+        assert len(out) == 1, out
+        m = _BAKE_PROGRESS_RE.match(out[0])
+        assert m is not None, f"line did not match contract: {out[0]!r}"
+        assert m.group("source") == "polyhaven"
+        assert m.group("done") == "25"
+        assert m.group("total") == "100"
+        assert m.group("pct") == "25"
+        assert m.group("batches") == "2"
+        assert m.group("commits") == "2"
+        # 5 MiB total pushed across the two batches.
+        assert float(m.group("bytes")) == pytest.approx(5.0, abs=0.1)
+
+    def test_derive_progress_uses_derive_prefix(self, capsys):
+        tracker = ProgressTracker(
+            source="polyhaven",
+            tier="512",
+            total_materials=20,
+            kind="derive",
+        )
+        tracker.record_batch(materials=5, bytes_added=1024)
+        tracker.record_batch(materials=5, bytes_added=1024)
+        tracker.emit_progress()
+        out = capsys.readouterr().out.strip().splitlines()
+        assert len(out) == 1, out
+        assert _DERIVE_PROGRESS_RE.match(out[0]) is not None, out[0]
+
+    def test_progress_pct_clamps_when_done_exceeds_total(self, capsys):
+        """Defensive: if a fetcher returns more materials than the
+        discover() count predicted, percent should still be a finite
+        integer (we don't clamp; it can read >100 — that's a useful
+        signal). The line MUST still parse."""
+        tracker = ProgressTracker(
+            source="polyhaven",
+            tier="1k",
+            total_materials=10,
+            kind="bake",
+        )
+        tracker.record_batch(materials=15, bytes_added=0)
+        tracker.record_batch(materials=0, bytes_added=0)
+        tracker.emit_progress()
+        out = capsys.readouterr().out.strip().splitlines()
+        assert _BAKE_PROGRESS_RE.match(out[0]) is not None, out[0]
+
+    def test_progress_with_zero_total_does_not_divide_by_zero(self, capsys):
+        """When discover() failed and total_materials=0, the line still
+        emits with pct=0. Prevents ZeroDivisionError from killing the
+        bake just because the upstream catalog probe blipped."""
+        tracker = ProgressTracker(
+            source="polyhaven",
+            tier="1k",
+            total_materials=0,
+            kind="bake",
+        )
+        tracker.record_batch(materials=5, bytes_added=0)
+        tracker.record_batch(materials=5, bytes_added=0)
+        tracker.emit_progress()
+        out = capsys.readouterr().out.strip().splitlines()
+        assert _BAKE_PROGRESS_RE.match(out[0]) is not None, out[0]
+
+
+class TestBakeDoneFormat:
+    _BAKE_DONE_RE = re.compile(
+        r"^bake_done source=\S+ tier=\S+ ok=\d+ failed=\d+ "
+        r"skipped_preflight=\d+ elapsed=\d+m\d+s$"
+    )
+    _DERIVE_DONE_RE = re.compile(
+        r"^derive_done source=\S+ tier=\S+ ok=\d+ failed=\d+ "
+        r"skipped_preflight=\d+ elapsed=\d+m\d+s$"
+    )
+
+    def test_bake_done_matches_contract(self, capsys):
+        tracker = ProgressTracker(source="polyhaven", tier="1k", total_materials=10, kind="bake")
+        tracker.emit_done(ok=8, failed=1, skipped_preflight=1)
+        out = capsys.readouterr().out.strip().splitlines()
+        assert len(out) == 1, out
+        assert self._BAKE_DONE_RE.match(out[0]) is not None, out[0]
+
+    def test_derive_done_matches_contract(self, capsys):
+        tracker = ProgressTracker(source="polyhaven", tier="512", total_materials=10, kind="derive")
+        tracker.emit_done(ok=10, failed=0, skipped_preflight=0)
+        out = capsys.readouterr().out.strip().splitlines()
+        assert len(out) == 1, out
+        assert self._DERIVE_DONE_RE.match(out[0]) is not None, out[0]
+
+
+class TestRollingRate:
+    """The 3-batch rolling window is the load-bearing detail that keeps
+    first-batch warm-up bias out of the rate. Test it directly so a
+    refactor that switches to a per-run average is caught."""
+
+    def test_rate_uses_last_three_batches_only(self):
+        import time as _time
+
+        tracker = ProgressTracker(source="polyhaven", tier="1k", total_materials=1000, kind="bake")
+        # Backdate the first batch by 10 minutes — the rolling window
+        # should drop it once we add three more.
+        tracker._window.append((_time.monotonic() - 600.0, 1))
+        tracker.record_batch(materials=10, bytes_added=0)
+        tracker.record_batch(materials=10, bytes_added=0)
+        tracker.record_batch(materials=10, bytes_added=0)
+        # Window now holds the three recent batches; the ancient one
+        # has been evicted by maxlen=3. Rate must be high (recent
+        # batches are sub-second apart in this test).
+        rate = tracker._rolling_rate_per_min()
+        assert rate > 100.0, f"rolling rate should reflect recent fast batches only, got {rate:.1f}"


### PR DESCRIPTION
## Summary
- Adds structured `bake_plan`/`bake_progress`/`bake_done` lines (and `derive_*` analogues) emitted with `flush=True` so the GitHub Actions live tail shows progress as the bake runs, not just after step exit.
- New `mat_vis_baker.progress` module with `ProgressTracker` (rolling 3-batch rate to dampen first-batch warm-up bias) and an `emit_bake_plan` helper.
- Wired into `hf_bake_per_file.bake_one_per_file` (plan after preflight, progress after every successful batch commit, done at end) and `hf_derive_per_file._derive_driver` (same plumbing for both PNG resize and KTX2 transcode paths).
- `__main__.main` reconfigures stdout for line buffering as a defensive belt to the Dagger container's existing `PYTHONUNBUFFERED=1` (already set in `_baker_container`).

Refs #217. No new runtime deps.

## Format contracts (verbatim per #217)
```
bake_plan source=<src> tier=<tier> total_materials=<N> expected_files≈<M> release_tag=<tag> repo=<owner/repo>
bake_progress source=<src> done=<k>/<N> (<pct>%) batches=<b> commits=<c> bytes_pushed=<X>MiB elapsed=<H>m<S>s rate=<r>mat/min eta=<E>m
bake_done source=<src> tier=<tier> ok=<k> failed=<f> skipped_preflight=<s> elapsed=<...>
```

## Judgment calls
- **`expected_files` is approximate**, hence the `≈` in the line shape: per-source channel sets are non-uniform (see `sources/ambientcg.py` comments), so the value is `total_materials × len(CANONICAL_CHANNELS)`. The issue's wording (`expected_files≈<M>`) reflects this.
- **Bytes accounting is fresh, not "reused"**: the issue suggested reusing manifest bytes accounting, but `release-manifest.json` doesn't track bytes today. Computing inline from the in-memory payloads `CommitOperationAdd` already holds avoids a second disk read while staying minimal.
- **`_discover_total_materials` is best-effort**: failures fall back to `total_materials=0` rather than crashing the bake. The real count surfaces in `bake_done` either way.
- **Done line is not emitted on the early `no materials` error path** — caller already gets an explicit error dict, and a synthetic done line could mislead a parser.

## Test plan
- [x] `uv run --extra baker --extra dev pytest tests/test_progress_lines.py -q` — 9 new tests, all passing
- [x] `uv run --extra baker --extra dev pytest tests/ -q --ignore=tests/e2e` — 347 passed, 5 skipped (1 pre-existing client-version drift failure deselected, unrelated to #217)
- [x] Verified live emission in a real bake invocation (test case `test_writes_one_hf_file_per_channel` shows the three lines flowing through `print(..., flush=True)`)
- [ ] Reviewer: confirm the live bake against `gerchowl/mat-vis-tst@v0.0.0-phase2` shows `bake_progress` lines in the GH Actions tail at batch boundaries