### PR TITLE
bugfix(audit-orphans): match LFS oid format between list and tree (#221)

### DIFF
--- a/src/mat_vis_baker/audit_orphans.py
+++ b/src/mat_vis_baker/audit_orphans.py
@@ -8,10 +8,20 @@ re-upload bytes-free, so the only practical damage is the storage
 accounting line on the repo. This module gives operators a way to see
 and (with explicit confirmation) reclaim that space.
 
-An orphan = an LFS blob (sha-256 ``oid``) returned by
-``HfApi.list_lfs_files`` whose ``oid`` does NOT appear as the
+An orphan = an LFS blob (sha-256 content hash) returned by
+``HfApi.list_lfs_files`` whose ``file_oid`` does NOT appear as the
 ``lfs.sha256`` of any file in the committed tree at ``revision``
 (default: ``main``).
+
+Note on the two oid attributes on ``LFSFileInfo``:
+
+- ``LFSFileInfo.oid`` is a 40-char SHA-1 — the Git blob OID of the
+  *pointer file* committed under refs/convert/lfs.
+- ``LFSFileInfo.file_oid`` is a 64-char SHA-256 — the actual LFS
+  content hash, which is what ``BlobLfsInfo.sha256`` returns from
+  ``list_repo_tree``. So the orphan check must compare ``file_oid``
+  against ``lfs.sha256`` (NOT ``oid`` against ``sha256``, which would
+  always disagree because they are different hash functions).
 
 Notes on the underlying API names — `huggingface_hub` (>=1.x) calls
 these `list_lfs_files` and `permanently_delete_lfs_files`. The issue
@@ -65,7 +75,10 @@ def _committed_lfs_oids(api: Any, repo_id: str, revision: str) -> set[str]:
         lfs = getattr(entry, "lfs", None)
         if lfs is None:
             continue
-        # `BlobLfsInfo.sha256` is what list_lfs_files returns as `oid`.
+        # `BlobLfsInfo.sha256` is the lowercased hex SHA-256 of the LFS
+        # blob content; matches `LFSFileInfo.file_oid` from
+        # `list_lfs_files` (NOT `LFSFileInfo.oid`, which is the SHA-1
+        # Git OID of the pointer file).
         sha = getattr(lfs, "sha256", None)
         if sha:
             oids.add(sha)
@@ -115,8 +128,10 @@ def audit_orphans(
     log.info("listing committed tree at %s@%s", repo_id, rev)
     referenced = _committed_lfs_oids(api, repo_id, rev)
 
-    orphan_blobs = [b for b in lfs_blobs if getattr(b, "oid", None) not in referenced]
-    orphan_oids = [b.oid for b in orphan_blobs]
+    # Compare on `file_oid` (LFS content SHA-256), not `oid` (pointer-file
+    # SHA-1). See module docstring for the two-attribute rationale (#221).
+    orphan_blobs = [b for b in lfs_blobs if getattr(b, "file_oid", None) not in referenced]
+    orphan_oids = [b.file_oid for b in orphan_blobs]
 
     deleted: int | None = None
     if delete and orphan_blobs:

--- a/tests/test_audit_orphans.py
+++ b/tests/test_audit_orphans.py
@@ -14,11 +14,25 @@ import pytest
 from mat_vis_baker.audit_orphans import audit_orphans
 
 
-def _fake_lfs_blob(oid: str, filename: str = "x") -> SimpleNamespace:
-    """Mimic ``huggingface_hub.hf_api.LFSFileInfo`` enough for the auditor."""
+def _fake_lfs_blob(
+    oid: str,
+    filename: str = "x",
+    file_oid: str | None = None,
+) -> SimpleNamespace:
+    """Mimic ``huggingface_hub.hf_api.LFSFileInfo`` enough for the auditor.
+
+    On the real API these two are *different* hash functions:
+    - ``oid``       = 40-char Git SHA-1 of the pointer file
+    - ``file_oid``  = 64-char SHA-256 of the LFS blob content (matches
+      ``BlobLfsInfo.sha256`` from ``list_repo_tree``).
+
+    Tests that don't care about the distinction can pass a single string
+    for both; #221's regression tests pass them separately to prove the
+    auditor compares on ``file_oid``.
+    """
     return SimpleNamespace(
         oid=oid,
-        file_oid=oid,
+        file_oid=file_oid if file_oid is not None else oid,
         filename=filename,
         size=1,
         ref="main",
@@ -153,3 +167,48 @@ class TestAuditOrphans:
         # Both scratch patterns must pass without allow_prod.
         audit_orphans(repo_id="gerchowl/mat-vis-tst", api=api)
         audit_orphans(repo_id="gerchowl/mat-vis-pr-tst", api=api)
+
+    # --- #221 regression: oid (SHA-1 pointer) vs file_oid (SHA-256 content) ---
+
+    def test_compares_on_file_oid_not_oid(self) -> None:
+        """Single matching blob → no orphans, even though ``oid`` differs.
+
+        Bug #221: the auditor used to compare ``LFSFileInfo.oid`` (the
+        Git pointer SHA-1) against ``BlobLfsInfo.sha256`` (the LFS
+        content SHA-256). Different hash functions never match, so
+        every blob looked orphaned. The fix compares ``file_oid``
+        against ``sha256`` — both are the lowercased hex SHA-256.
+        """
+        sha256 = "b9218b28613580501254426b643cc43e9ecb7b2e5892125ee1a7cc977388e50a"
+        sha1_pointer = "f84bae448eb7b78de429072bdde9fddaa812f54f"
+        blobs = [_fake_lfs_blob(oid=sha1_pointer, file_oid=sha256)]
+        tree = [_fake_repo_file("a.png", sha256)]
+        api = _make_api(lfs_blobs=blobs, tree_entries=tree)
+
+        result = audit_orphans(repo_id="gerchowl/mat-vis-tst", api=api)
+
+        assert result["total_lfs"] == 1
+        assert result["referenced"] == 1
+        assert result["orphans"] == []
+
+    def test_oid_collision_does_not_falsely_mark_referenced(self) -> None:
+        """One real match, one truly orphan → exactly one orphan.
+
+        Belt-and-braces for #221: even if the comparison were wrong we
+        could get accidental "0 orphans"; this test ensures both the
+        match and the miss are detected on the right attribute.
+        """
+        sha256_kept = "a" * 64
+        sha256_orphan = "b" * 64
+        blobs = [
+            _fake_lfs_blob(oid="1" * 40, file_oid=sha256_kept, filename="kept.png"),
+            _fake_lfs_blob(oid="2" * 40, file_oid=sha256_orphan, filename="crashed.png"),
+        ]
+        tree = [_fake_repo_file("kept.png", sha256_kept)]
+        api = _make_api(lfs_blobs=blobs, tree_entries=tree)
+
+        result = audit_orphans(repo_id="gerchowl/mat-vis-tst", api=api)
+
+        assert result["total_lfs"] == 2
+        assert result["referenced"] == 1
+        assert result["orphans"] == [sha256_orphan]


### PR DESCRIPTION
## Summary

Fixes #221.

`mat-vis-baker audit-orphans` was reporting every LFS blob as an orphan because it compared the wrong attribute. `HfApi.list_lfs_files` returns `LFSFileInfo` objects with two oid fields:

- `LFSFileInfo.oid` — 40-char Git **SHA-1** of the pointer file
- `LFSFileInfo.file_oid` — 64-char **SHA-256** of the LFS blob content

`HfApi.list_repo_tree` returns `BlobLfsInfo.sha256`, which is the **same SHA-256** as `file_oid`. The audit code was comparing `b.oid` (SHA-1) against `lfs.sha256` (SHA-256) — different hash functions never match, so on a 3748-blob repo every blob fell through into the orphan list and the log line read `total_lfs=3748 referenced=3748 orphans=3748` (which is contradictory on its face — every blob can't be both referenced *and* unreferenced).

### Probe evidence (against `gerchowl/mat-vis-tst@v0.0.0-phase2`, read-only)

```
LFSFileInfo(
  file_oid='e1bc4beada70c42f447344eeed8d21cd3a8d2a4cdc625f684fed5bbebea9695f',  # 64 hex, SHA-256
  filename='polyhaven/1k/worn_asphalt/normal.png',
  oid='f84bae448eb7b78de429072bdde9fddaa812f54f',                              # 40 hex, SHA-1
  ...
)

BlobLfsInfo(
  size=1837419,
  sha256='b9218b28613580501254426b643cc43e9ecb7b2e5892125ee1a7cc977388e50a',   # 64 hex, SHA-256
  pointer_size=132,
)
```

Cross-check: picking one tree entry's `lfs.sha256` and grepping `list_lfs_files` for a match on `file_oid` returns the corresponding `LFSFileInfo` immediately. Match on `oid` returns nothing.

### Fix

`src/mat_vis_baker/audit_orphans.py`:

- `audit_orphans` now compares `b.file_oid` against the SHA-256 set built from `lfs.sha256`.
- The orphan list emits content SHA-256s (`b.file_oid`), which is the actually-meaningful identifier — pointer-file SHA-1s aren't useful for any downstream LFS tool.
- Module docstring + inline comments pin the exact attribute semantics so this doesn't regress.

`src/mat_vis_baker/__main__.py` — unchanged. The log line and orphan-list dump still read correctly; the values they print are now meaningful.

## Test plan

- [x] Two new regression tests in `tests/test_audit_orphans.py`:
  - `test_compares_on_file_oid_not_oid` — single matching SHA-256, with `oid` (SHA-1) deliberately *different* from `file_oid` (SHA-256) → `orphans == []`.
  - `test_oid_collision_does_not_falsely_mark_referenced` — one true match + one true orphan → exactly one orphan returned (with the correct SHA-256).
- [x] `_fake_lfs_blob` fixture extended to take `oid` and `file_oid` separately so tests can exercise the bug shape; existing tests keep their old single-arg call style (defaults to `file_oid=oid`).
- [x] Full baker test suite runs green: `340 passed, 5 skipped, 1 deselected` (the deselected `test_client_runtime_version_matches_pyproject` is a pre-existing failure on `dev`, unrelated to this change — confirmed by re-running on the base commit).
- [ ] Reviewer can validate against the live repo with: `mat-vis-baker audit-orphans --repo gerchowl/mat-vis-tst --revision v0.0.0-phase2` — should now show `orphans=0` (or a small number, not 3748).