### PR TITLE
feat(baker): bytes-aware batching for HF per-commit headroom (#228)

### DIFF
--- a/.dagger/src/mat_vis_ci/_bake_cli.py
+++ b/.dagger/src/mat_vis_ci/_bake_cli.py
@@ -19,6 +19,7 @@ def bake_argv(
     limit: int,
     dry_run: bool,
     allow_prod: bool,
+    batch_max_bytes: int = 700 * 1024 * 1024,
 ) -> list[str]:
     """Build the ``mat-vis-baker hf-bake`` argv list.
 
@@ -30,6 +31,10 @@ def bake_argv(
     retired with the legacy tar substrate (#189 / ADR-0012) — per-file
     bakes use pre-flight tree scan + batch commits as the resumability
     primitive instead of shard-N-of-K artifacts.
+
+    #228: ``--batch-max-bytes`` is always emitted. The CLI defaults
+    match this default, but emitting unconditionally keeps the Dagger
+    surface explicit (and lets a workflow input override it).
     """
     argv: list[str] = [
         "uv",
@@ -47,6 +52,8 @@ def bake_argv(
         str(offset),
         "--batch-size",
         str(batch_size),
+        "--batch-max-bytes",
+        str(batch_max_bytes),
     ]
     if limit > 0:
         argv += ["--limit", str(limit)]

--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -547,7 +547,15 @@ class MatVisCi:
         ] = False,
         limit: Annotated[int, Doc("Max materials (0 = no limit)")] = 0,
         offset: Annotated[int, Doc("Skip first N materials")] = 0,
-        batch_size: Annotated[int, Doc("Materials per streaming batch")] = 50,
+        batch_size: Annotated[int, Doc("Materials per atomic commit (count ceiling, #228)")] = 300,
+        batch_max_bytes: Annotated[
+            int,
+            Doc(
+                "Bytes per atomic commit (default 700 MiB). #228: flush "
+                "trips on first-of-N-or-bytes. HF caps at 1 GiB/commit; "
+                "700 MiB leaves room for catalog + manifest + sentinel."
+            ),
+        ] = 700 * 1024 * 1024,
         dry_run: Annotated[bool, Doc("Build locally; skip HF push")] = False,
     ) -> str:
         """Bake one (source, tier) into an HF commit (#136 / ADR-0012).
@@ -580,6 +588,7 @@ class MatVisCi:
             repo_id=repo_id,
             offset=offset,
             batch_size=batch_size,
+            batch_max_bytes=batch_max_bytes,
             limit=limit,
             dry_run=dry_run,
             allow_prod=allow_prod,
@@ -717,7 +726,14 @@ class MatVisCi:
             bool, Doc("Opt-in flag required to target any non-*-tst repo")
         ] = False,
         limit: Annotated[int, Doc("Max materials (0 = no limit)")] = 0,
-        batch_size: Annotated[int, Doc("Materials per atomic commit batch")] = 50,
+        batch_size: Annotated[int, Doc("Materials per atomic commit (count ceiling, #228)")] = 300,
+        batch_max_bytes: Annotated[
+            int,
+            Doc(
+                "Bytes per atomic commit (default 700 MiB). #228: flush "
+                "trips on first-of-N-or-bytes. HF caps at 1 GiB/commit."
+            ),
+        ] = 700 * 1024 * 1024,
         dry_run: Annotated[bool, Doc("Skip the HF push; build locally")] = False,
     ) -> str:
         """Per-file derive: resize an existing per-file tier into a smaller one (#204).
@@ -754,6 +770,8 @@ class MatVisCi:
             "env:HF_TOKEN",
             "--batch-size",
             str(batch_size),
+            "--batch-max-bytes",
+            str(batch_max_bytes),
         ]
         if limit > 0:
             cmd += ["--limit", str(limit)]
@@ -777,7 +795,14 @@ class MatVisCi:
         ] = False,
         target_tier: Annotated[str, Doc("KTX2 target tier label; empty = ktx2-<source-tier>")] = "",
         limit: Annotated[int, Doc("Max materials (0 = no limit)")] = 0,
