### PR TITLE
bugfix(ci): use matrix.max-parallel for within-run serialisation (#235)

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -94,6 +94,16 @@ permissions:
   contents: read
   issues: write          # needed by notify-on-failure composite action
 
+# #235 hotfix: workflow-level budget — serialise *every* dispatch
+# against a given HF repo. Previously this was at workflow level, then
+# moved to job level by #233 to support matrix fan-out. The job-level
+# group conflicted with matrix siblings (one-pending-per-group cancels
+# mid-matrix). Reverted here to workflow level; serialization within
+# one dispatch is now done by `matrix.max-parallel: 1` below.
+concurrency:
+  group: bake-${{ inputs.repo-id }}-budget
+  cancel-in-progress: false
+
 jobs:
   plan:
     name: plan (matrix expansion)
@@ -143,26 +153,16 @@ jobs:
     timeout-minutes: 350
     strategy:
       fail-fast: false
+      # #235 hotfix: serialise the matrix siblings WITHIN one dispatch
+      # via matrix.max-parallel. Job-level concurrency-group serialization
+      # (added in #233) doesn't work for matrix siblings — GH's "one
+      # pending slot per group" rule cancels every sibling beyond the
+      # second within the same run, killing #214 phase-7 polyhaven on
+      # the first prod-derive matrix dispatch. matrix.max-parallel is
+      # the correct within-run primitive.
+      max-parallel: 1
       matrix:
         source: ${{ fromJson(needs.plan.outputs.sources) }}
-    # #225: serialise *every* dispatch against a given HF repo. Previously
-    # the group was (repo, release, source, tier), which let parallel
-    # matrix bakes (different sources / tiers) saturate HF's 128-commits/hr
-    # repo-wide cap and 429 the in-flight job at its final manifest commit.
-    # A single repo-scoped writer keeps us safely under that cap.
-    #
-    # #233: moved from workflow level to job level so a single dispatch
-    # can fan out N matrix jobs that all queue under the same group
-    # without GH's "one pending per group" rule cancelling siblings.
-    # Trade-off remains: bakes that previously fanned out across
-    # sources now serialize. The narrower (repo, release, source, tier)
-    # grouping remains the right model once the helper's 429 backoff
-    # (#225) absorbs the residual contention.
-    concurrency:
-      group: bake-${{ inputs.repo-id }}-budget
-      cancel-in-progress: false
-      # Future option (when 429 backoff makes per-tier serialization safe):
-      # group: bake-${{ inputs.repo-id }}-${{ inputs.release-tag }}-${{ matrix.source }}-${{ inputs.tier }}
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:

--- a/.github/workflows/derive.yml
+++ b/.github/workflows/derive.yml
@@ -104,6 +104,13 @@ permissions:
   contents: read
   issues: write          # needed by notify-on-failure composite action
 
+# #235 hotfix: workflow-level budget — see the matching block in
+# bake.yml. Job-level concurrency in #233 conflicted with matrix
+# siblings; reverted to workflow level + matrix.max-parallel: 1 below.
+concurrency:
+  group: derive-${{ inputs.repo-id }}-budget
+  cancel-in-progress: false
+
 jobs:
   plan:
     name: plan (matrix expansion + target-tier)
@@ -181,27 +188,11 @@ jobs:
     timeout-minutes: 350
     strategy:
       fail-fast: false
+      # #235 hotfix: serialise the matrix siblings WITHIN one dispatch
+      # via matrix.max-parallel. See the matching comment in bake.yml.
+      max-parallel: 1
       matrix:
         source: ${{ fromJson(needs.plan.outputs.sources) }}
-    # #225: serialise *every* dispatch against a given HF repo. The matrix
-    # of phase-3 bakes + phase-4 derives in the same hour tripped HF's
-    # 128-commits/hr repo-wide cap, killing the gpuopen derive at its
-    # final manifest commit. Repo-scoped concurrency keeps one writer at
-    # a time, well under the budget.
-    #
-    # #233: moved from workflow level to job level so a single dispatch
-    # can fan out N matrix jobs that all queue under the same group
-    # without GH's "one pending per group" rule cancelling siblings.
-    # Trade-off remains: derives that previously ran in parallel for
-    # different (source-tier, kind) combos now serialize. Wallclock
-    # grows roughly linearly with the number of derive flavours; given
-    # derives are already cheap (~1-2h per source × tier), the
-    # reliability win dominates.
-    concurrency:
-      group: derive-${{ inputs.repo-id }}-budget
-      cancel-in-progress: false
-      # Future option (when 429 backoff makes per-target serialization safe):
-      # group: derive-${{ inputs.repo-id }}-${{ inputs.release-tag }}-${{ matrix.source }}-${{ inputs.source-tier }}-${{ inputs.kind }}
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:


### PR DESCRIPTION
## Summary

#233 moved the concurrency group from workflow level to job level so a single matrix dispatch could fan out across N sources. But job-level concurrency-group serialization runs into GH Actions' \"one pending slot per group\" cancellation: every matrix sibling beyond the second gets cancelled.

#214 phase-7's first prod-derive matrix dispatch ([run 25110390223](https://github.com/MorePET/mat-vis/actions/runs/25110390223)) reproduced it: gpuopen ran, ambientcg pended, **polyhaven cancelled**.

## Fix

The right primitive for "serialise the matrix within one run" is \`strategy.max-parallel: 1\`. The right primitive for "serialise across dispatches" is workflow-level \`concurrency:\`. Use both:

- **Workflow-level concurrency** \`<bake|derive>-<repo-id>-budget\` — enforces "one matrix dispatch at a time" against the same HF repo (preserves #225 budget intent).
- **\`strategy.max-parallel: 1\`** on the matrix — serialises the N sibling jobs within a single dispatch.

Backward-compatible with the legacy single-source dispatch path #233 preserved (\`-f source=<name>\`); matrix degrades to 1-element strategy.

## Test plan
- [x] yamllint clean.
- [ ] Once landed, re-run #214 phase 7's prod derive matrix dispatch and confirm all 3 sources land sequentially (gpuopen → ambientcg → polyhaven) without any cancellation.