### PR TITLE
feat(baker): bounded retry/backoff for HF 429 commit-rate cap (#225)

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -75,13 +75,24 @@ permissions:
   contents: read
   issues: write          # needed by notify-on-failure composite action
 
-# Serialise dispatches on (repo, release, source, tier). Two parallel
-# dispatches against the same target tier would race on the catalog +
-# release-manifest commits — order is observable to clients.
+# #225: serialise *every* dispatch against a given HF repo. Previously
+# the group was (repo, release, source, tier), which let parallel
+# matrix bakes (different sources / tiers) saturate HF's 128-commits/hr
+# repo-wide cap and 429 the in-flight job at its final manifest commit.
+# A single repo-scoped writer keeps us safely under that cap.
+#
+# Trade-off: slower wallclock — bakes that previously fanned out
+# across 3-4 sources now serialize. The reliability win is worth it
+# under a hard external rate limit. The narrower (repo, release,
+# source, tier) grouping remains the right model once the helper's
+# 429 backoff (#225) absorbs the residual contention; it's noted as a
+# future option below for when we have telemetry showing the budget
+# is no longer biting.
 concurrency:
-  group: >-
-    bake-${{ inputs.repo-id }}-${{ inputs.release-tag }}-${{ inputs.source }}-${{ inputs.tier }}
+  group: bake-${{ inputs.repo-id }}-budget
   cancel-in-progress: false
+  # Future option (when 429 backoff makes per-tier serialization safe):
+  # group: bake-${{ inputs.repo-id }}-${{ inputs.release-tag }}-${{ inputs.source }}-${{ inputs.tier }}
 
 jobs:
   bake:

--- a/.github/workflows/derive.yml
+++ b/.github/workflows/derive.yml
@@ -78,14 +78,23 @@ permissions:
   contents: read
   issues: write          # needed by notify-on-failure composite action
 
-# Serialise dispatches on (release, source, source-tier, kind, target).
-# Two parallel dispatches against the same target tier would race on
-# the .tier_complete sentinel commit — order is observable to clients.
+# #225: serialise *every* dispatch against a given HF repo. The matrix
+# of phase-3 bakes + phase-4 derives in the same hour tripped HF's
+# 128-commits/hr repo-wide cap, killing the gpuopen derive at its
+# final manifest commit. Repo-scoped concurrency keeps one writer at
+# a time, well under the budget.
+#
+# Trade-off: derives that previously ran in parallel for different
+# (source-tier, kind) combos now serialize. Wallclock grows roughly
+# linearly with the number of derive flavours; given derives are
+# already cheap (~1-2h per source × tier), the reliability win
+# dominates. Narrower group noted below as a future option once
+# telemetry shows the budget is no longer biting.
 concurrency:
-  group: >-
-    derive-${{ inputs.repo-id }}-${{ inputs.release-tag }}-${{ inputs.source }}
-    -${{ inputs.source-tier }}-${{ inputs.kind }}
+  group: derive-${{ inputs.repo-id }}-budget
   cancel-in-progress: false
+  # Future option (when 429 backoff makes per-target serialization safe):
+  # group: derive-${{ inputs.repo-id }}-${{ inputs.release-tag }}-${{ inputs.source }}-${{ inputs.source-tier }}-${{ inputs.kind }}
 
 jobs:
   setup:

--- a/src/mat_vis_baker/hf_bake_per_file.py
+++ b/src/mat_vis_baker/hf_bake_per_file.py
@@ -44,6 +44,7 @@ from mat_vis_baker.common import (
     MaterialRecord,
     hash_textures,
 )
+from mat_vis_baker.hf_retry import _create_commit_with_backoff
 from mat_vis_baker.index_builder import build_index
 from mat_vis_baker.progress import ProgressTracker, emit_bake_plan
 from mat_vis_baker.source_tiers import is_supported, unsupported_tier_message
@@ -350,7 +351,12 @@ def bake_one_per_file(
             log.info("dry-run: would commit %d files for %d materials", len(ops), len(batch))
             sha = ""
         else:
-            commit = api.create_commit(
+            # #225: bounded 429 retry/backoff. Helper re-raises every other
+            # exception so the existing CAS / auth / network handlers
+            # keep working untouched.
+            commit = _create_commit_with_backoff(
+                api,
+                source=source,
                 repo_id=repo_id,
                 repo_type="dataset",
                 operations=ops,
@@ -470,7 +476,13 @@ def bake_one_per_file(
             merged = _merge_manifest_for_source(existing_manifest, source, tier, release_tag)
             manifest_path.write_text(json.dumps(merged, indent=2, ensure_ascii=False) + "\n")
             try:
-                catalog_commit = api.create_commit(
+                # #225: 429 retry sits *inside* the CAS loop. The helper
+                # re-raises 412 unchanged so the precondition matcher
+                # below still catches concurrent-writer conflicts; only
+                # 429 throttles get the bounded backoff treatment.
+                catalog_commit = _create_commit_with_backoff(
+                    api,
+                    source=source,
                     repo_id=repo_id,
                     repo_type="dataset",
                     operations=[
@@ -508,8 +520,10 @@ def bake_one_per_file(
                     continue
                 raise
 
-        # Sentinel commit — final marker.
-        sentinel_commit = api.create_commit(
+        # Sentinel commit — final marker. #225: 429-aware.
+        sentinel_commit = _create_commit_with_backoff(
+            api,
+            source=source,
             repo_id=repo_id,
             repo_type="dataset",
             operations=[

--- a/src/mat_vis_baker/hf_derive_per_file.py
+++ b/src/mat_vis_baker/hf_derive_per_file.py
@@ -54,6 +54,7 @@ from PIL import Image
 
 from mat_vis_baker.common import CANONICAL_CHANNELS, TIER_TO_PX
 from mat_vis_baker.hf_bake_per_file import _guard_prod_target
+from mat_vis_baker.hf_retry import _create_commit_with_backoff
 from mat_vis_baker.progress import ProgressTracker, emit_bake_plan
 
 log = logging.getLogger("mat-vis-baker.hf_derive_per_file")
@@ -472,7 +473,12 @@ def _derive_driver(
             )
             sha = ""
         else:
-            commit = api.create_commit(
+            # #225: 429-aware. Per-batch derive commits are the busiest
+            # writers — phase-4 derive jobs against a freshly baked tier
+            # were the trigger for the original 429.
+            commit = _create_commit_with_backoff(
+                api,
+                source=source,
                 repo_id=repo_id,
                 repo_type="dataset",
                 operations=list(pending_ops),
@@ -604,7 +610,12 @@ def _derive_driver(
                     "utf-8"
                 )
                 try:
-                    commit = api.create_commit(
+                    # #225: 429-aware inside the CAS loop — same shape as
+                    # the bake-side catalog commit; helper re-raises 412
+                    # so the precondition matcher below still fires.
+                    commit = _create_commit_with_backoff(
+                        api,
+                        source=source,
                         repo_id=repo_id,
                         repo_type="dataset",
                         operations=[
@@ -655,7 +666,11 @@ def _derive_driver(
     if dry_run:
         log.info("%s dry-run: would commit sentinel %s", label, sentinel_path)
     else:
-        commit = api.create_commit(
+        # #225: 429-aware. The sentinel is the very last commit and the
+        # one that died in #225's stack trace — wrap it.
+        commit = _create_commit_with_backoff(
+            api,
+            source=source,
             repo_id=repo_id,
             repo_type="dataset",
             operations=[

--- a/src/mat_vis_baker/hf_retry.py
+++ b/src/mat_vis_baker/hf_retry.py
@@ -1,0 +1,223 @@
+"""Bounded retry/backoff for HF Hub 429 commit-rate throttling (#225).
+
+The HF Hub enforces two rate caps that surface as ``429 Too Many
+Requests`` on ``api.create_commit``:
+
+1. **Commit-rate cap** — ~128 commits per hour per repo. Phase-3 matrix
+   bakes plus phase-4 derives running in the same hour against the same
+   repo can saturate this, killing the in-flight job at its final
+   manifest commit (see #225 stack trace).
+
+2. **API-rate cap** — ~1000 requests per 300s rolling window. Not
+   biting yet, but surfaces as the same 429 status, so the same retry
+   path handles it.
+
+This module wraps every ``api.create_commit`` call site (bake +
+derive) with :func:`_create_commit_with_backoff`, which:
+
+- Detects 429 via ``response.status_code``.
+- Parses ``Retry-After`` (HTTP-date or integer seconds) from headers.
+- Falls back to parsing ``"Retry after N seconds"`` from the response
+  body.
+- Falls back to exponential backoff with jitter, starting at 30s and
+  capped at 120s.
+- Caps total attempts at ``max_retries`` (default 5).
+- Emits one structured ``bake_throttle`` log line per retry, mirroring
+  the format conventions in :mod:`mat_vis_baker.progress` (single line,
+  ``key=value`` pairs, ``flush=True`` for live-tail visibility).
+- Re-raises every other exception unchanged so the existing 412 (CAS
+  precondition) retry loop in :mod:`hf_bake_per_file` keeps working.
+
+No new runtime deps — just stdlib ``time`` + a small regex on the body.
+"""
+
+from __future__ import annotations
+
+import email.utils
+import random
+import re
+import time
+from typing import Any
+
+from huggingface_hub.errors import HfHubHTTPError
+
+# Backoff envelope. The 30s floor matches the smallest ``Retry-After``
+# HF observed in #225's stack trace; the 120s cap keeps a runaway repo
+# from stalling a workflow for the full GH-Actions step budget.
+_BACKOFF_FLOOR_S = 30.0
+_BACKOFF_CEIL_S = 120.0
+_DEFAULT_MAX_RETRIES = 5
+
+# Body fallback: HF's API includes a human-readable "Retry after N
+# seconds" phrase in the JSON error body when the header is absent on
+# some edge cases. Match it case-insensitively.
+_BODY_RETRY_RE = re.compile(r"retry after\s+(\d+)\s*seconds?", re.IGNORECASE)
+
+
+def _parse_retry_after_header(value: str | None) -> float | None:
+    """Parse ``Retry-After``: integer seconds or HTTP-date.
+
+    Returns ``None`` if absent or unparsable so the caller can fall
+    back to body parsing or exponential backoff.
+    """
+    if not value:
+        return None
+    value = value.strip()
+    # Integer seconds form (e.g. "30").
+    try:
+        return float(int(value))
+    except ValueError:
+        pass
+    # HTTP-date form (e.g. "Wed, 21 Oct 2026 07:28:00 GMT").
+    try:
+        dt = email.utils.parsedate_to_datetime(value)
+        if dt is None:
+            return None
+        delta = dt.timestamp() - time.time()
+        return max(0.0, delta)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_retry_after_body(body: str | None) -> float | None:
+    """Parse ``"Retry after N seconds"`` from the response body."""
+    if not body:
+        return None
+    m = _BODY_RETRY_RE.search(body)
+    if m is None:
+        return None
+    try:
+        return float(int(m.group(1)))
+    except ValueError:
+        return None
+
+
+def _exponential_backoff(attempt: int) -> float:
+    """Exponential backoff with jitter, clamped to [floor, ceil].
+
+    ``attempt`` is 1-indexed. attempt=1 → ~30s, attempt=2 → ~60s,
+    attempt=3+ → 120s ceiling. Adds ±10% jitter to desync concurrent
+    retriers (matrix-bake N writers all woken by the same 429 would
+    otherwise re-burst together).
+    """
+    base = _BACKOFF_FLOOR_S * (2 ** (attempt - 1))
+    base = min(base, _BACKOFF_CEIL_S)
+    jitter = base * 0.1 * (random.random() * 2 - 1)  # ±10%
+    return max(_BACKOFF_FLOOR_S, base + jitter)
+
+
+def _extract_response_pieces(exc: HfHubHTTPError) -> tuple[int | None, dict, str]:
+    """Pull (status_code, headers, body_text) from an HfHubHTTPError.
+
+    Defensive: every attribute lookup is guarded because the response
+    object's exact shape varies between huggingface_hub versions and
+    test fixtures (httpx.Response in real life, SimpleNamespace in
+    unit tests).
+    """
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    headers = getattr(response, "headers", None) or {}
+    # httpx.Headers behaves dict-like; SimpleNamespace test fixtures use
+    # a plain dict. Both support ``.get``.
+    body = ""
+    try:
+        body = getattr(response, "text", "") or ""
+    except Exception:  # noqa: BLE001 — body access can raise on detached responses
+        body = ""
+    return status, headers, body
+
+
+def _format_elapsed(seconds: float) -> str:
+    """Mirror :func:`mat_vis_baker.progress._format_elapsed` so the
+    ``bake_throttle`` line speaks the same time format as the
+    ``bake_progress`` lines around it."""
+    total = int(seconds)
+    minutes, secs = divmod(total, 60)
+    return f"{minutes}m{secs}s"
+
+
+def _emit_throttle_line(
+    *,
+    source: str,
+    attempt: int,
+    max_retries: int,
+    wait_s: float,
+    elapsed_s: float,
+) -> None:
+    """Single-line, structured throttle log — one per retry.
+
+    Format mirrors the contract in :mod:`mat_vis_baker.progress`:
+    leading prefix token, ``key=value`` pairs, ``flush=True`` so the
+    line streams to GH Actions' live tail rather than buffering until
+    process exit.
+    """
+    print(
+        f"bake_throttle source={source} retry={attempt}/{max_retries} "
+        f"reason=429 wait_s={wait_s:.1f} elapsed={_format_elapsed(elapsed_s)}",
+        flush=True,
+    )
+
+
+def _create_commit_with_backoff(
+    api: Any,
+    *,
+    source: str = "unknown",
+    max_retries: int = _DEFAULT_MAX_RETRIES,
+    _sleep: Any = time.sleep,
+    **kwargs: Any,
+) -> Any:
+    """Wrap ``api.create_commit(**kwargs)`` with bounded 429 retry.
+
+    On ``HfHubHTTPError`` with ``response.status_code == 429``:
+
+    1. Parse ``Retry-After`` header (integer seconds or HTTP-date).
+    2. Fall back to parsing the body for ``"Retry after N seconds"``.
+    3. Fall back to exponential backoff with jitter, in
+       ``[30s, 120s]``.
+    4. Sleep that long, emit a structured ``bake_throttle`` log line,
+       and retry.
+
+    Bounded at ``max_retries`` (default 5). Every other exception
+    (412 CAS, network, auth, etc.) re-raises unchanged so existing
+    handlers — notably the 412 retry loop in
+    :mod:`hf_bake_per_file.bake_one_per_file` — keep working.
+
+    ``source`` is plumbed through for log-line attribution; both bake
+    and derive call sites pass it. ``_sleep`` is injectable so unit
+    tests can run instantly.
+    """
+    started = time.monotonic()
+    last_exc: HfHubHTTPError | None = None
+    for attempt in range(1, max_retries + 1):
+        try:
+            return api.create_commit(**kwargs)
+        except HfHubHTTPError as e:
+            status, headers, body = _extract_response_pieces(e)
+            if status != 429:
+                # Not a throttle — re-raise so 412 / auth / network
+                # propagate to the caller's handlers untouched.
+                raise
+            last_exc = e
+            if attempt == max_retries:
+                # Out of retries — surface the original 429 so the
+                # caller sees the actual HF response, not a wrapper.
+                raise
+            wait_s = _parse_retry_after_header(headers.get("Retry-After"))
+            if wait_s is None:
+                wait_s = _parse_retry_after_body(body)
+            if wait_s is None:
+                wait_s = _exponential_backoff(attempt)
+            wait_s = max(_BACKOFF_FLOOR_S, min(wait_s, _BACKOFF_CEIL_S))
+            _emit_throttle_line(
+                source=source,
+                attempt=attempt,
+                max_retries=max_retries,
+                wait_s=wait_s,
+                elapsed_s=time.monotonic() - started,
+            )
+            _sleep(wait_s)
+    # Unreachable — the loop either returns or re-raises — but keep a
+    # defensive raise so type-checkers don't infer ``None``.
+    if last_exc is not None:  # pragma: no cover
+        raise last_exc
+    raise RuntimeError("create_commit retry loop exited without result")  # pragma: no cover

--- a/tests/test_hf_retry.py
+++ b/tests/test_hf_retry.py
@@ -1,0 +1,290 @@
+"""Unit tests for the HF 429 retry/backoff helper (#225).
+
+The helper wraps ``api.create_commit`` with bounded retries on 429,
+parses ``Retry-After`` from the header (with a body-text fallback and
+exponential-backoff fallback after that), and emits one structured
+``bake_throttle`` log line per retry. Every non-429 exception
+re-raises unchanged so the existing 412 (CAS precondition) retry loop
+in :mod:`mat_vis_baker.hf_bake_per_file` keeps working.
+
+These tests must NOT touch the real HF API — phase-4 derives are
+running against ``gerchowl/mat-vis-tst@v0.0.0-phase3`` and any traffic
+would fight for the very rate budget this module exists to defend.
+Pure mocks throughout.
+"""
+
+from __future__ import annotations
+
+import re
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from huggingface_hub.errors import HfHubHTTPError
+
+from mat_vis_baker import hf_retry
+from mat_vis_baker.hf_retry import _create_commit_with_backoff
+
+
+_THROTTLE_RE = re.compile(
+    r"^bake_throttle source=(?P<source>\S+) "
+    r"retry=(?P<attempt>\d+)/(?P<max>\d+) "
+    r"reason=429 wait_s=(?P<wait>[\d.]+) "
+    r"elapsed=(?P<elapsed>\d+m\d+s)$"
+)
+
+
+def _make_429(retry_after: str | None = "30", body: str = "") -> HfHubHTTPError:
+    """Build a fake 429 with the same attribute surface
+    huggingface_hub's real HfHubHTTPError exposes — status_code,
+    headers (dict-like), text. SimpleNamespace is enough; the helper
+    only does ``.get`` on headers and reads ``.text`` defensively.
+
+    HfHubHTTPError.__init__ touches ``response.headers.get`` for a few
+    diagnostic IDs and ``response.request`` — supply both as
+    no-ops so the constructor doesn't choke."""
+    headers: dict[str, str] = {}
+    if retry_after is not None:
+        headers["Retry-After"] = retry_after
+    response = SimpleNamespace(
+        status_code=429,
+        headers=headers,
+        text=body,
+        request=SimpleNamespace(method="POST", url="https://huggingface.co/test"),
+    )
+    return HfHubHTTPError("429 Too Many Requests", response=response)  # type: ignore[arg-type]
+
+
+def _make_412() -> Exception:
+    """A 412 CAS precondition surfaces as a plain Exception with the
+    string ``"412 Precondition Failed"`` in the existing baker code —
+    the CAS loop matches on string content, not type. Use the same
+    shape so the test reflects production behaviour."""
+    return Exception("412 Precondition Failed: parent_commit mismatch")
+
+
+# ── basic 429 retry path ─────────────────────────────────────────
+
+
+def test_retry_then_succeed_returns_commit(capsys):
+    """One 429 → sleep → second call returns the commit."""
+    api = MagicMock()
+    sleeps: list[float] = []
+    sentinel = SimpleNamespace(oid="abc123")
+    api.create_commit.side_effect = [_make_429(retry_after="30"), sentinel]
+
+    result = _create_commit_with_backoff(
+        api,
+        source="ambientcg",
+        _sleep=sleeps.append,
+        repo_id="x/y",
+    )
+
+    assert result is sentinel
+    assert api.create_commit.call_count == 2
+    assert sleeps == [30.0]
+    out = capsys.readouterr().out.strip().splitlines()
+    assert len(out) == 1
+    m = _THROTTLE_RE.match(out[0])
+    assert m is not None, f"throttle line did not match contract: {out[0]!r}"
+    assert m.group("source") == "ambientcg"
+    assert m.group("attempt") == "1"
+    assert m.group("wait") == "30.0"
+
+
+def test_retry_after_header_http_date_is_parsed(capsys):
+    """``Retry-After`` may be an HTTP-date instead of seconds; the
+    helper must compute the delta from now and sleep that long."""
+    import email.utils
+    import time
+
+    future = email.utils.formatdate(time.time() + 45, usegmt=True)
+    api = MagicMock()
+    sleeps: list[float] = []
+    sentinel = SimpleNamespace(oid="abc")
+    api.create_commit.side_effect = [_make_429(retry_after=future), sentinel]
+
+    result = _create_commit_with_backoff(api, source="polyhaven", _sleep=sleeps.append)
+    assert result is sentinel
+    # Allow a few seconds slack for clock drift in CI.
+    assert len(sleeps) == 1
+    assert 30.0 <= sleeps[0] <= 60.0
+
+
+def test_body_fallback_when_header_missing(capsys):
+    """Header absent but body says ``"Retry after 30 seconds"`` → use
+    the body value (matches the real #225 stack trace shape)."""
+    api = MagicMock()
+    sleeps: list[float] = []
+    sentinel = SimpleNamespace(oid="abc")
+    api.create_commit.side_effect = [
+        _make_429(
+            retry_after=None,
+            body=(
+                "You have exceeded the rate limit for repository commits "
+                "(128 per hour). Retry after 30 seconds (647/1000 requests "
+                "remaining in current 300s window)."
+            ),
+        ),
+        sentinel,
+    ]
+
+    result = _create_commit_with_backoff(api, source="gpuopen", _sleep=sleeps.append)
+    assert result is sentinel
+    assert sleeps == [30.0]
+
+
+def test_exponential_backoff_when_no_hint(capsys, monkeypatch):
+    """Both header and body silent → exponential backoff with jitter,
+    floored at 30s and capped at 120s. Pin random for determinism."""
+    monkeypatch.setattr(hf_retry.random, "random", lambda: 0.5)  # zero jitter
+
+    api = MagicMock()
+    sleeps: list[float] = []
+    sentinel = SimpleNamespace(oid="abc")
+    api.create_commit.side_effect = [
+        _make_429(retry_after=None, body=""),
+        sentinel,
+    ]
+
+    result = _create_commit_with_backoff(api, source="ambientcg", _sleep=sleeps.append)
+    assert result is sentinel
+    assert len(sleeps) == 1
+    assert sleeps[0] == 30.0  # floor
+
+
+# ── exhaustion path ──────────────────────────────────────────────
+
+
+def test_429_forever_raises_after_max_retries(capsys):
+    """``max_retries`` consecutive 429s → re-raise the original
+    HfHubHTTPError so the caller sees the real HF response."""
+    api = MagicMock()
+    sleeps: list[float] = []
+    api.create_commit.side_effect = [_make_429(retry_after="30") for _ in range(10)]
+
+    with pytest.raises(HfHubHTTPError):
+        _create_commit_with_backoff(
+            api,
+            source="polyhaven",
+            max_retries=3,
+            _sleep=sleeps.append,
+        )
+
+    # 3 attempts; sleeps only happen between retries → 2 sleeps emitted.
+    assert api.create_commit.call_count == 3
+    assert len(sleeps) == 2
+    out = capsys.readouterr().out.strip().splitlines()
+    assert len(out) == 2
+    for i, line in enumerate(out, start=1):
+        m = _THROTTLE_RE.match(line)
+        assert m is not None, line
+        assert m.group("attempt") == str(i)
+        assert m.group("max") == "3"
+
+
+# ── non-429 propagation path ─────────────────────────────────────
+
+
+def test_412_reraises_immediately_no_retry(capsys):
+    """412 from create_commit must re-raise unchanged — the existing
+    CAS retry loop in ``bake_one_per_file`` matches on string content,
+    so the helper must let it through to that handler."""
+    api = MagicMock()
+    sleeps: list[float] = []
+    exc = _make_412()
+    api.create_commit.side_effect = exc
+
+    with pytest.raises(Exception) as excinfo:
+        _create_commit_with_backoff(api, source="ambientcg", _sleep=sleeps.append)
+
+    assert excinfo.value is exc
+    assert api.create_commit.call_count == 1
+    assert sleeps == []
+    assert capsys.readouterr().out == ""
+
+
+def test_other_HfHubHTTPError_status_codes_reraise(capsys):
+    """A 500 / 401 / etc. surfacing as HfHubHTTPError must NOT be
+    retried — only 429 is throttle. Authentication failures retried
+    silently would mask real config bugs."""
+    api = MagicMock()
+    response = SimpleNamespace(
+        status_code=500,
+        headers={},
+        text="server boom",
+        request=SimpleNamespace(method="POST", url="https://huggingface.co/test"),
+    )
+    err = HfHubHTTPError("500", response=response)  # type: ignore[arg-type]
+    api.create_commit.side_effect = err
+
+    with pytest.raises(HfHubHTTPError):
+        _create_commit_with_backoff(api, source="x", _sleep=lambda _w: None)
+    assert api.create_commit.call_count == 1
+
+
+# ── log-line format contract ─────────────────────────────────────
+
+
+def test_throttle_line_matches_progress_module_format(capsys):
+    """Format mirrors :mod:`mat_vis_baker.progress` — single line,
+    leading prefix token, ``key=value`` pairs, no trailing newline
+    fluff. Downstream log scrapers grep on this exact shape."""
+    api = MagicMock()
+    sentinel = SimpleNamespace(oid="abc")
+    api.create_commit.side_effect = [
+        _make_429(retry_after="30"),
+        _make_429(retry_after="30"),
+        sentinel,
+    ]
+
+    _create_commit_with_backoff(api, source="ambientcg", _sleep=lambda _w: None)
+
+    out = capsys.readouterr().out.strip().splitlines()
+    assert len(out) == 2
+    for line in out:
+        assert _THROTTLE_RE.match(line) is not None, line
+
+
+def test_default_source_is_unknown(capsys):
+    """Helper accepts ``source`` as optional; absent → ``unknown`` so
+    callers that haven't been updated yet still emit valid lines."""
+    api = MagicMock()
+    sentinel = SimpleNamespace(oid="abc")
+    api.create_commit.side_effect = [_make_429(retry_after="30"), sentinel]
+
+    _create_commit_with_backoff(api, _sleep=lambda _w: None)
+
+    out = capsys.readouterr().out.strip().splitlines()
+    assert len(out) == 1
+    m = _THROTTLE_RE.match(out[0])
+    assert m is not None
+    assert m.group("source") == "unknown"
+
+
+# ── 412 CAS loop integration ─────────────────────────────────────
+
+
+def test_cas_412_loop_still_works_with_helper_wrapped_call(capsys):
+    """Smoke test: when the helper wraps a create_commit that the CAS
+    loop in ``bake_one_per_file`` calls, a 412 still bubbles up and
+    the loop's ``"412"/"precondition"/"parent_commit"`` matcher fires.
+
+    Don't spin up the whole baker — just simulate the call chain so a
+    refactor that accidentally swallows 412 in the helper trips this.
+    """
+    api = MagicMock()
+    api.create_commit.side_effect = _make_412()
+
+    # Re-implement the CAS matcher inline (matches lines 492-509 of
+    # hf_bake_per_file.py at HEAD). If the helper ever swallows 412,
+    # this branch will never fire and the assert will trip.
+    matched_412 = False
+    try:
+        _create_commit_with_backoff(api, source="ambientcg", _sleep=lambda _w: None)
+    except Exception as e:  # noqa: BLE001
+        msg = str(e).lower()
+        matched_412 = "412" in msg or "precondition" in msg or "parent_commit" in msg
+
+    assert matched_412, "412 must propagate through the helper to the CAS loop"
+    assert api.create_commit.call_count == 1


### PR DESCRIPTION
## Summary

Closes #225.

The HF Hub enforces ~128 commits / hour / repo. Phase-3 matrix bakes plus
phase-4 derives running in the same hour saturated this cap and the
gpuopen derive job died at its final manifest commit:

```
huggingface_hub.errors.HfHubHTTPError: 429 Client Error: Too Many Requests
You have exceeded the rate limit for repository commits (128 per hour).
Retry after 30 seconds (647/1000 requests remaining in current 300s window).
```

This PR adds a small bounded retry helper around every `api.create_commit`
call site, plus a repo-scoped GH-Actions concurrency cap so cross-source
matrix dispatches no longer race for the same per-repo budget.

## Changes

- **`src/mat_vis_baker/hf_retry.py`** (new) — `_create_commit_with_backoff(api, *, source="unknown", max_retries=5, **kwargs)`:
  - Detects 429 via `response.status_code`.
  - Parses `Retry-After` header (integer seconds or HTTP-date).
  - Falls back to parsing `"Retry after N seconds"` from the response body.
  - Falls back to exponential backoff with ±10% jitter, floored at 30s, capped at 120s.
  - Bounded at 5 attempts; re-raises original `HfHubHTTPError` on exhaustion.
  - Re-raises every other exception unchanged so the existing 412 CAS retry loop in `bake_one_per_file` keeps working.
- **`src/mat_vis_baker/hf_bake_per_file.py`** — wired the helper into all 3 `create_commit` sites: per-batch flush, catalog + manifest CAS loop, sentinel.
- **`src/mat_vis_baker/hf_derive_per_file.py`** — wired the helper into all 3 `create_commit` sites: per-batch flush, catalog + manifest CAS loop, sentinel.
- **`.github/workflows/bake.yml` + `.github/workflows/derive.yml`** — replaced the per-tier concurrency group with a repo-scoped `<repo-id>-budget` group so all writers against a given HF repo serialize. Trade-off (slower wallclock, higher reliability under rate-limit cap) documented in header comment along with the narrower future-option group preserved as a comment.
- **`tests/test_hf_retry.py`** (new) — 10 unit tests with pure mocks (no real HF traffic, since phase-4 derives are still running against `gerchowl/mat-vis-tst@v0.0.0-phase3`).

## Structured log format

One line per retry, streaming via `print(..., flush=True)` to match the `progress.py` conventions from #217:

```
bake_throttle source=<src> retry=<n>/<max> reason=429 wait_s=<W> elapsed=<NmSs>
```

Regex contract (asserted in tests):

```
^bake_throttle source=\S+ retry=\d+/\d+ reason=429 wait_s=[\d.]+ elapsed=\d+m\d+s$
```

## Acceptance criteria checklist (#225)

- [x] Helper `_create_commit_with_backoff` parses `Retry-After` header (int seconds + HTTP-date).
- [x] Falls back to body parse, then exponential backoff (30s..120s).
- [x] Bounded at 5 retries.
- [x] Re-raises non-429 exceptions unchanged (412 CAS continues to work).
- [x] Structured `bake_throttle` log per retry, `flush=True`.
- [x] Applied at every `api.create_commit` site in bake + derive (6 sites total).
- [x] Workflow concurrency cap added (repo-scoped, `cancel-in-progress: false`).
- [x] No new runtime deps.
- [x] Unit tests with pure mocks (no real HF traffic).
- [x] Existing baker test suite passes (`uv run --extra baker pytest tests/ --ignore=tests/e2e` → 359 passed, 5 skipped, 1 deselected\*).

\* Deselected test is `tests/test_version_sync.py::test_client_runtime_version_matches_pyproject` — pre-existing failure unrelated to this PR (`mat-vis-client` version drift), reproduces on `dev` HEAD.

## Test plan

- [x] `uv run --extra baker --extra dev pytest tests/test_hf_retry.py -q` (10 passed).
- [x] `uv run --extra baker --extra dev pytest tests/ -q --ignore=tests/e2e` (no regressions).
- [x] `uv run --extra dev ruff check` + `ruff format --check` (clean).
- [x] `yamllint .github/workflows/bake.yml .github/workflows/derive.yml` (clean).
- [ ] Phase-6 e2e concurrency stress test (`MAT_VIS_E2E_CONCURRENCY=3 uv run --extra baker pytest tests/e2e/test_per_file_roundtrip.py::TestConcurrentBakesShareTag -v`) — exercised by the existing #210 test once phase-4 derives complete; expectations not changed (helper transparently passes through successful commits).
- [ ] Real workflow dispatch on `gerchowl/mat-vis-tst` once phase-4 finishes — confirms the repo-scoped concurrency serializes as intended.

## Judgment calls

1. **Workflow concurrency**: GH Actions only supports one `concurrency:` block per workflow/job, not nested. The issue offered two options; I chose the workflow-level repo-scoped group (`<repo-id>-budget`) because it's the smallest change and most aligned with "one writer per repo at a time without cancellation". The narrower per-(source,tier) group is preserved as a comment-noted future option for when telemetry shows the 429 backoff has absorbed enough residual contention to safely re-parallelize.

2. **Re-raise the original 429 on exhaustion** rather than wrapping in a new exception type. Keeps the call-site's existing exception-handling behaviour identical when retries genuinely run out, surfaces the real HF response to the operator, and leaves room for a future structured `RetriesExhaustedError` if anyone needs to distinguish.

3. **`source="unknown"` default**: helper accepts source as an optional kwarg so future call sites that haven't been updated still emit valid `bake_throttle` lines. Both bake and derive currently pass an explicit source.

4. **Exponential backoff jitter is ±10%, not ±50%**: enough to desync N concurrent retriers without making the worst-case wait blow past the 120s ceiling. Real production traffic at low concurrency (≤4 matrix workers) doesn't need wider jitter.