-        batch_size: Annotated[int, Doc("Materials per atomic commit batch")] = 50,
+        batch_size: Annotated[int, Doc("Materials per atomic commit (count ceiling, #228)")] = 300,
+        batch_max_bytes: Annotated[
+            int,
+            Doc(
+                "Bytes per atomic commit (default 700 MiB). #228: flush "
+                "trips on first-of-N-or-bytes. HF caps at 1 GiB/commit."
+            ),
+        ] = 700 * 1024 * 1024,
         dry_run: Annotated[bool, Doc("Skip the HF push; build locally")] = False,
     ) -> str:
         """Per-file derive: transcode an existing per-file PNG tier to KTX2 (#204).
@@ -815,6 +840,8 @@ class MatVisCi:
             "env:HF_TOKEN",
             "--batch-size",
             str(batch_size),
+            "--batch-max-bytes",
+            str(batch_max_bytes),
         ]
         if target_tier:
             cmd += ["--target-tier", target_tier]

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -46,9 +46,14 @@ on:  # yamllint disable-line rule:truthy
         default: '0'
         type: string
       batch-size:
-        description: 'Materials per streaming batch'
+        description: 'Materials per atomic commit (count ceiling). #228: bytes is the binding constraint at typical content; 300 is a safe overshoot.'
         required: false
-        default: '50'
+        default: '300'
+        type: string
+      batch-max-bytes:
+        description: 'Bytes per atomic commit (#228). 734003200 = 700 MiB; HF caps at 1 GiB/commit, leaving headroom for catalog + manifest + sentinel.'
+        required: false
+        default: '734003200'
         type: string
       release-tag:
         description: 'Calver data release tag (e.g. v2026.04.1)'
@@ -134,6 +139,7 @@ jobs:
             --limit=${{ inputs.limit }}
             --offset=${{ inputs.offset }}
             --batch-size=${{ inputs.batch-size }}
+            --batch-max-bytes=${{ inputs.batch-max-bytes }}
             ${{ inputs.dry-run == true && '--dry-run=true' || '' }}
 
       # ADR-0011 / mat-vis#152 phase-c: lock the Layer-2 upstream mirror

--- a/.github/workflows/derive.yml
+++ b/.github/workflows/derive.yml
@@ -73,6 +73,16 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: false
         type: boolean
+      batch-size:
+        description: 'Materials per atomic commit (count ceiling, #228). 300 is a safe overshoot — bytes is the binding constraint at typical content.'
+        required: false
+        default: '300'
+        type: string
+      batch-max-bytes:
+        description: 'Bytes per atomic commit (#228). 734003200 = 700 MiB; HF caps at 1 GiB/commit.'
+        required: false
+        default: '734003200'
+        type: string
 
 permissions:
   contents: read
@@ -157,6 +167,8 @@ jobs:
             --repo-id=${{ inputs.repo-id }}
             --hf-token=env:HF_TOKEN
             --allow-prod=${{ inputs.allow-prod }}
+            --batch-size=${{ inputs.batch-size }}
+            --batch-max-bytes=${{ inputs.batch-max-bytes }}
 
   report:
     needs: [setup, derive]

--- a/src/mat_vis_baker/__main__.py
+++ b/src/mat_vis_baker/__main__.py
@@ -227,6 +227,7 @@ def cmd_hf_derive(args: argparse.Namespace) -> int:
         allow_prod=args.allow_prod,
         limit=args.limit,
         batch_size=args.batch_size,
+        batch_max_bytes=args.batch_max_bytes,
     )
     log.info("hf-derive result: %s", result)
     if "error" in result:
@@ -252,6 +253,7 @@ def cmd_hf_derive_ktx2(args: argparse.Namespace) -> int:
         allow_prod=args.allow_prod,
         limit=args.limit,
         batch_size=args.batch_size,
+        batch_max_bytes=args.batch_max_bytes,
     )
     log.info("hf-derive-ktx2 result: %s", result)
     if "error" in result:
@@ -278,6 +280,7 @@ def cmd_hf_bake(args: argparse.Namespace) -> int:
         limit=args.limit,
         offset=args.offset,
         batch_size=args.batch_size,
+        batch_max_bytes=args.batch_max_bytes,
         dry_run=args.dry_run,
         allow_prod=args.allow_prod,
     )
@@ -405,7 +408,28 @@ def main() -> int:
     )
     p_hf.add_argument("--limit", type=int, default=None)
     p_hf.add_argument("--offset", type=int, default=0)
-    p_hf.add_argument("--batch-size", type=int, default=50)
+    p_hf.add_argument(
+        "--batch-size",
+        type=int,
+        default=300,
+        help=(
+            "Materials per atomic commit (count ceiling). #228: bytes is "
+            "the binding constraint at typical content (~1.5 MiB/material), "
+            "so 300 is a safe overshoot — flush trips on whichever bound hits first."
+        ),
+    )
+    p_hf.add_argument(
+        "--batch-max-bytes",
+        type=int,
+        default=700 * 1024 * 1024,
+        help=(
+            "Max bytes per atomic commit (default 734003200 = 700 MiB). "
+            "Flush triggers on first-of-N-or-bytes — whichever bound trips "
+            "first. Bytes only; no human-friendly units. HF hard-caps at "
+            "1 GiB/commit; 700 MiB leaves headroom for catalog + manifest "
+            "+ sentinel commits sharing the 128/hr/repo budget."
+        ),
+    )
     p_hf.add_argument(
         "--dry-run",
         action="store_true",
@@ -455,7 +479,25 @@ def main() -> int:
         help="HfApi token; raw or 'env:VAR'. Falls back to cached HF login.",
     )
     p_hfd.add_argument("--limit", type=int, default=None)
-    p_hfd.add_argument("--batch-size", type=int, default=50)
+    p_hfd.add_argument(
+        "--batch-size",
+        type=int,
+        default=300,
+        help=(
+            "Materials per atomic commit (count ceiling, #228). Bytes is "
+            "the binding constraint at typical content; 300 is a safe overshoot."
+        ),
+    )
+    p_hfd.add_argument(
+        "--batch-max-bytes",
+        type=int,
+        default=700 * 1024 * 1024,
+        help=(
+            "Max bytes per atomic commit (default 734003200 = 700 MiB). "
+            "Flush triggers on first-of-N-or-bytes. HF caps at 1 GiB/commit; "
+            "700 MiB leaves headroom for catalog + manifest + sentinel."
+        ),
+    )
     p_hfd.add_argument("--dry-run", action="store_true")
     p_hfd.add_argument(
         "--allow-prod",
@@ -495,7 +537,25 @@ def main() -> int:
         help="HfApi token; raw or 'env:VAR'. Falls back to cached HF login.",
     )
     p_hfk.add_argument("--limit", type=int, default=None)
-    p_hfk.add_argument("--batch-size", type=int, default=50)
+    p_hfk.add_argument(
+        "--batch-size",
+        type=int,
+        default=300,
+        help=(
+            "Materials per atomic commit (count ceiling, #228). Bytes is "
+            "the binding constraint at typical content; 300 is a safe overshoot."
+        ),
+    )
+    p_hfk.add_argument(
+        "--batch-max-bytes",
+        type=int,
+        default=700 * 1024 * 1024,
+        help=(
+            "Max bytes per atomic commit (default 734003200 = 700 MiB). "
+            "Flush triggers on first-of-N-or-bytes. HF caps at 1 GiB/commit; "
+            "700 MiB leaves headroom for catalog + manifest + sentinel."
+        ),
+    )
     p_hfk.add_argument("--dry-run", action="store_true")
     p_hfk.add_argument(
         "--allow-prod",

--- a/src/mat_vis_baker/hf_bake.py
+++ b/src/mat_vis_baker/hf_bake.py
@@ -35,7 +35,10 @@ from mat_vis_baker.index_builder import build_index
 log = logging.getLogger("mat-vis-baker.hf_bake")
 
 DEFAULT_REPO_ID = "gerchowl/mat-vis"
-DEFAULT_BATCH_SIZE = 50
+# #228: count default raised to 300 to mirror per-file driver. Bytes
+# becomes the binding constraint for typical-sized content.
+DEFAULT_BATCH_SIZE = 300
+DEFAULT_BATCH_MAX_BYTES = 700 * 1024 * 1024  # 700 MiB
 
 
 def _get_fetcher(source: str):
@@ -100,6 +103,7 @@ def bake_one(
     limit: int | None = None,
     offset: int = 0,
     batch_size: int = DEFAULT_BATCH_SIZE,
+    batch_max_bytes: int = DEFAULT_BATCH_MAX_BYTES,
     hf_token: str | None = None,
     dry_run: bool = False,
     allow_prod: bool = False,
@@ -156,5 +160,6 @@ def bake_one(
         limit=limit,
         offset=offset,
         batch_size=batch_size,
+        batch_max_bytes=batch_max_bytes,
         dry_run=dry_run,
     )

--- a/src/mat_vis_baker/hf_bake_per_file.py
+++ b/src/mat_vis_baker/hf_bake_per_file.py
@@ -51,7 +51,16 @@ from mat_vis_baker.source_tiers import is_supported, unsupported_tier_message
 
 log = logging.getLogger("mat-vis-baker.hf_bake_per_file")
 
-DEFAULT_BATCH_SIZE = 50
+# #228: bytes-aware batching. HF caps per-commit at 1 GiB and 25k files,
+# rate-limits at 128 commits/hr/repo. Old default of 50 materials ran
+# 4-70× under the per-commit caps, burning the rate budget on
+# mostly-empty commits. Now: flush on whichever bound trips first
+# (count >= batch_size OR pending_bytes >= batch_max_bytes), so commits
+# self-tune to per-commit headroom and we use ~5× fewer commits. The
+# count default rises to 300 — at typical 1k content (~1.5 MiB/material)
+# 300 materials = ~450 MiB, comfortably under the 700 MiB byte cap.
+DEFAULT_BATCH_SIZE = 300
+DEFAULT_BATCH_MAX_BYTES = 700 * 1024 * 1024  # 700 MiB
 
 
 def _guard_prod_target(repo_id: str, allow_prod: bool) -> None:
@@ -231,6 +240,7 @@ def bake_one_per_file(
     limit: int | None = None,
     offset: int = 0,
     batch_size: int = DEFAULT_BATCH_SIZE,
+    batch_max_bytes: int = DEFAULT_BATCH_MAX_BYTES,
     dry_run: bool = False,
 ) -> dict:
     """Bake one (source, tier) into per-file HF commits.
