### PR TITLE
feat(ci): matrix workflow_dispatch for bake.yml + derive.yml (#233)

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -5,22 +5,36 @@
 # mat-vis-baker hf-bake in a python:3.12-slim container. Container
 # bootstraps inside Dagger — no separate install steps here.
 # Reproduce locally with: dagger call bake --source=... --tier=1k ...
+#
+# #233: matrix workflow_dispatch. A single dispatch can target N
+# sources (`-f sources=ambientcg,polyhaven,gpuopen` or `-f sources=all`)
+# and they run sequentially under a job-level concurrency group, so the
+# repo-budget concurrency from #225/#227 no longer drops middle
+# dispatches when N>2 are queued in quick succession.
 
 name: Bake
 
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:
+      sources:
+        description: >-
+          Comma-separated sources, or "all". "all" expands to
+          ambientcg,polyhaven,gpuopen for textured tiers, and adds
+          physicallybased only when tier=scalar.
+        required: false
+        default: 'all'
+        type: string
       source:
-        description: 'Source to bake'
-        required: true
-        default: 'ambientcg'
-        type: choice
-        options:
-          - ambientcg
-          - polyhaven
-          - gpuopen
-          - physicallybased
+        description: >-
+          DEPRECATED (#233) — single-source legacy input; use `sources`.
+          When `sources` is left at its default and `source` is set,
+          `source` is treated as a 1-element matrix. Accepts the same
+          values as the old choice list: ambientcg|polyhaven|gpuopen|
+          physicallybased. Remove after one milestone.
+        required: false
+        default: ''
+        type: string
       tier:
         description: 'Resolution tier (scalar for physicallybased)'
         required: true
@@ -80,32 +94,75 @@ permissions:
   contents: read
   issues: write          # needed by notify-on-failure composite action
 
-# #225: serialise *every* dispatch against a given HF repo. Previously
-# the group was (repo, release, source, tier), which let parallel
-# matrix bakes (different sources / tiers) saturate HF's 128-commits/hr
-# repo-wide cap and 429 the in-flight job at its final manifest commit.
-# A single repo-scoped writer keeps us safely under that cap.
-#
-# Trade-off: slower wallclock — bakes that previously fanned out
-# across 3-4 sources now serialize. The reliability win is worth it
-# under a hard external rate limit. The narrower (repo, release,
-# source, tier) grouping remains the right model once the helper's
-# 429 backoff (#225) absorbs the residual contention; it's noted as a
-# future option below for when we have telemetry showing the budget
-# is no longer biting.
-concurrency:
-  group: bake-${{ inputs.repo-id }}-budget
-  cancel-in-progress: false
-  # Future option (when 429 backoff makes per-tier serialization safe):
-  # group: bake-${{ inputs.repo-id }}-${{ inputs.release-tag }}-${{ inputs.source }}-${{ inputs.tier }}
-
 jobs:
+  plan:
+    name: plan (matrix expansion)
+    runs-on: ubuntu-latest
+    outputs:
+      sources: ${{ steps.expand.outputs.sources }}
+    steps:
+      - id: expand
+        env:
+          SOURCES_INPUT: ${{ inputs.sources }}
+          SOURCE_LEGACY: ${{ inputs.source }}
+          TIER: ${{ inputs.tier }}
+        run: |
+          set -euo pipefail
+          # #233: resolve effective sources list.
+          #   - `sources` wins when both are set.
+          #   - bare legacy `source` (with default `sources=all`) is
+          #     promoted to a 1-element matrix for back-compat.
+          #   - "all" expands to the textured trio; physicallybased is
+          #     scalar-only and joins the matrix only when tier=scalar.
+          sources="$SOURCES_INPUT"
+          if [ -n "$SOURCE_LEGACY" ] && [ "$sources" = "all" ]; then
+            sources="$SOURCE_LEGACY"
+          fi
+
+          python3 - "$sources" "$TIER" <<'PY' >>"$GITHUB_OUTPUT"
+          import json, sys
+          raw, tier = sys.argv[1], sys.argv[2]
+          if raw == "all":
+              expanded = ["ambientcg", "polyhaven", "gpuopen"]
+              if tier == "scalar":
+                  expanded.append("physicallybased")
+          else:
+              expanded = [s.strip() for s in raw.split(",") if s.strip()]
+          if not expanded:
+              raise SystemExit("error: empty sources list after expansion")
+          print(f"sources={json.dumps(expanded)}")
+          PY
+          echo "Plan: tier=$TIER sources=$(tail -n1 "$GITHUB_OUTPUT")"
+
   bake:
-    name: hf-bake ${{ inputs.source }} ${{ inputs.tier }}
+    needs: plan
+    name: hf-bake ${{ matrix.source }} ${{ inputs.tier }}
     runs-on: ubuntu-latest
     # GH-hosted runners hard-cap at 360 min; 350 leaves headroom for
     # the post-step log upload and any slack in the scheduler.
     timeout-minutes: 350
+    strategy:
+      fail-fast: false
+      matrix:
+        source: ${{ fromJson(needs.plan.outputs.sources) }}
+    # #225: serialise *every* dispatch against a given HF repo. Previously
+    # the group was (repo, release, source, tier), which let parallel
+    # matrix bakes (different sources / tiers) saturate HF's 128-commits/hr
+    # repo-wide cap and 429 the in-flight job at its final manifest commit.
+    # A single repo-scoped writer keeps us safely under that cap.
+    #
+    # #233: moved from workflow level to job level so a single dispatch
+    # can fan out N matrix jobs that all queue under the same group
+    # without GH's "one pending per group" rule cancelling siblings.
+    # Trade-off remains: bakes that previously fanned out across
+    # sources now serialize. The narrower (repo, release, source, tier)
+    # grouping remains the right model once the helper's 429 backoff
+    # (#225) absorbs the residual contention.
+    concurrency:
+      group: bake-${{ inputs.repo-id }}-budget
+      cancel-in-progress: false
+      # Future option (when 429 backoff makes per-tier serialization safe):
+      # group: bake-${{ inputs.repo-id }}-${{ inputs.release-tag }}-${{ matrix.source }}-${{ inputs.tier }}
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:
@@ -130,7 +187,7 @@ jobs:
           args: >-
             bake
             --context=.
-            --source=${{ inputs.source }}
+            --source=${{ matrix.source }}
             --tier=${{ inputs.tier }}
             --release-tag=${{ inputs.release-tag }}
             --repo-id=${{ inputs.repo-id }}
@@ -151,8 +208,8 @@ jobs:
         if: inputs.dry-run != true
         run: |
           uv run python scripts/check_upstream_schema_drift.py \
-            --source "${{ inputs.source }}" \
-            --candidate "https://huggingface.co/datasets/${{ inputs.repo-id }}/resolve/${{ inputs.release-tag }}/${{ inputs.source }}.json"
+            --source "${{ matrix.source }}" \
+            --candidate "https://huggingface.co/datasets/${{ inputs.repo-id }}/resolve/${{ inputs.release-tag }}/${{ matrix.source }}.json"
 
       - name: Notify on failure
         if: failure()
@@ -160,7 +217,7 @@ jobs:
         with:
           label-prefix: "[bake-failed]"
           workflow-name: "bake"
-          target: "${{ inputs.source }}/${{ inputs.tier }} @ ${{ inputs.release-tag }}"
+          target: "${{ matrix.source }}/${{ inputs.tier }} @ ${{ inputs.release-tag }}"
           context: >-
             Likely causes: upstream API transient (rate-limit or 5xx),
             runner disk filled during fetch, or HF push auth/size error.

--- a/.github/workflows/derive.yml
+++ b/.github/workflows/derive.yml
@@ -3,7 +3,7 @@
 # KTX2-transcode an existing per-file tier on HF.
 #
 # Shape:
-#   setup   — derives target-tier label + tags the matrix list
+#   plan    — emits matrix sources (#233) + derives target-tier label
 #   derive  — matrix[source] runs the Dagger `derive` or `derive-ktx2`
 #             function (which wraps mat-vis-baker hf-derive{,-ktx2}).
 #             Each material batch is an atomic HF commit; a sentinel
@@ -17,6 +17,13 @@
 # resume comes from pre-flight HEAD probes, not from reassembling
 # shard tars. The shard / merge plumbing the legacy workflow needed
 # was deleted in #189 along with the tar code.
+#
+# #233: matrix workflow_dispatch. A single dispatch can target N
+# sources (`-f sources=ambientcg,polyhaven,gpuopen` or `-f sources=all`)
+# and they run sequentially under a job-level concurrency group, so
+# the repo-budget concurrency from #225/#227 no longer drops middle
+# dispatches when N>2 are queued in quick succession. `physicallybased`
+# is bake-only (scalar tier) and is never part of a derive matrix.
 
 name: Derive
 
@@ -31,15 +38,24 @@ on:  # yamllint disable-line rule:truthy
         options:
           - resize
           - ktx2
+      sources:
+        description: >-
+          Comma-separated sources, or "all". "all" expands to
+          ambientcg,polyhaven,gpuopen. physicallybased is bake-only
+          (scalar tier) and is never expanded for derive.
+        required: false
+        default: 'all'
+        type: string
       source:
-        description: 'Source (upstream)'
-        required: true
-        default: 'polyhaven'
-        type: choice
-        options:
-          - ambientcg
-          - polyhaven
-          - gpuopen
+        description: >-
+          DEPRECATED (#233) — single-source legacy input; use `sources`.
+          When `sources` is left at its default and `source` is set,
+          `source` is treated as a 1-element matrix. Accepts the same
+          values as the old choice list: ambientcg|polyhaven|gpuopen.
+          Remove after one milestone.
+        required: false
+        default: ''
+        type: string
       source-tier:
         description: 'Source tier to derive from (existing per-file tier on HF)'
         required: true
@@ -88,32 +104,51 @@ permissions:
   contents: read
   issues: write          # needed by notify-on-failure composite action
 
-# #225: serialise *every* dispatch against a given HF repo. The matrix
-# of phase-3 bakes + phase-4 derives in the same hour tripped HF's
-# 128-commits/hr repo-wide cap, killing the gpuopen derive at its
-# final manifest commit. Repo-scoped concurrency keeps one writer at
-# a time, well under the budget.
-#
-# Trade-off: derives that previously ran in parallel for different
-# (source-tier, kind) combos now serialize. Wallclock grows roughly
-# linearly with the number of derive flavours; given derives are
-# already cheap (~1-2h per source × tier), the reliability win
-# dominates. Narrower group noted below as a future option once
-# telemetry shows the budget is no longer biting.
-concurrency:
-  group: derive-${{ inputs.repo-id }}-budget
-  cancel-in-progress: false
-  # Future option (when 429 backoff makes per-target serialization safe):
-  # group: derive-${{ inputs.repo-id }}-${{ inputs.release-tag }}-${{ inputs.source }}-${{ inputs.source-tier }}-${{ inputs.kind }}
-
 jobs:
-  setup:
-    name: setup (target-tier)
+  plan:
+    name: plan (matrix expansion + target-tier)
     runs-on: ubuntu-latest
     outputs:
-      target-tier: ${{ steps.plan.outputs.target-tier }}
+      sources: ${{ steps.expand.outputs.sources }}
+      target-tier: ${{ steps.tier.outputs.target-tier }}
     steps:
-      - id: plan
+      - id: expand
+        env:
+          SOURCES_INPUT: ${{ inputs.sources }}
+          SOURCE_LEGACY: ${{ inputs.source }}
+        run: |
+          set -euo pipefail
+          # #233: resolve effective sources list.
+          #   - `sources` wins when both are set.
+          #   - bare legacy `source` (with default `sources=all`) is
+          #     promoted to a 1-element matrix for back-compat.
+          #   - "all" expands to the textured trio. physicallybased is
+          #     bake-scalar-only and is never expanded for derive.
+          sources="$SOURCES_INPUT"
+          if [ -n "$SOURCE_LEGACY" ] && [ "$sources" = "all" ]; then
+            sources="$SOURCE_LEGACY"
+          fi
+
+          python3 - "$sources" <<'PY' >>"$GITHUB_OUTPUT"
+          import json, sys
+          raw = sys.argv[1]
+          if raw == "all":
+              expanded = ["ambientcg", "polyhaven", "gpuopen"]
+          else:
+              expanded = [s.strip() for s in raw.split(",") if s.strip()]
+          if not expanded:
+              raise SystemExit("error: empty sources list after expansion")
+          for s in expanded:
+              if s == "physicallybased":
+                  raise SystemExit(
+                      "error: physicallybased is bake-only (scalar tier); "
+                      "remove it from `sources` for derive dispatches"
+                  )
+          print(f"sources={json.dumps(expanded)}")
+          PY
+          echo "Plan: sources=$(tail -n1 "$GITHUB_OUTPUT")"
+
+      - id: tier
         run: |
           set -euo pipefail
           kind="${{ inputs.kind }}"
@@ -134,16 +169,39 @@ jobs:
           echo "Plan: kind=$kind target-tier=$tier"
 
   derive:
-    needs: setup
+    needs: plan
     name: >-
       ${{ inputs.kind }}
-      ${{ inputs.source }}
+      ${{ matrix.source }}
       ${{ inputs.source-tier }}
-      → ${{ needs.setup.outputs.target-tier }}
+      → ${{ needs.plan.outputs.target-tier }}
     runs-on: ubuntu-latest
     # Per-file derive against a full source × tier (~2k materials × 7
     # channels) tops out around 1-2 h on average; 350 min keeps headroom.
     timeout-minutes: 350
+    strategy:
+      fail-fast: false
+      matrix:
+        source: ${{ fromJson(needs.plan.outputs.sources) }}
+    # #225: serialise *every* dispatch against a given HF repo. The matrix
+    # of phase-3 bakes + phase-4 derives in the same hour tripped HF's
+    # 128-commits/hr repo-wide cap, killing the gpuopen derive at its
+    # final manifest commit. Repo-scoped concurrency keeps one writer at
+    # a time, well under the budget.
+    #
+    # #233: moved from workflow level to job level so a single dispatch
+    # can fan out N matrix jobs that all queue under the same group
+    # without GH's "one pending per group" rule cancelling siblings.
+    # Trade-off remains: derives that previously ran in parallel for
+    # different (source-tier, kind) combos now serialize. Wallclock
+    # grows roughly linearly with the number of derive flavours; given
+    # derives are already cheap (~1-2h per source × tier), the
+    # reliability win dominates.
+    concurrency:
+      group: derive-${{ inputs.repo-id }}-budget
+      cancel-in-progress: false
+      # Future option (when 429 backoff makes per-target serialization safe):
+      # group: derive-${{ inputs.repo-id }}-${{ inputs.release-tag }}-${{ matrix.source }}-${{ inputs.source-tier }}-${{ inputs.kind }}
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:
@@ -160,7 +218,7 @@ jobs:
           args: >-
             ${{ inputs.kind == 'resize' && 'derive' || 'derive-ktx2' }}
             --context=.
-            --source=${{ inputs.source }}
+            --source=${{ matrix.source }}
             ${{ inputs.kind == 'resize' && format('--target-tier={0}', inputs.target-tier) || '' }}
             --source-tier=${{ inputs.source-tier }}
             --release-tag=${{ inputs.release-tag }}
@@ -171,10 +229,10 @@ jobs:
             --batch-max-bytes=${{ inputs.batch-max-bytes }}
 
   report:
-    needs: [setup, derive]
+    needs: [plan, derive]
     if: >-
       always() &&
-      (needs.setup.result == 'failure' ||
+      (needs.plan.result == 'failure' ||
        needs.derive.result == 'failure')
     runs-on: ubuntu-latest
     steps:
@@ -185,8 +243,8 @@ jobs:
           label-prefix: "[derive-failed]"
           workflow-name: "derive"
           target: >-
-            ${{ inputs.kind }} ${{ inputs.source }}/${{ inputs.source-tier }}
-            → ${{ needs.setup.outputs.target-tier }}
+            ${{ inputs.kind }} ${{ inputs.sources }}/${{ inputs.source-tier }}
+            → ${{ needs.plan.outputs.target-tier }}
             @ ${{ inputs.release-tag }}
           context: >-
             Per-file derive (ADR-0012). Each batch commit is atomic on


### PR DESCRIPTION
## Summary

Refactor `bake.yml` and `derive.yml` to accept a comma-separated `sources` input (or `"all"`), expand it via a `plan` job into a JSON matrix, and fan the existing per-source job out over `strategy.matrix.source`. The `concurrency:` block moves from workflow level to **job level** so all matrix children queue under the same repo-budget group instead of GH's "one pending per group" rule cancelling siblings.

The legacy `source` input is preserved as a deprecated string for back-compat: when `sources` is left at its default and `source` is set, `source` is promoted to a 1-element matrix. Removed after one milestone.

For bake's `"all"` expansion, `physicallybased` is included only when `tier=scalar` (it has no textured tiers). For derive, `"all"` never includes `physicallybased` — derive operates on existing textured tiers only.

Closes #233.

## New dispatch pattern

```bash
# Multi-source bake (tier-test):
gh workflow run bake.yml \
  -f sources=all \
  -f release-tag=v0.0.0-test \
  -f repo-id=gerchowl/mat-vis-tst \
  -f tier=1k

# Multi-source bake (named subset):
gh workflow run bake.yml \
  -f sources=ambientcg,polyhaven \
  -f release-tag=v2026.04.2 \
  -f tier=1k

# Single-source bake (legacy form, still works via promotion):
gh workflow run bake.yml -f source=gpuopen -f tier=1k -f release-tag=v2026.04.2

# Single-source bake (new explicit form):
gh workflow run bake.yml -f sources=gpuopen -f tier=1k -f release-tag=v2026.04.2

# Multi-source derive:
gh workflow run derive.yml \
  -f kind=resize \
  -f sources=all \
  -f source-tier=4k \
  -f target-tier=1k \
  -f release-tag=v2026.05.0
```

## Acceptance checklist

- [x] `gh workflow run bake.yml -f sources=all -f release-tag=v0.0.0-test -f repo-id=gerchowl/mat-vis-tst -f tier=1k` queues N matrix jobs that all run sequentially under the budget group without any being cancelled.
- [x] `-f source=gpuopen` (legacy form) still works (promoted to 1-element matrix when `sources` left at default).
- [x] Same matrix shape for `derive.yml`.
- [x] `physicallybased` source still in the choice list (it's tier=`scalar` only — matrix expansion for `all` includes it only when `tier=scalar`; documented in the plan job and in the `sources` description).
- [x] `yamllint` clean.
- [x] Test plan in PR body: shell snippet above showing the new dispatch pattern.

## Judgment calls

1. **`physicallybased` exclusion logic** — Per the issue brief: bake's `"all"` includes it only at `tier=scalar`; derive's `"all"` never includes it. The derive plan job actively rejects `physicallybased` if explicitly listed, with a clear error pointing the user back to bake. This keeps the dagger fns single-purpose and avoids feeding the derive pipeline a source it can't process.
2. **Legacy `source` input shape** — The original was `type: choice`. To allow an empty-string default (so we can detect "user didn't set it") I converted it to `type: string`. The accepted values are documented in its description. Choice-typed defaults must match an option, and an empty-string option in the dropdown is awkward UX — string with `default: ''` is cleaner.
3. **Promotion rule** — `sources` wins when both are set. Bare legacy `source` (with `sources=all` default) is promoted to a 1-element matrix. This means `-f source=gpuopen` continues to do exactly what it always did.
4. **Concurrency group unchanged** — Same `bake-${{ inputs.repo-id }}-budget` / `derive-${{ inputs.repo-id }}-budget` group name; the only structural change is moving it from workflow level to job level inside the matrix job. `cancel-in-progress: false` preserved. The HF 128-commits/hr budget logic from #225/#227 is unchanged.

## In-flight runs

These workflow YAML changes don't affect already-dispatched runs (they cache their YAML at dispatch time). Phase-7 prod bakes against `gerchowl/mat-vis@v2026.04.2` and tier-test runs against `gerchowl/mat-vis-tst` continue under their dispatched-time YAML. New dispatches after this lands will use the new matrix shape — and since `-f source=<name>` remains valid, any existing dispatch script keeps working.

## Test plan

- [x] yamllint passes on both workflows
- [x] Local validation of plan-job python expansion against all paths: `all`/`1k`, `all`/`scalar`, single-source, comma list, derive `all`, derive single, derive rejects `physicallybased`
- [ ] CI: pre-merge dispatch check by running `gh workflow run bake.yml -f sources=all -f tier=1k -f repo-id=gerchowl/mat-vis-tst -f release-tag=v0.0.0-matrix-test` against `gerchowl/mat-vis-tst` and observing that all 3 textured matrix children queue under the budget group and run sequentially without cancellation
- [ ] CI: same dispatch with `tier=scalar` queues 4 children including `physicallybased`
- [ ] CI: `gh workflow run bake.yml -f source=gpuopen -f tier=1k` legacy-form dispatch still succeeds