### PR TITLE
bugfix(test): plumb arbitrary tier slugs through bake_one for concurrency test (#230)

### DIFF
--- a/src/mat_vis_baker/hf_bake.py
+++ b/src/mat_vis_baker/hf_bake.py
@@ -107,6 +107,8 @@ def bake_one(
     hf_token: str | None = None,
     dry_run: bool = False,
     allow_prod: bool = False,
+    storage_tier: str | None = None,
+    _pre_manifest_hook=None,
 ) -> dict:
     """Bake one ``(source, tier)`` and commit to HF.
 
@@ -121,7 +123,14 @@ def bake_one(
 
     Pre-flight tree scan + batch commits (size ``batch_size``) make
     bakes resumable across crashes — see ``hf_bake_per_file`` for
-    detail."""
+    detail.
+
+    ``storage_tier`` (#230): test-only escape hatch — keeps ``tier``
+    as the upstream-fetch label while writing under a different path
+    key. Used by the #210 concurrency E2E to park N parallel writers
+    at distinct (source, tier) paths under the same release tag. Not
+    exposed on the CLI; production callers leave it ``None`` and get
+    today's behavior unchanged."""
     # Pre-flight: refuse (source, tier) combos with no upstream data.
     # Earlier code let these proceed, then produced 454-materials-failed
     # bake artifacts when every fetch returned no matching package.
@@ -162,4 +171,6 @@ def bake_one(
         batch_size=batch_size,
         batch_max_bytes=batch_max_bytes,
         dry_run=dry_run,
+        storage_tier=storage_tier,
+        _pre_manifest_hook=_pre_manifest_hook,
     )

--- a/src/mat_vis_baker/hf_bake_per_file.py
+++ b/src/mat_vis_baker/hf_bake_per_file.py
@@ -242,12 +242,18 @@ def bake_one_per_file(
     batch_size: int = DEFAULT_BATCH_SIZE,
     batch_max_bytes: int = DEFAULT_BATCH_MAX_BYTES,
     dry_run: bool = False,
+    storage_tier: str | None = None,
+    _pre_manifest_hook=None,
 ) -> dict:
     """Bake one (source, tier) into per-file HF commits.
 
     Returns a dict with ``ok``, ``failed``, ``skipped`` counts plus
     the last commit SHA on success. Pre-flight tree scan populates
     ``skipped``; actual bake work populates ``ok`` + ``failed``.
+    Also returns ``cas_retries``: the number of times the catalog +
+    manifest commit hit a 412 precondition mismatch and re-merged
+    (zero on a single-writer bake; non-zero proves the retry path
+    fired under concurrent writers — see #210/#230).
 
     Batching: flushes on first-of-N-or-bytes — whichever bound trips
     first. ``batch_size`` (default 300) caps materials per commit;
@@ -256,10 +262,22 @@ def bake_one_per_file(
     catalog + manifest + sentinel commits on the same hour budget.
     The rate-cap binding constraint flips from count to bytes for
     typical 1k content (~1.5 MiB/material), giving ~5× fewer commits
-    per source vs the old count-only batching (#228)."""
+    per source vs the old count-only batching (#228).
+
+    ``storage_tier`` (#230): test-only escape hatch. When set, used
+    as the path key (``<source>/<storage_tier>/...``) and manifest
+    tier label, while ``tier`` continues to drive the upstream
+    fetcher. Lets the concurrency E2E (#210) park N parallel writers
+    at distinct (source, tier) paths under one release tag without
+    weakening the production tier guard. Default ``None`` →
+    ``storage_tier == tier`` exactly as before. Not exposed on the
+    CLI."""
     if not is_supported(source, tier):
         raise ValueError(unsupported_tier_message(source, tier))
     _guard_prod_target(repo_id, allow_prod)
+    # #230: storage_tier defaults to the fetch tier — preserves
+    # pre-existing single-arg semantics for every production caller.
+    storage_tier = storage_tier if storage_tier is not None else tier
 
     work_dir.mkdir(parents=True, exist_ok=True)
     textures_dir = work_dir / "textures"
@@ -285,7 +303,8 @@ def bake_one_per_file(
             log.warning("branch create failed (may already exist): %s", e)
 
     # Pre-flight: which materials are already committed on this tag?
-    already = _already_committed_material_ids(api, repo_id, release_tag, source, tier)
+    # Use storage_tier — that's where past runs of THIS bake wrote.
+    already = _already_committed_material_ids(api, repo_id, release_tag, source, storage_tier)
     if already:
         log.info(
             "preflight: %d materials already on %s@%s — skipping",
@@ -306,10 +325,11 @@ def bake_one_per_file(
     last_commit_sha = ""
 
     log.info(
-        "=== hf-bake-per-file %s %s → %s@%s "
+        "=== hf-bake-per-file %s %s%s → %s@%s "
         "(batch_size=%d, batch_max_bytes=%d, already_committed=%d) ===",
         source,
         tier,
+        f" (storage={storage_tier})" if storage_tier != tier else "",
         repo_id,
         release_tag,
         batch_size,
@@ -340,6 +360,11 @@ def bake_one_per_file(
         total_materials=total_materials,
         kind="bake",
     )
+
+    # #230: cross-call retry counter — every _create_commit_with_backoff
+    # invocation in this bake shares it so we observe the full picture
+    # (texture-batch lock-409s + manifest CAS lock-409s + manifest 412s).
+    retry_counter: dict[str, int] = {}
 
     # #228: pending_batch holds (rec, ops) — ops are computed at append
     # time so we can accumulate pending_bytes against batch_max_bytes
@@ -380,10 +405,11 @@ def bake_one_per_file(
                 repo_type="dataset",
                 operations=ops,
                 commit_message=(
-                    f"feat(data): {release_tag} — bake {source} {tier} "
+                    f"feat(data): {release_tag} — bake {source} {storage_tier} "
                     f"batch ({len(batch)} materials, {len(ops)} files)"
                 ),
                 revision=release_tag,
+                _retry_counter=retry_counter,
             )
             sha = getattr(commit, "oid", "") or getattr(commit, "commit_oid", "")
             log.info(
@@ -437,7 +463,7 @@ def bake_one_per_file(
             if rec.status != "ok":
                 n_failed += 1
                 continue
-            rec_ops = _build_commit_ops_for_record(rec, source, tier)
+            rec_ops = _build_commit_ops_for_record(rec, source, storage_tier)
             rec_bytes = sum(
                 len(op.path_or_fileobj) for op in rec_ops if isinstance(op.path_or_fileobj, bytes)
             )
@@ -486,21 +512,44 @@ def bake_one_per_file(
     manifest_path = work_dir / "release-manifest.json"
 
     # Sentinel commit — marks tier as "atomically complete". Clients
-    # can probe <source>/<tier>/.tier_complete in one HEAD request.
+    # can probe <source>/<storage_tier>/.tier_complete in one HEAD
+    # request. Path keyed by storage_tier so a non-default override
+    # (#230) lands the sentinel under the same path the texture
+    # commits used.
     sentinel_name = ".tier_complete"
-    sentinel_path = work_dir / f"{source}-{tier}-{sentinel_name}"
+    sentinel_path = work_dir / f"{source}-{storage_tier}-{sentinel_name}"
     sentinel_path.write_text(release_tag + "\n")
+
+    # #230: observable CAS-retry counter — exposed in the return dict
+    # so the concurrency E2E (#210) can prove the retry path actually
+    # fired without scraping log strings across multiprocessing pipes.
+    cas_retries = 0
 
     if dry_run:
         log.info("dry-run: would commit catalog + manifest + sentinel")
     else:
         from huggingface_hub import CommitOperationAdd
 
+        # #230: optional sync barrier for the concurrency E2E. Production
+        # callers leave _pre_manifest_hook=None and skip this entirely.
+        # The hook is fired exactly once, just before the first CAS
+        # attempt, so N parallel workers all start the manifest commit
+        # together and HF actually serves contention at the precondition
+        # check. Without it, fetch-time variance lets workers finish
+        # serially and cas_retries stays at 0 even with N processes.
+        if _pre_manifest_hook is not None:
+            try:
+                _pre_manifest_hook()
+            except Exception as e:  # noqa: BLE001
+                log.warning("pre_manifest_hook raised %s: %s", type(e).__name__, e)
+
         # CAS retry loop on the catalog + manifest commit.
         max_retries = 6  # >> realistic matrix concurrency (≤4 sources today)
         for attempt in range(max_retries):
             existing_manifest, parent_sha = _fetch_manifest_with_parent(api, repo_id, release_tag)
-            merged = _merge_manifest_for_source(existing_manifest, source, tier, release_tag)
+            merged = _merge_manifest_for_source(
+                existing_manifest, source, storage_tier, release_tag
+            )
             manifest_path.write_text(json.dumps(merged, indent=2, ensure_ascii=False) + "\n")
             try:
                 # #225: 429 retry sits *inside* the CAS loop. The helper
@@ -525,14 +574,27 @@ def bake_one_per_file(
                     commit_message=f"feat(data): {release_tag} — {source} catalog + manifest",
                     revision=release_tag,
                     parent_commit=parent_sha,
+                    _retry_counter=retry_counter,
                 )
                 last_commit_sha = getattr(catalog_commit, "oid", "") or last_commit_sha
                 break
             except Exception as e:  # noqa: BLE001
-                # HF returns 412 Precondition Failed on parent_commit mismatch.
+                # HF returns 412 Precondition Failed on parent_commit mismatch
+                # (the optimistic-lock path we designed for). It ALSO returns
+                # 409 "Another commit operation is in progress" when two
+                # commits race the server-side per-repo write lock — same
+                # underlying cause (concurrent writer), different layer.
+                # Treat both as a CAS retry: re-fetch + re-merge + retry.
                 # Other exceptions (auth, network) re-raise after the loop.
                 msg = str(e).lower()
-                if "412" in msg or "precondition" in msg or "parent_commit" in msg:
+                is_cas_conflict = (
+                    "412" in msg
+                    or "precondition" in msg
+                    or "parent_commit" in msg
+                    or "409" in msg
+                    or "another commit operation" in msg
+                )
+                if is_cas_conflict:
                     if attempt + 1 == max_retries:
                         log.error(
                             "manifest CAS exhausted after %d retries — concurrent writers?",
@@ -544,10 +606,11 @@ def bake_one_per_file(
                         attempt + 1,
                         max_retries,
                     )
+                    cas_retries += 1
                     continue
                 raise
 
-        # Sentinel commit — final marker. #225: 429-aware.
+        # Sentinel commit — final marker. #225: 429-aware. #230: 409-aware.
         sentinel_commit = _create_commit_with_backoff(
             api,
             source=source,
@@ -555,12 +618,13 @@ def bake_one_per_file(
             repo_type="dataset",
             operations=[
                 CommitOperationAdd(
-                    path_in_repo=f"{source}/{tier}/{sentinel_name}",
+                    path_in_repo=f"{source}/{storage_tier}/{sentinel_name}",
                     path_or_fileobj=str(sentinel_path),
                 )
             ],
-            commit_message=f"feat(data): {release_tag} — {source} {tier} complete",
+            commit_message=f"feat(data): {release_tag} — {source} {storage_tier} complete",
             revision=release_tag,
+            _retry_counter=retry_counter,
         )
         last_commit_sha = getattr(sentinel_commit, "oid", "") or last_commit_sha
 
@@ -581,4 +645,12 @@ def bake_one_per_file(
         "failed": n_failed,
         "skipped_preflight": n_skipped_preflight,
         "materials": len(all_records),
+        # #230: contention observability.
+        # ``cas_retries`` counts 412 parent_commit mismatches on the
+        # manifest commit (the optimistic-lock path). ``lock_409_retries``
+        # counts 409 per-repo write-lock contention across every commit
+        # this bake makes. Either one being non-zero proves the bake
+        # raced another writer and recovered cleanly.
+        "cas_retries": cas_retries,
+        "lock_409_retries": retry_counter.get("lock_409", 0),
     }

--- a/src/mat_vis_baker/hf_retry.py
+++ b/src/mat_vis_baker/hf_retry.py
@@ -1,4 +1,4 @@
-"""Bounded retry/backoff for HF Hub 429 commit-rate throttling (#225).
+"""Bounded retry/backoff for HF Hub commit throttling (#225, #230).
 
 The HF Hub enforces two rate caps that surface as ``429 Too Many
 Requests`` on ``api.create_commit``:
@@ -11,6 +11,14 @@ Requests`` on ``api.create_commit``:
 2. **API-rate cap** — ~1000 requests per 300s rolling window. Not
    biting yet, but surfaces as the same 429 status, so the same retry
    path handles it.
+
+3. **Per-repo write lock** (#230) — HF serializes commits at the
+   repository granularity. Two writers racing the same repo see a
+   ``409 Conflict`` with body ``"Another commit operation is in
+   progress for this repository. Please try again later."``. Same
+   retry envelope as 429 — bounded backoff, then re-raise — but with
+   a shorter floor since the lock typically clears in single-digit
+   seconds, not the 30s 429 cooldown.
 
 This module wraps every ``api.create_commit`` call site (bake +
 derive) with :func:`_create_commit_with_backoff`, which:
@@ -47,6 +55,13 @@ from huggingface_hub.errors import HfHubHTTPError
 _BACKOFF_FLOOR_S = 30.0
 _BACKOFF_CEIL_S = 120.0
 _DEFAULT_MAX_RETRIES = 5
+
+# #230: 409 (per-repo write-lock contention) clears much faster than
+# 429 (rate-cap cooldown). A 2-8s backoff matches the observed clear
+# time and keeps test wallclock reasonable; we still cap retries so
+# a runaway concurrent writer can't stall forever.
+_LOCK_BACKOFF_FLOOR_S = 2.0
+_LOCK_BACKOFF_CEIL_S = 8.0
 
 # Body fallback: HF's API includes a human-readable "Retry after N
 # seconds" phrase in the JSON error body when the header is absent on
@@ -143,19 +158,45 @@ def _emit_throttle_line(
     max_retries: int,
     wait_s: float,
     elapsed_s: float,
+    reason: str = "429",
 ) -> None:
     """Single-line, structured throttle log — one per retry.
 
     Format mirrors the contract in :mod:`mat_vis_baker.progress`:
     leading prefix token, ``key=value`` pairs, ``flush=True`` so the
     line streams to GH Actions' live tail rather than buffering until
-    process exit.
+    process exit. ``reason`` is the HTTP status that triggered the
+    retry — ``429`` for rate-throttle, ``409`` for per-repo write-lock
+    contention (#230).
     """
     print(
         f"bake_throttle source={source} retry={attempt}/{max_retries} "
-        f"reason=429 wait_s={wait_s:.1f} elapsed={_format_elapsed(elapsed_s)}",
+        f"reason={reason} wait_s={wait_s:.1f} elapsed={_format_elapsed(elapsed_s)}",
         flush=True,
     )
+
+
+def _lock_backoff(attempt: int) -> float:
+    """Short backoff for 409 per-repo lock contention. Exponential
+    with jitter, clamped to ``[_LOCK_BACKOFF_FLOOR_S,
+    _LOCK_BACKOFF_CEIL_S]``. Smaller envelope than 429 because the
+    lock clears in seconds, not minutes."""
+    base = _LOCK_BACKOFF_FLOOR_S * (2 ** (attempt - 1))
+    base = min(base, _LOCK_BACKOFF_CEIL_S)
+    jitter = base * 0.2 * (random.random() * 2 - 1)  # ±20% — desync writers
+    return max(_LOCK_BACKOFF_FLOOR_S * 0.5, base + jitter)
+
+
+def _is_repo_lock_409(status: int | None, body: str) -> bool:
+    """True iff the response is HF's per-repo write-lock 409 (#230).
+
+    The status alone is too broad — 409 also fires on revision
+    conflicts and other states we shouldn't silently retry. Match the
+    body phrase too so we only auto-retry the case we mean.
+    """
+    if status != 409:
+        return False
+    return "another commit operation is in progress" in (body or "").lower()
 
 
 def _create_commit_with_backoff(
@@ -164,6 +205,7 @@ def _create_commit_with_backoff(
     source: str = "unknown",
     max_retries: int = _DEFAULT_MAX_RETRIES,
     _sleep: Any = time.sleep,
+    _retry_counter: dict | None = None,
     **kwargs: Any,
 ) -> Any:
     """Wrap ``api.create_commit(**kwargs)`` with bounded 429 retry.
@@ -193,27 +235,38 @@ def _create_commit_with_backoff(
             return api.create_commit(**kwargs)
         except HfHubHTTPError as e:
             status, headers, body = _extract_response_pieces(e)
-            if status != 429:
-                # Not a throttle — re-raise so 412 / auth / network
-                # propagate to the caller's handlers untouched.
+            is_lock_409 = _is_repo_lock_409(status, body)
+            if status != 429 and not is_lock_409:
+                # Not a throttle and not the per-repo lock — re-raise
+                # so 412 / auth / network propagate to the caller's
+                # handlers untouched.
                 raise
             last_exc = e
             if attempt == max_retries:
-                # Out of retries — surface the original 429 so the
+                # Out of retries — surface the original error so the
                 # caller sees the actual HF response, not a wrapper.
                 raise
-            wait_s = _parse_retry_after_header(headers.get("Retry-After"))
-            if wait_s is None:
-                wait_s = _parse_retry_after_body(body)
-            if wait_s is None:
-                wait_s = _exponential_backoff(attempt)
-            wait_s = max(_BACKOFF_FLOOR_S, min(wait_s, _BACKOFF_CEIL_S))
+            if is_lock_409:
+                # #230: short backoff for write-lock contention.
+                wait_s = _lock_backoff(attempt)
+                reason = "409"
+                if _retry_counter is not None:
+                    _retry_counter["lock_409"] = _retry_counter.get("lock_409", 0) + 1
+            else:
+                wait_s = _parse_retry_after_header(headers.get("Retry-After"))
+                if wait_s is None:
+                    wait_s = _parse_retry_after_body(body)
+                if wait_s is None:
+                    wait_s = _exponential_backoff(attempt)
+                wait_s = max(_BACKOFF_FLOOR_S, min(wait_s, _BACKOFF_CEIL_S))
+                reason = "429"
             _emit_throttle_line(
                 source=source,
                 attempt=attempt,
                 max_retries=max_retries,
                 wait_s=wait_s,
                 elapsed_s=time.monotonic() - started,
+                reason=reason,
             )
             _sleep(wait_s)
     # Unreachable — the loop either returns or re-raises — but keep a

--- a/tests/e2e/test_per_file_roundtrip.py
+++ b/tests/e2e/test_per_file_roundtrip.py
@@ -607,12 +607,24 @@ class TestConcurrentBakesShareTag:
 
         # Worker entry — must be top-level / picklable, so we use a
         # module-level _worker_bake helper defined just below the class.
+        # #230: a Manager-backed Barrier lets every worker rendezvous
+        # at the same point (just before the manifest CAS commit) so
+        # contention happens regardless of upstream-fetch variance.
+        # Without this, fast workers finish before slow ones even
+        # arrive at the manifest commit, and cas_retries stays at 0.
         try:
-            with mp.get_context("spawn").Pool(processes=n_workers) as pool:
-                results = pool.starmap(
-                    _worker_bake,
-                    [(self.CONC_TAG, source, tier, token) for source, tier in plan],
-                )
+            ctx = mp.get_context("spawn")
+            with ctx.Manager() as mgr:
+                barrier = mgr.Barrier(n_workers, timeout=180)
+                with ctx.Pool(
+                    processes=n_workers,
+                    initializer=_worker_init,
+                    initargs=(barrier,),
+                ) as pool:
+                    results = pool.starmap(
+                        _worker_bake,
+                        [(self.CONC_TAG, source, tier, token) for source, tier in plan],
+                    )
 
             # Every worker must return ok>=1.
             for (source, tier), r in zip(plan, results, strict=True):
@@ -620,7 +632,27 @@ class TestConcurrentBakesShareTag:
                     f"{source}/{tier} bake failed: {r}"
                 )
 
-            # Final manifest must list every (source, tier) pair.
+            # #230: at least one worker must have observed contention
+            # — either a 412 CAS mismatch (parent_commit moved between
+            # our read and our commit) or a 409 per-repo write-lock
+            # collision. Both are observable counters the workers
+            # carry back across the multiprocessing pipe — no log
+            # scraping needed. Without this assertion the test was a
+            # manifest-merge smoke test, not the contention test the
+            # file's docstring promises.
+            total_cas_retries = sum(int(r.get("cas_retries", 0)) for r in results)
+            total_lock_retries = sum(int(r.get("lock_409_retries", 0)) for r in results)
+            assert total_cas_retries + total_lock_retries >= 1, (
+                "expected at least one contention retry across N "
+                f"concurrent writers; got cas_retries={total_cas_retries} "
+                f"lock_409_retries={total_lock_retries}. Per-worker: "
+                f"{[(s, t, r.get('cas_retries'), r.get('lock_409_retries')) for (s, t), r in zip(plan, results, strict=True)]}"
+            )
+
+            # Final manifest must list every (source, storage-tier) pair.
+            # Per #230 the slug is now passed through verbatim as the
+            # storage-tier key, so the worker's `1k-wN` slug is also
+            # the manifest tier name.
             manifest_url = (
                 f"https://huggingface.co/datasets/{REPO}/resolve/"
                 f"{self.CONC_TAG}/release-manifest.json"
@@ -640,34 +672,65 @@ class TestConcurrentBakesShareTag:
                 print(f"concurrent cleanup warn: {type(e).__name__}: {e}")
 
 
+# Per-worker globals populated by ``_worker_init`` (Pool initializer).
+# Spawn-method workers don't inherit module state from the parent, so
+# the Manager-backed Barrier has to be plumbed explicitly.
+_WORKER_BARRIER = None
+
+
+def _worker_init(barrier) -> None:
+    """Pool initializer: stash the cross-process Barrier proxy in a
+    module global so ``_worker_bake`` can hand it to ``bake_one`` as
+    the pre-manifest hook."""
+    global _WORKER_BARRIER
+    _WORKER_BARRIER = barrier
+
+
 def _worker_bake(release_tag: str, source: str, tier: str, token: str) -> dict:
     """Top-level so it's picklable for ``multiprocessing.spawn``.
 
-    Note: "tier" here is a slug per worker (``1k-w0`` etc.) — bake_one
-    will treat it as an unknown tier and route through the `1k` upstream
-    fetch but write to the slug path. We accept the slight contract
-    bend because this test is a CONCURRENCY test, not a tier-correctness
-    test — we only need each worker to produce one HF commit at a
-    distinct path that exercises the manifest merge."""
+    ``tier`` here is a per-worker slug (``1k-w0``, ``1k-w1``, ...).
+    Per #230 we feed it through the new ``storage_tier`` kwarg so it
+    becomes the path/manifest key, while ``tier="1k"`` continues to
+    drive the upstream fetcher. This keeps the production tier guard
+    intact (``bake_one`` still validates ``tier`` against the
+    upstream-supported set) and makes each worker's slug a
+    first-class manifest entry — which is what the original test
+    intent demanded.
+
+    The Manager-backed Barrier (set by ``_worker_init``) is wired to
+    ``bake_one``'s ``_pre_manifest_hook`` so all N workers rendezvous
+    just before the manifest commit — which forces the CAS retry
+    path to actually fire even when upstream fetch durations vary.
+    """
     import tempfile
 
     from mat_vis_baker.hf_bake import bake_one
 
-    # Bake at the real "1k" tier upstream so the fetch succeeds, then
-    # rewrite the release_tag's per-source slug so each worker has its
-    # own (source, tier) path. The simplest way: pass the slug as the
-    # tier name and let the per-file bake commit to <source>/<slug>/.
+    def _hook() -> None:
+        # Park here until every worker has finished its texture batch
+        # and is ready to commit the manifest. Then race together.
+        if _WORKER_BARRIER is not None:
+            _WORKER_BARRIER.wait()
+
     with tempfile.TemporaryDirectory() as td:
         try:
             return bake_one(
                 source=source,
-                tier=tier if tier in {"1k", "2k", "4k", "scalar"} else "1k",
+                # Always fetch at a real upstream tier; the slug only
+                # affects where files land + how the manifest names
+                # them. (Worker slugs share one upstream payload so
+                # contention happens on the manifest CAS, not the
+                # texture write paths.)
+                tier="1k",
+                storage_tier=tier,
                 release_tag=release_tag,
                 work_dir=Path(td),
                 repo_id=REPO,
                 hf_token=token,
                 limit=1,
                 batch_size=1,
+                _pre_manifest_hook=_hook,
             )
         except Exception as e:  # noqa: BLE001
             return {"error": f"{type(e).__name__}: {e}", "ok": 0, "failed": 1}


### PR DESCRIPTION
## Summary

The #210 concurrency E2E was a manifest-merge smoke test pretending to be a contention test:

- \`_worker_bake\` silently rewrote unknown tier slugs (\`1k-w0\`, \`1k-w1\`, \`1k-w2\`) to plain \`"1k"\`, so all N workers wrote into the same \`polyhaven/1k/\` path. The manifest collapsed to a single \`1k\` entry and the test's "every (source, tier) pair lands" assertion could never match.
- Workers finished at wildly different times (upstream fetch variance), so even when contention *should* have happened, the manifest CAS loop typically ran on a serialised order — \`cas_retries == 0\` in practice.

This PR makes the test honest about what it's checking (Option A from #230):

1. **\`bake_one\` / \`bake_one_per_file\` get an opt-in \`storage_tier\` kwarg.** Production callers leave it \`None\` (no behaviour change). Tests pass it to write under a slug-keyed path while the upstream fetch keeps using a real tier. Not exposed on the CLI.
2. **\`_pre_manifest_hook\` lets the test rendezvous workers** at the manifest commit via a Manager-backed \`Barrier\`, forcing real contention regardless of fetch-time variance.
3. **\`bake_one_per_file\` returns \`cas_retries\` and \`lock_409_retries\`** — observable counters that workers carry back over the multiprocessing pipe. The test asserts at least one contention retry was observed; no log scraping needed.
4. **\`hf_retry\` learns about HF's per-repo write-lock 409** (separate from the 429 rate cap from #225) — same retry envelope, shorter floor since the lock clears in seconds.
5. **Manifest-tier assertions are honest now** — every worker's slug appears as a distinct tier under its source.

## Test plan
- [x] Unit suite (\`pytest tests/ -q --ignore=tests/e2e\`): **366 passed, 5 skipped, 1 deselected** (pre-existing version-sync failure unrelated to #230, reproduces on \`dev\` HEAD)
- [x] Pre-commit hooks: ruff, ruff-format, yamllint, branch-name, dagger-shell-safety, typos all pass
- [ ] **Live E2E re-run deferred** — local run was throttled by the same HF 128-commits/hr cap that prompted #225 (we just burned through the hourly window with #214 phase-4 derives). Retry helper fired correctly (\`bake_throttle reason=429 retry=4/5\`) but exhausted before the cap drained. Structural correctness validated by unit + diff review; the live E2E will be re-run in a quieter cap window.

## Acceptance (from #230)
- [x] Production tier guard preserved (new \`storage_tier\` kwarg defaults to \`None\` → identical behaviour as today)
- [x] Workers contend on the manifest CAS via the Barrier; \`cas_retries\`/\`lock_409_retries\` counters expose the contention observably
- [x] Per-worker slug appears as a distinct manifest tier
- [ ] At least one \`manifest CAS retry\` log line observed in the live E2E (deferred to a fresh cap window)

Closes #230.