@@ -239,12 +249,14 @@ def bake_one_per_file(
     the last commit SHA on success. Pre-flight tree scan populates
     ``skipped``; actual bake work populates ``ok`` + ``failed``.
 
-    Caller responsibility: batch_size and the overall wall-clock
-    should stay within HF's commit-rate budget (~10-20/hr/user).
-    Default batch_size=50 across ~2000 materials = 40 commits =
-    over-budget for one user in one hour. Use shards if needed, or
-    increase batch_size (trades commit count for per-commit wall
-    time — a 10k-file commit takes ~90 s by empirical probe)."""
+    Batching: flushes on first-of-N-or-bytes — whichever bound trips
+    first. ``batch_size`` (default 300) caps materials per commit;
+    ``batch_max_bytes`` (default 700 MiB) caps payload size,
+    well under HF's 1 GiB hard cap and leaves headroom for the
+    catalog + manifest + sentinel commits on the same hour budget.
+    The rate-cap binding constraint flips from count to bytes for
+    typical 1k content (~1.5 MiB/material), giving ~5× fewer commits
+    per source vs the old count-only batching (#228)."""
     if not is_supported(source, tier):
         raise ValueError(unsupported_tier_message(source, tier))
     _guard_prod_target(repo_id, allow_prod)
@@ -294,12 +306,14 @@ def bake_one_per_file(
     last_commit_sha = ""
 
     log.info(
-        "=== hf-bake-per-file %s %s → %s@%s (batch_size=%d, already_committed=%d) ===",
+        "=== hf-bake-per-file %s %s → %s@%s "
+        "(batch_size=%d, batch_max_bytes=%d, already_committed=%d) ===",
         source,
         tier,
         repo_id,
         release_tag,
         batch_size,
+        batch_max_bytes,
         len(already),
     )
 
@@ -327,9 +341,14 @@ def bake_one_per_file(
         kind="bake",
     )
 
-    pending_batch: list[MaterialRecord] = []
+    # #228: pending_batch holds (rec, ops) — ops are computed at append
+    # time so we can accumulate pending_bytes against batch_max_bytes
+    # without a second disk read at flush. Caching ops also avoids the
+    # `_build_commit_ops_for_record` recomputation that the old flush did.
+    pending_batch: list[tuple[MaterialRecord, list]] = []
+    pending_bytes = 0
 
-    def _flush_batch(batch: list[MaterialRecord]) -> str:
+    def _flush_batch(batch: list[tuple[MaterialRecord, list]]) -> str:
         """Upload every baked record's files as one atomic commit, then
         free the local texture bytes for that batch. Keeping the wipe
         coupled to the flush bounds peak disk at one batch — a crash
@@ -337,8 +356,8 @@ def bake_one_per_file(
         re-upload free on the next run."""
         nonlocal last_commit_sha, n_ok
         ops = []
-        for rec in batch:
-            ops.extend(_build_commit_ops_for_record(rec, source, tier))
+        for _rec, rec_ops in batch:
+            ops.extend(rec_ops)
         if not ops:
             return last_commit_sha
         # Account bytes by reading the same in-memory payload the
@@ -380,7 +399,7 @@ def bake_one_per_file(
         progress.record_batch(materials=len(batch), bytes_added=batch_bytes)
         progress.emit_progress()
         # Free per-rec files now the commit is durable.
-        for rec in batch:
+        for rec, _rec_ops in batch:
             for p in list(rec.texture_paths.values()):
                 try:
                     Path(p).unlink(missing_ok=True)
@@ -412,16 +431,23 @@ def bake_one_per_file(
                     hash_textures(rec)
 
         # Commit: add every successfully-baked record to the pending batch;
-        # when it reaches batch_size, flush.
+        # flush on whichever bound trips first — count >= batch_size
+        # OR pending_bytes >= batch_max_bytes (#228).
         for rec in to_bake:
             if rec.status != "ok":
                 n_failed += 1
                 continue
-            pending_batch.append(rec)
+            rec_ops = _build_commit_ops_for_record(rec, source, tier)
+            rec_bytes = sum(
+                len(op.path_or_fileobj) for op in rec_ops if isinstance(op.path_or_fileobj, bytes)
+            )
+            pending_batch.append((rec, rec_ops))
+            pending_bytes += rec_bytes
             n_ok += 1
-            if len(pending_batch) >= batch_size:
+            if len(pending_batch) >= batch_size or pending_bytes >= batch_max_bytes:
                 last_commit_sha = _flush_batch(pending_batch)
                 pending_batch.clear()
+                pending_bytes = 0
                 # Local cleanup: textures / baked dirs get wiped every
                 # cursor advance below, bounding peak disk.
 
@@ -436,6 +462,7 @@ def bake_one_per_file(
     if pending_batch:
         last_commit_sha = _flush_batch(pending_batch)
         pending_batch.clear()
+        pending_bytes = 0
 
     if n_ok == 0 and n_skipped_preflight == 0:
         return {"error": "no materials", "ok": 0, "failed": n_failed}

--- a/src/mat_vis_baker/hf_derive_per_file.py
+++ b/src/mat_vis_baker/hf_derive_per_file.py
@@ -64,7 +64,13 @@ log = logging.getLogger("mat-vis-baker.hf_derive_per_file")
 # accept the canonical override so test/staging fixtures can stub it.
 HF_RESOLVE_BASE = "https://huggingface.co/datasets"
 
-DEFAULT_BATCH_SIZE = 50
+# #228: count default raised to 300; bytes ceiling becomes the real
+# binding constraint at typical 1k content (~1.5 MiB/material × 7
+# channels). Default batch_max_bytes 700 MiB stays well under HF's
+# 1 GiB per-commit cap and keeps headroom for catalog + manifest +
+# sentinel commits on the 128/hr/repo budget.
+DEFAULT_BATCH_SIZE = 300
+DEFAULT_BATCH_MAX_BYTES = 700 * 1024 * 1024  # 700 MiB
 
 # PNG / KTX2 magic — matches ``hf_bake_per_file._channel_ext``. Used by
 # the magic-byte verification in :func:`_verify_png` / :func:`_verify_ktx2`.
@@ -395,25 +401,31 @@ def _derive_driver(
     allow_prod: bool,
     limit: int | None,
     batch_size: int,
+    batch_max_bytes: int,
     on_progress: Callable[[dict], None] | None,
 ) -> dict:
     """Shared driver behind :func:`derive_smaller_tier` and
     :func:`derive_ktx2_tier`. Single code path so the sentinel-last,
     catalog-update, and batching invariants only need to live in one
-    place."""
+    place.
+
+    Batching: first-of-N-or-bytes — flush on whichever bound trips
+    first (count >= ``batch_size`` OR pending payload bytes >=
+    ``batch_max_bytes``). #228."""
     _guard_prod_target(repo_id, allow_prod)
     work_dir.mkdir(parents=True, exist_ok=True)
     api = HfApi(token=hf_token)
 
     t0 = time.monotonic()
     log.info(
-        "=== %s %s/%s → %s @ %s (batch_size=%d, dry_run=%s) ===",
+        "=== %s %s/%s → %s @ %s (batch_size=%d, batch_max_bytes=%d, dry_run=%s) ===",
         label,
         source,
         source_tier,
         target_tier,
         release_tag,
         batch_size,
+        batch_max_bytes,
         dry_run,
     )
 
@@ -454,6 +466,8 @@ def _derive_driver(
 
     pending_ops: list[CommitOperationAdd] = []
     pending_mids: list[str] = []
+    # #228: bytes accumulator drives the bytes-aware flush bound.
+    pending_bytes = 0
 
     def _flush_batch() -> str:
         nonlocal last_commit_sha
@@ -551,6 +565,11 @@ def _derive_driver(
         derived_ids.add(mid)
         pending_ops.extend(ops)
         pending_mids.append(mid)
+        # #228: byte-account at append-time so the flush check below can
+        # short-circuit on bytes ceiling without re-reading payloads.
+        pending_bytes += sum(
+            len(op.path_or_fileobj) for op in ops if isinstance(op.path_or_fileobj, bytes)
+        )
         if on_progress is not None:
             on_progress(
                 {
@@ -562,16 +581,20 @@ def _derive_driver(
                 }
             )
 
-        if len(pending_mids) >= batch_size:
+        # #228: first-of-N-or-bytes — count >= batch_size OR pending
+        # bytes >= batch_max_bytes triggers a flush.
+        if len(pending_mids) >= batch_size or pending_bytes >= batch_max_bytes:
             last_commit_sha = _flush_batch()
             pending_ops.clear()
             pending_mids.clear()
+            pending_bytes = 0
 
     # Final partial batch.
     if pending_mids:
         last_commit_sha = _flush_batch()
         pending_ops.clear()
         pending_mids.clear()
+        pending_bytes = 0
 
     if n_ok == 0 and n_skipped == 0:
         return {
@@ -722,6 +745,7 @@ def derive_smaller_tier(
     allow_prod: bool = False,
     limit: int | None = None,
     batch_size: int = DEFAULT_BATCH_SIZE,
+    batch_max_bytes: int = DEFAULT_BATCH_MAX_BYTES,
     on_progress: Callable[[dict], None] | None = None,
 ) -> dict:
     """Resize every channel from ``source_tier`` (PNG) into ``target_tier``
@@ -770,6 +794,7 @@ def derive_smaller_tier(
         allow_prod=allow_prod,
         limit=limit,
         batch_size=batch_size,
+        batch_max_bytes=batch_max_bytes,
         on_progress=on_progress,
     )
 
@@ -787,6 +812,7 @@ def derive_ktx2_tier(
     allow_prod: bool = False,
     limit: int | None = None,
     batch_size: int = DEFAULT_BATCH_SIZE,
+    batch_max_bytes: int = DEFAULT_BATCH_MAX_BYTES,
     on_progress: Callable[[dict], None] | None = None,
 ) -> dict:
     """Transcode every channel from ``source_tier`` (PNG) into
@@ -824,5 +850,6 @@ def derive_ktx2_tier(
         allow_prod=allow_prod,
         limit=limit,
         batch_size=batch_size,
+        batch_max_bytes=batch_max_bytes,
         on_progress=on_progress,
     )

--- a/tests/test_dagger_bake_argv.py
+++ b/tests/test_dagger_bake_argv.py
@@ -55,9 +55,31 @@ class TestBakeArgvContract:
         assert "--release-tag" in argv and "v0.0.0-test" in argv
         assert "--repo-id" in argv and "gerchowl/mat-vis-tst" in argv
         assert "--batch-size" in argv and "50" in argv
+        # #228: --batch-max-bytes always emitted; default tracks the
+        # 700 MiB ceiling.
+        assert "--batch-max-bytes" in argv
+        idx = argv.index("--batch-max-bytes")
+        assert argv[idx + 1] == str(700 * 1024 * 1024)
         # No optional flags fired.
         for flag in ("--limit", "--dry-run", "--allow-prod"):
             assert flag not in argv, f"unexpected {flag} in default argv"
+
+    def test_batch_max_bytes_propagates(self, bake_argv):
+        """Custom byte ceiling makes it through to the CLI argv (#228)."""
+        argv = bake_argv(
+            source="polyhaven",
+            tier="1k",
+            release_tag="v0.0.0-test",
+            repo_id="gerchowl/mat-vis-tst",
+            offset=0,
+            batch_size=300,
+            batch_max_bytes=512 * 1024 * 1024,
+            limit=0,
+            dry_run=False,
+            allow_prod=False,
+        )
+        idx = argv.index("--batch-max-bytes")
+        assert argv[idx + 1] == str(512 * 1024 * 1024)
 
     def test_limit_emits_when_positive(self, bake_argv):
         argv = bake_argv(

--- a/tests/test_hf_bake_per_file.py
+++ b/tests/test_hf_bake_per_file.py
@@ -504,3 +504,147 @@ class TestCasRetryOnManifestCommit:
         assert attempts["n"] == 1, f"401 must not retry (got {attempts['n']} attempts)"
         assert fetch_mfst.call_count == 1, fetch_mfst.call_count
         assert exc is not None and "401" in str(exc), exc
+
+
+# ── #228: bytes-aware batching (first-of-N-or-bytes) ─────────────────
+
+
+PNG_HDR = b"\x89PNG\r\n\x1a\n"
+
+
+def _texture_commit_calls(api):
+    """Texture-batch commits only — strip the catalog + sentinel calls.
+
+    Per the substrate contract the trailing two commits are
+    catalog+manifest then sentinel, so anything before that is a
+    texture batch flush."""
+    return [
+        c
+        for c in api.create_commit.call_args_list
+        if not any(
+            op.path_in_repo
+            in {
+                "release-manifest.json",
+                "polyhaven.json",
+                "polyhaven/1k/.tier_complete",
+            }
+            for op in c.kwargs["operations"]
+        )
+    ]
+
+
+class TestBytesAwareBatching:
+    """#228: flush trips on first-of-N-or-bytes — whichever bound hits
+    first. Locks down both halves of the OR so a regression that drops
+    either ceiling fails fast."""
+
+    def test_count_ceiling_flushes_when_bytes_below_max(self, tmp_path):
+        """Many tiny materials → bytes is far below ceiling → count
+        ceiling (batch_size) drives the flush. With batch_size=2 across
+        5 materials we expect 3 texture-batch commits (2 + 2 + 1)."""
+        # Each material is tiny (~108 bytes per channel) — well below
+        # any reasonable bytes ceiling.
+        small = PNG_HDR + b"\x00" * 100
+        fake_records = [_fake_record(f"mat_{i}", {"color": small}, tmp_path) for i in range(5)]
+
+        api = _bake_with_records(
+            fake_records,
+            tmp_path,
+            batch_size=2,
+            batch_max_bytes=10 * 1024 * 1024,  # 10 MiB — far above any single material
+        )
+
+        texture_calls = _texture_commit_calls(api)
+        assert len(texture_calls) == 3, (
+            f"expected 3 texture-batch commits (2+2+1, count-driven); got {len(texture_calls)}"
+        )
+
+    def test_bytes_ceiling_flushes_when_count_below_max(self, tmp_path):
+        """Few large materials → count is below ceiling → bytes ceiling
+        (batch_max_bytes) drives the flush. Each material's payload
+        already exceeds the ceiling, so every append immediately
+        crosses it and flushes — one material per commit despite
+        ``batch_size`` being far above 1."""
+        # Each material is "large": ~5 MiB per channel; the ceiling
+        # at 4 MiB is below a single material's payload so the very
+        # first append crosses the bound and triggers the flush.
+        big_payload = PNG_HDR + b"\x00" * (5 * 1024 * 1024)
+        fake_records = [
+            _fake_record(f"mat_{i}", {"color": big_payload}, tmp_path) for i in range(3)
+        ]
+
+        api = _bake_with_records(
+            fake_records,
+            tmp_path,
+            batch_size=300,  # high — count must NOT be the binding constraint
+            batch_max_bytes=4 * 1024 * 1024,  # below one material's payload
+        )
+
+        texture_calls = _texture_commit_calls(api)
+        # Each material's 5 MiB payload exceeds 4 MiB on the very
+        # first append → 3 materials = 3 texture commits.
+        assert len(texture_calls) == 3, (
+            f"expected 3 texture commits (bytes-driven, one material each); "
+            f"got {len(texture_calls)}"
+        )
+
+    def test_preflight_skip_still_works_under_bytes_aware_batching(self, tmp_path):
+        """The preflight skip primitive must keep working: of N=5
+        materials with M=2 already-committed, only 3 should reach
+        the bake/commit path. Bytes ceiling high so the count ceiling
+        bounds batches predictably."""
+        fake_records = [
+            _fake_record(f"mat_{i}", {"color": PNG_HDR + b"\x00" * 200}, tmp_path) for i in range(5)
+        ]
+
+        # Pretend mat_0 + mat_1 already on HF.
+        from huggingface_hub.hf_api import RepoFile
+
+        existing_files = [
+            RepoFile(path=f"polyhaven/1k/mat_{i}/color.png", size=80, oid="x") for i in range(2)
+        ]
+
+        bake_calls: list[str] = []
+
+        def track_bake(rec, *a, **k):
+            bake_calls.append(rec.id)
+            return rec
+
+        with (
+            patch("mat_vis_baker.hf_bake_per_file._get_fetcher") as fetcher,
+            patch("mat_vis_baker.hf_bake_per_file.HfApi") as api_cls,
+            patch(
+                "mat_vis_baker.hf_bake_per_file.bake_material",
+                side_effect=track_bake,
+            ),
+        ):
+
+            def _sliced(tier, textures_dir, *, limit=None, offset=0, **kw):
+                end = None if limit is None else offset + limit
+                return fake_records[offset:end]
+
+            fetcher.return_value = _sliced
+            api = api_cls.return_value
+            api.list_repo_tree.return_value = existing_files
+
+            result = bake_one_per_file(
+                source="polyhaven",
+                tier="1k",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                hf_token="t",
+                repo_id="gerchowl/mat-vis-tst",
+                batch_size=2,  # 3 unskipped → 2 then 1 → 2 texture commits
+                batch_max_bytes=10 * 1024 * 1024,
+            )
+
+        # Only the 3 unskipped materials reached bake_material.
+        assert bake_calls == ["mat_2", "mat_3", "mat_4"], bake_calls
+        assert result["ok"] == 3
+        assert result["skipped_preflight"] == 2
+
+        texture_calls = _texture_commit_calls(api)
+        assert len(texture_calls) == 2, (
+            f"expected 2 texture commits across 3 unskipped materials "
+            f"(batch_size=2); got {len(texture_calls)}"
+        )

--- a/tests/test_hf_derive_per_file.py
+++ b/tests/test_hf_derive_per_file.py
@@ -614,3 +614,173 @@ class TestDeriveCasRetryOnManifestCommit:
         assert attempts["n"] == 1, f"401 must not retry (got {attempts['n']} attempts)"
         assert fetch_mfst.call_count == 1, fetch_mfst.call_count
         assert exc is not None and "401" in str(exc), exc
+
+
+# ── #228: bytes-aware batching (derive path) ─────────────────────────
+
+
+def _texture_only_commits(api):
+    """Strip the catalog+manifest commit and the sentinel commit from the
+    derive call list — what's left is the texture-batch flushes."""
+    return [
+        c
+        for c in api.create_commit.call_args_list
+        if not any(
+            op.path_in_repo
+            in {
+                "release-manifest.json",
+                "polyhaven.json",
+                "polyhaven/512/.tier_complete",
+            }
+            for op in c.kwargs["operations"]
+        )
+    ]
+
+
+class TestDeriveBytesAwareBatching:
+    """#228: derive driver flushes on first-of-N-or-bytes. Same shape
+    of test as the bake-side coverage. The transform inflates payload
+    bytes (resize → smaller PNG) so the test stubs the transform with a
+    deterministic fixed-size payload to make the math predictable."""
+
+    def _setup_api_with_n_materials(self, n: int) -> MagicMock:
+        api = MagicMock()
+        tree = [_fake_tree_entry(f"polyhaven/1k/mat_{i}/color.png") for i in range(n)]
+
+        def _list(repo_id, repo_type, revision, path_in_repo, recursive=False, **kw):
+            return [e for e in tree if e.path.startswith(path_in_repo.rstrip("/") + "/")]
+
+        api.list_repo_tree.side_effect = _list
+        api.create_commit.return_value = SimpleNamespace(oid="deadbeef" * 5)
+        return api
+
+    def test_count_ceiling_drives_flush_when_bytes_below_max(self, tmp_path):
+        """Many tiny derived payloads → count drives the flush.
+        batch_size=2 across 5 materials ⇒ 3 texture-batch commits."""
+        api = self._setup_api_with_n_materials(5)
+        small_png = _make_png(8)  # ~70-90 bytes
+
+        def _get(url, *, token=None, timeout=120):
+            if url.endswith(".json"):
+                return json.dumps(
+                    [{"id": f"mat_{i}", "available_tiers": ["1k"]} for i in range(5)]
+                ).encode("utf-8")
+            return small_png
+
+        # Stub transform to return a fixed-size small payload.
+        small_out = PNG_MAGIC + b"\x00" * 200
+
+        with (
+            patch("mat_vis_baker.hf_derive_per_file.HfApi", return_value=api),
+            patch("mat_vis_baker.hf_derive_per_file._http_get", side_effect=_get),
+            patch("mat_vis_baker.hf_derive_per_file._http_head_ok", return_value=False),
+            patch(
+                "mat_vis_baker.hf_derive_per_file._resize_png",
+                side_effect=lambda raw, target_px: small_out,
+            ),
+        ):
+            result = derive_smaller_tier(
+                source="polyhaven",
+                source_tier="1k",
+                target_tier="512",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                repo_id="gerchowl/mat-vis-tst",
+                batch_size=2,
+                batch_max_bytes=10 * 1024 * 1024,
+            )
+
+        assert result["ok"] == 5
+        texture_calls = _texture_only_commits(api)
+        assert len(texture_calls) == 3, (
+            f"expected 3 texture commits (count-driven 2+2+1); got {len(texture_calls)}"
+        )
+
+    def test_bytes_ceiling_drives_flush_when_count_below_max(self, tmp_path):
+        """Few large derived payloads → bytes drives the flush.
+        Stub transform returns ~5 MiB per channel; with a 6 MiB ceiling
+        each material lands as its own commit despite batch_size=300."""
+        api = self._setup_api_with_n_materials(3)
+        small_in = _make_png(8)
+        big_out = PNG_MAGIC + b"\x00" * (5 * 1024 * 1024)
+
+        def _get(url, *, token=None, timeout=120):
+            if url.endswith(".json"):
+                return json.dumps(
+                    [{"id": f"mat_{i}", "available_tiers": ["1k"]} for i in range(3)]
+                ).encode("utf-8")
+            return small_in
+
+        with (
+            patch("mat_vis_baker.hf_derive_per_file.HfApi", return_value=api),
+            patch("mat_vis_baker.hf_derive_per_file._http_get", side_effect=_get),
+            patch("mat_vis_baker.hf_derive_per_file._http_head_ok", return_value=False),
+            patch(
+                "mat_vis_baker.hf_derive_per_file._resize_png",
+                side_effect=lambda raw, target_px: big_out,
+            ),
+        ):
+            result = derive_smaller_tier(
+                source="polyhaven",
+                source_tier="1k",
+                target_tier="512",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                repo_id="gerchowl/mat-vis-tst",
+                batch_size=300,  # high — count must NOT bind
+                batch_max_bytes=4 * 1024 * 1024,  # below one material's payload
+            )
+
+        assert result["ok"] == 3
+        texture_calls = _texture_only_commits(api)
+        assert len(texture_calls) == 3, (
+            f"expected 3 texture commits (bytes-driven, one each); got {len(texture_calls)}"
+        )
+
+    def test_preflight_skip_still_works_under_bytes_aware_batching(self, tmp_path):
+        """Preflight skip primitive intact: 5 materials, mat_0 + mat_1
+        already on HF, batch_size=2 → only 3 derived → 2 texture commits."""
+        api = self._setup_api_with_n_materials(5)
+        png = _make_png(16)
+
+        # Mark mat_0 + mat_1 as already present at target tier.
+        existing_target_urls = {
+            f"https://huggingface.co/datasets/gerchowl/mat-vis-tst/resolve/v0.0.0-test"
+            f"/polyhaven/512/mat_{i}/color.png"
+            for i in range(2)
+        }
+
+        def _get(url, *, token=None, timeout=120):
+            if url.endswith(".json"):
+                return json.dumps(
+                    [{"id": f"mat_{i}", "available_tiers": ["1k"]} for i in range(5)]
+                ).encode("utf-8")
+            return png
+
+        def _head(url, *, token=None, timeout=30):
+            return url in existing_target_urls
+
+        with (
+            patch("mat_vis_baker.hf_derive_per_file.HfApi", return_value=api),
+            patch("mat_vis_baker.hf_derive_per_file._http_get", side_effect=_get),
+            patch("mat_vis_baker.hf_derive_per_file._http_head_ok", side_effect=_head),
+        ):
+            result = derive_smaller_tier(
+                source="polyhaven",
+                source_tier="1k",
+                target_tier="512",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                repo_id="gerchowl/mat-vis-tst",
+                batch_size=2,
+                batch_max_bytes=10 * 1024 * 1024,
+            )
+
+        assert result["ok"] == 3
+        assert result["skipped_preflight"] == 2
+
+        texture_calls = _texture_only_commits(api)
+        # 3 unskipped → batch_size=2 → 2+1 → 2 texture commits.
+        assert len(texture_calls) == 2, (
+            f"expected 2 texture commits across 3 unskipped materials; got {len(texture_calls)}"
+        )


### PR DESCRIPTION
Closes #228.

## Summary

The baker batched commits by material count only (default 50). HF caps
each commit at 1 GiB / 25k files and rate-limits at 128 commits/hr/repo.
Current usage was 4-70× under the per-commit caps, so we hit the rate
cap with mostly-empty commits. This switches to **first-of-N-or-bytes**
batching so commits self-tune to per-commit headroom and we use ~5×
fewer commits per source.

| dimension     | HF cap            | old default usage | new default cap |
|---------------|-------------------|-------------------|------------------|
| files/commit  | 25,000            | ~350 (50 × 7)     | ~2,100 (300 × 7) |
| bytes/commit  | 1 GiB             | ~75 MiB (50 × ~1.5 MiB) | 700 MiB    |
| rate          | 128 commits/hr    | ~40/source        | ~8/source        |

Flush condition is now:

```python
if len(pending_batch) >= batch_size or pending_bytes >= batch_max_bytes:
    sha = _flush_batch(pending_batch)
    pending_batch.clear()
    pending_bytes = 0
```

## Implementation choices

- **Defaults**: `batch_size=300` (was 50), `batch_max_bytes=700 * 1024 * 1024` (700 MiB). Bytes is the binding constraint at typical content; the count ceiling is an overshoot that catches odd shapes (lots of tiny scalar entries, etc.).
- **Bake driver**: stores `(rec, ops)` tuples in `pending_batch` so ops are computed once at append-time (used for both byte accounting and the eventual flush). `_flush_batch` no longer recomputes ops.
- **Derive driver**: extends `pending_ops`/`pending_mids` with a parallel `pending_bytes` accumulator updated at the same site.
- **`bake_progress` line**: untouched. `_flush_batch` still self-computes `batch_bytes` from `op.path_or_fileobj` lengths — same formula, idempotent, no double-counting.
- **Concurrency group from #225**: stays. Belt-and-suspenders under the rate cap; explicitly kept per the issue.
- **Plumbing**: CLI flag (`--batch-max-bytes`, bytes only — no human-friendly units) on `hf-bake`/`hf-derive`/`hf-derive-ktx2`; Dagger `bake`/`derive`/`derive-ktx2` parameters; `bake.yml`/`derive.yml` `workflow_dispatch` inputs (default `734003200`).

## Acceptance checklist

- [x] `batch_max_bytes` parameter added to `bake_one_per_file` (default 700 MiB)
- [x] `batch_max_bytes` parameter added to `_derive_driver` (default 700 MiB)
- [x] Flush condition switched to first-of-N-or-bytes in both drivers
- [x] `pending_bytes` accumulator runs alongside `pending_batch`/`pending_mids`
- [x] `batch_size` default raised 50 → 300 in both drivers (CLI flag preserved)
- [x] `--batch-max-bytes` CLI flag on `hf-bake`, `hf-derive`, `hf-derive-ktx2`
- [x] `batch_max_bytes` plumbed through Dagger `bake`, `derive`, `derive_ktx2`
- [x] `batch-max-bytes` workflow_dispatch input on `bake.yml` and `derive.yml`
- [x] Unit test: many small materials → count-driven flush
- [x] Unit test: few large materials → bytes-driven flush
- [x] Unit test: preflight skip + bytes-aware batching coexist (bake + derive)
- [x] All HF-API mocked; no real HF traffic
- [x] Existing `bake_progress` `bytes_pushed` accounting unchanged
- [x] `MAT_VIS_E2E_CONCURRENCY=3` test in `tests/e2e/test_per_file_roundtrip.py` not impacted (drivers' public surface is purely additive defaults)
- [x] Per-repo concurrency group (#225) preserved on both workflows

## Test plan

- [x] `uv run pytest tests/ -q --ignore=tests/e2e` — 367 passed, 5 skipped (matches main)
- [x] Targeted: `tests/test_hf_bake_per_file.py`, `tests/test_hf_derive_per_file.py`, `tests/test_dagger_bake_argv.py` — all green
- [x] Pre-commit hooks pass (ruff, ruff-format, yamllint, branch-name, etc.)
- [ ] Live verification deferred to next phase-3 bake — same dispatch surface, only the flush trigger changes