### PR TITLE
bugfix(client): read release-manifest.json directly to fix scale bug (#238)

### DIFF
--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -50,7 +50,7 @@ DEFAULT_CACHE_DIR = Path(os.environ.get("MAT_VIS_CACHE", Path.home() / ".cache" 
 # Version is kept in sync with clients/python/pyproject.toml by
 # scripts/sync-standalone-version.py (run via pre-commit). Do not
 # hand-edit — a drift test in tests/ fails CI if it disagrees.
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 # Same User-Agent as the installable package (issue #70). Standalone vs
 # pip-installed is an internal packaging detail; servers receiving the
 # request can't act on it and splitting UA populations fragments

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mat-vis-client"
-version = "0.6.0"
+version = "0.6.1"
 description = "Pure Python client for mat-vis PBR textures — HTTP range reads, zero deps"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -529,11 +529,13 @@ class MatVisClient:
 
     @property
     def manifest(self) -> dict:
-        """Return the v2 manifest for the pinned revision.
+        """Return the v3 manifest for the pinned revision.
 
-        Derived from the HF dataset tree listing — zero cross-run
-        shared writable state on the baker side (ADR-0007). Cached
-        per-tag scope on disk.
+        Read directly from the authoritative ``release-manifest.json``
+        file at the dataset root — one HTTP GET, no tree-listing
+        reconstruction (the HF tree API caps at 1000 entries per page,
+        which prod bakes blow past easily, see #238). Cached per-tag
+        scope on disk so repeat calls in the same process are free.
         """
         if self._manifest is None:
             cache_path = self._cache_scope / ".manifest.json"
@@ -541,57 +543,11 @@ class MatVisClient:
             if cached is not None:
                 self._manifest = json.loads(cached)
             else:
-                self._manifest = self._build_manifest_from_tree()
+                self._manifest = _get_json(self._manifest_url)
                 self._cache_write_text(cache_path, json.dumps(self._manifest, indent=2))
             self._check_schema_version(self._manifest)
             self._maybe_warn_updates()
         return self._manifest
-
-    def _build_manifest_from_tree(self) -> dict:
-        """Build the manifest in memory from the HF tree listing.
-
-        Single HTTPS GET — no bake-time shared state to race on. Per-
-        file substrate (#186 / ADR-0012): ``<src>.json`` catalogs at
-        root, ``<src>/<tier>/.tier_complete`` sentinels mark which
-        tiers are atomically complete. Each material × channel file
-        lives at ``<src>/<tier>/<mid>/<channel>.{png,ktx2}`` but the
-        manifest only enumerates (source, tier) pairs — material lists
-        come from the catalog.
-        """
-        rev = self._tag or "main"
-        tree_url = f"https://huggingface.co/api/datasets/{HF_DATASET}/tree/{rev}?recursive=true"
-        tree = _get_json(tree_url)
-        paths = [e["path"] for e in tree if e.get("type") == "file"]
-
-        sources: dict[str, dict] = {}
-
-        # 1) Discover per-source catalogs at repo root.
-        for path in paths:
-            if (
-                path.endswith(".json")
-                and "-rowmap" not in path  # legacy bakes still co-exist on old tags
-                and "/" not in path
-                and path != "release-manifest.json"
-            ):
-                src = path[:-5]
-                sources.setdefault(src, {"catalog": path, "tiers": {}})
-
-        # 2) Discover completed tiers via .tier_complete sentinels.
-        for path in paths:
-            if not path.endswith("/.tier_complete"):
-                continue
-            parts = path.split("/")
-            if len(parts) != 3:
-                continue
-            src, tier, _sentinel = parts
-            sources.setdefault(src, {"catalog": f"{src}.json", "tiers": {}})
-            sources[src]["tiers"][tier] = {"complete": True}
-
-        return {
-            "schema_version": 3,
-            "release_tag": rev,
-            "sources": sources,
-        }
 
     # ── update checks ──────────────────────────────────────────
 

--- a/clients/python/tests/test_cache.py
+++ b/clients/python/tests/test_cache.py
@@ -34,12 +34,10 @@ MOCK_MANIFEST_V1 = {
     },
 }
 
-# HF tree-listing fixture for tests that exercise _build_manifest_from_tree.
-MOCK_TREE_V3 = [
-    {"path": "ambientcg.json", "type": "file"},
-    {"path": "ambientcg/1k/.tier_complete", "type": "file"},
-    {"path": "ambientcg/1k/Rock064/color.png", "type": "file"},
-]
+# release-manifest.json fixture for tests that exercise the manifest fetch.
+# Post mat-vis#238: the client reads release-manifest.json directly via a
+# single GET; the returned JSON is the manifest dict verbatim.
+MOCK_MANIFEST_FETCH = MOCK_MANIFEST_V1
 
 MOCK_MANIFEST_V2 = {
     "schema_version": 3,
@@ -99,10 +97,9 @@ def test_cache_true_is_default(tmp_cache):
 def test_cache_false_does_not_write_manifest_to_disk(tmp_cache):
     """With cache=False, fetching manifest must not create a .manifest.json."""
     c = MatVisClient(cache_dir=tmp_cache, tag="v2026.04.0", cache=False)
-    # Per-file substrate (#186): the manifest is synthesized from the
-    # HF tree listing; the tree-listing GET returns a list of {path, type}
-    # entries, not a manifest dict.
-    with patch("mat_vis_client.client._get_json", return_value=MOCK_TREE_V3):
+    # Post mat-vis#238: the client fetches release-manifest.json directly,
+    # so _get_json returns the manifest dict verbatim.
+    with patch("mat_vis_client.client._get_json", return_value=MOCK_MANIFEST_FETCH):
         _ = c.manifest
     # No cached manifest anywhere under tmp_cache
     matches = list(tmp_cache.rglob(".manifest.json"))
@@ -112,7 +109,7 @@ def test_cache_false_does_not_write_manifest_to_disk(tmp_cache):
 def test_cache_false_fetches_manifest_every_time(tmp_cache):
     """With cache=False, manifest is fetched on every .manifest access."""
     c = MatVisClient(cache_dir=tmp_cache, tag="v2026.04.0", cache=False)
-    with patch("mat_vis_client.client._get_json", return_value=MOCK_TREE_V3) as mock_get:
+    with patch("mat_vis_client.client._get_json", return_value=MOCK_MANIFEST_FETCH) as mock_get:
         _ = c.manifest
         # Re-reset the in-memory cache to force another fetch
         c._manifest = None

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -226,6 +226,42 @@ class TestClientManifest:
         assert "ambientcg" in sources
         assert "polyhaven" in sources
 
+    def test_manifest_fetches_release_manifest_directly(self):
+        """Cold cache: ``manifest`` fetches release-manifest.json verbatim
+        via a single GET (mat-vis#238). No tree-listing reconstruction."""
+        with tempfile.TemporaryDirectory() as tmp:
+            client = MatVisClient(tag="v2026.04.0", cache_dir=Path(tmp))
+            with patch("mat_vis_client.client._get_json", return_value=MOCK_MANIFEST) as mock_get:
+                m = client.manifest
+            # Returned verbatim
+            assert m == MOCK_MANIFEST
+            # Single fetch, against the release-manifest.json URL
+            assert mock_get.call_count == 1
+            (url,), _ = mock_get.call_args
+            assert url.endswith("/v2026.04.0/release-manifest.json")
+            # Cached on disk under the tag scope
+            cached = Path(tmp) / "v2026.04.0" / ".manifest.json"
+            assert cached.exists()
+            assert json.loads(cached.read_text()) == MOCK_MANIFEST
+
+    def test_manifest_rejects_unsupported_schema(self):
+        """``_check_schema_version`` still gates the fetched manifest."""
+        with tempfile.TemporaryDirectory() as tmp:
+            client = MatVisClient(tag="v2026.04.0", cache_dir=Path(tmp))
+            bad = {**MOCK_MANIFEST, "schema_version": 99}
+            with patch("mat_vis_client.client._get_json", return_value=bad):
+                with pytest.raises(RuntimeError, match="schema_version=99"):
+                    _ = client.manifest
+
+    def test_manifest_rejects_missing_schema(self):
+        """A manifest with no ``schema_version`` surfaces the cache-clear hint."""
+        with tempfile.TemporaryDirectory() as tmp:
+            client = MatVisClient(tag="v2026.04.0", cache_dir=Path(tmp))
+            bad = {k: v for k, v in MOCK_MANIFEST.items() if k != "schema_version"}
+            with patch("mat_vis_client.client._get_json", return_value=bad):
+                with pytest.raises(RuntimeError, match="missing 'schema_version'"):
+                    _ = client.manifest
+
 
 class TestClientCatalogQueries:
     """Per-file substrate (#186): materials/channels read from v3 catalog."""


### PR DESCRIPTION
## Summary

The Python \`MatVisClient.manifest\` property reconstructs the manifest from the HF tree-listing API. HF caps tree responses at **1000 entries / page** (no pagination handled in the client). On \`gerchowl/mat-vis@v2026.04.2\` the per-material directory entries alone exceed 1000 — the response is 100% \`type=directory\`, **0 files reach the client**, and \`sources\` ends up empty:

\`\`\`
client.manifest → {\"schema_version\": 3, \"release_tag\": \"v2026.04.2\", \"sources\": {}}
client.tiers()  → []
client.materials(\"ambientcg\", \"1k\") → SourceNotFoundError
\`\`\`

The committed \`release-manifest.json\` on prod is correct — direct \`curl\` shows all 3 sources at \`[1k, 512]\`. The client just doesn't read it. JS / shell / Rust clients DO read it directly, which is why their phase-5 tests pass against prod.

This is a v0.6.0 release-cut blocker (#214 phase-7 surfaced it).

## Fix

Switch \`MatVisClient.manifest\` to a single GET on \`release-manifest.json\` (matches the JS client). Drop \`_build_manifest_from_tree\` — the manifest file has been authoritative since #207's CAS retry loop. Bump \`mat-vis-client\` from 0.6.0 → 0.6.1.

## Verification

\`\`\`
MAT_VIS_LIVE_TESTS=1 MAT_VIS_LIVE_TAG=v2026.04.2 \\
  pytest clients/python/tests/test_client.py -v -k Live

================= 9 passed, 3 skipped, 50 deselected in 6.22s ==================
\`\`\`

(Skipped tests are pre-existing gpuopen name-lookup ones, unrelated.)

Unit suite: 58 passed, 12 skipped.

## Test plan
- [x] Live tests pass against \`v2026.04.2\` prod tag.
- [x] Unit suite green.
- [x] Bumped \`mat-vis-client\` to 0.6.1 (also synced standalone).
- [ ] Re-run #214 phase-5 client validation across all 4 clients against \`v2026.04.2\` once this lands.

Closes #238.