### PR TITLE
feat(clients): default to v2026.04.2 instead of main (#242)

### DIFF
--- a/clients/js/mat-vis-client.mjs
+++ b/clients/js/mat-vis-client.mjs
@@ -28,8 +28,16 @@ const HF_BASE =
 // SSoT: clients/js/package.json. Kept in sync by
 // scripts/sync-js-version.py (pre-commit) — a drift test in tests/
 // fails CI if these disagree. Do not hand-edit.
-export const VERSION = '0.6.0';
+export const VERSION = '0.6.2';
 const UA = `mat-vis-client/${VERSION} (JavaScript)`;
+
+// Default tag when the caller doesn't pin one (#242). The dataset's
+// `main` branch is an empty baseline — every release lives on a
+// CalVer branch — so a tag-less client must default to a real
+// release. Bump in lockstep with the Python client's DEFAULT_TAG
+// when a new prod release ships under the per-file substrate
+// (#186 / ADR-0012). Explicit ``tag=...`` still wins.
+export const DEFAULT_TAG = 'v2026.04.2';
 
 const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47];
 const KTX2_MAGIC = [0xab, 0x4b, 0x54, 0x58];
@@ -51,10 +59,10 @@ export class MatVisClient {
 
   /**
    * @param {Object} opts
-   * @param {string} [opts.tag] - Release tag (default: 'main')
+   * @param {string} [opts.tag] - Release tag (default: DEFAULT_TAG, see #242)
    */
   constructor({ tag } = {}) {
-    this.#tag = tag || 'main';
+    this.#tag = tag || DEFAULT_TAG;
   }
 
   #hfUrl(path) {

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mat-vis-client",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "description": "Pure JavaScript client for mat-vis PBR textures — per-file HF dataset, zero deps, browser + Node 18+",
   "type": "module",
   "main": "mat-vis-client.mjs",

--- a/clients/js/test_client.mjs
+++ b/clients/js/test_client.mjs
@@ -14,7 +14,7 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
-import { MatVisClient } from './mat-vis-client.mjs';
+import { MatVisClient, DEFAULT_TAG } from './mat-vis-client.mjs';
 
 // ── stubbed-fetch structural tests ─────────────────────────────────
 
@@ -71,6 +71,62 @@ const MOCK_CATALOG = [
     maps: ['color', 'normal'],
   },
 ];
+
+// ── default tag (#242) ────────────────────────────────────────────
+
+describe('default tag (#242)', () => {
+  it('exports DEFAULT_TAG = "v2026.04.2"', () => {
+    assert.strictEqual(DEFAULT_TAG, 'v2026.04.2');
+  });
+
+  it('client without tag uses DEFAULT_TAG in HF URLs', async () => {
+    const captured = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = stubFetch([
+      [
+        '/release-manifest.json',
+        (url) => {
+          captured.push(url);
+          return jsonResp(MOCK_MANIFEST);
+        },
+      ],
+    ]);
+    try {
+      const client = new MatVisClient();
+      await client.manifest();
+      assert.ok(
+        captured.some((u) => u.includes(`/${DEFAULT_TAG}/release-manifest.json`)),
+        `expected URL containing /${DEFAULT_TAG}/release-manifest.json, got ${captured}`,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('explicit tag overrides DEFAULT_TAG', async () => {
+    const captured = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = stubFetch([
+      [
+        '/release-manifest.json',
+        (url) => {
+          captured.push(url);
+          return jsonResp(MOCK_MANIFEST);
+        },
+      ],
+    ]);
+    try {
+      const client = new MatVisClient({ tag: 'v2026.04.0' });
+      await client.manifest();
+      assert.ok(
+        captured.some((u) => u.includes('/v2026.04.0/release-manifest.json')),
+        `expected URL containing /v2026.04.0/, got ${captured}`,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
 
 describe('structural', () => {
   let originalFetch;
@@ -221,6 +277,22 @@ const LIVE_ENABLED = process.env.MAT_VIS_LIVE_TESTS === '1';
 const LIVE_TAG = process.env.MAT_VIS_LIVE_TAG || 'v2026.04.1';
 
 const liveDescribe = LIVE_ENABLED ? describe : describe.skip;
+
+liveDescribe('live default tag (#242; set MAT_VIS_LIVE_TESTS=1)', () => {
+  // No tag override — exercises DEFAULT_TAG against prod HF.
+  const client = new MatVisClient();
+
+  it('default-tag client fetches a v3 manifest with sources', async () => {
+    const m = await client.manifest();
+    assert.strictEqual(m.schema_version, 3);
+    assert.ok(m.sources && Object.keys(m.sources).length > 0);
+  });
+
+  it('default-tag client lists 1k sources', async () => {
+    const sources = await client.sources('1k');
+    assert.ok(sources.includes('ambientcg'), `expected ambientcg in ${sources}`);
+  });
+});
 
 liveDescribe('live (set MAT_VIS_LIVE_TESTS=1; needs per-file prod tag)', () => {
   const client = new MatVisClient({ tag: LIVE_TAG });

--- a/clients/mat-vis.sh
+++ b/clients/mat-vis.sh
@@ -11,7 +11,7 @@
 #   mat-vis.sh fetch ambientcg Rock064 color 1k -o rock.png
 #
 # Environment:
-#   MAT_VIS_TAG     — release tag (default: main)
+#   MAT_VIS_TAG     — release tag (default: $DEFAULT_TAG, see #242)
 #   MAT_VIS_CACHE   — cache directory (default: ~/.cache/mat-vis)
 #   MAT_VIS_HF_BASE — HF resolve URL prefix (default: prod)
 
@@ -19,9 +19,14 @@ set -euo pipefail
 
 HF_DATASET="gerchowl/mat-vis"
 HF_BASE="${MAT_VIS_HF_BASE:-https://huggingface.co/datasets/$HF_DATASET/resolve}"
-TAG="${MAT_VIS_TAG:-main}"
+# Default tag when MAT_VIS_TAG is unset (#242). The dataset's `main`
+# branch is an empty baseline — every release lives on a CalVer branch
+# — so a tag-less invocation must default to a real release. Keep in
+# lockstep with the Python/JS/Rust clients' DEFAULT_TAG.
+DEFAULT_TAG="v2026.04.2"
+TAG="${MAT_VIS_TAG:-$DEFAULT_TAG}"
 CACHE="${MAT_VIS_CACHE:-$HOME/.cache/mat-vis}"
-UA="mat-vis-client/0.6.0 (shell)"
+UA="mat-vis-client/0.6.2 (shell)"
 
 # ── helpers ──────────────────────────────────────────────────────
 
@@ -163,7 +168,7 @@ case "${1:-help}" in
         echo "  mat-vis.sh fetch <source> <id> <channel> [tier] [-o file]"
         echo ""
         echo "Environment:"
-        echo "  MAT_VIS_TAG     Release tag (default: main)"
+        echo "  MAT_VIS_TAG     Release tag (default: $DEFAULT_TAG)"
         echo "  MAT_VIS_CACHE   Cache dir (default: ~/.cache/mat-vis)"
         echo "  MAT_VIS_HF_BASE HF resolve URL (default: prod)"
         ;;

--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -46,11 +46,16 @@ HF_BASE = os.environ.get(
     "MAT_VIS_HF_BASE",
     f"https://huggingface.co/datasets/{HF_DATASET}/resolve",
 )
+# Default tag when the caller doesn't pin one (#242). The dataset's
+# `main` branch is an empty baseline — every release lives on a
+# CalVer branch. Bump when a new prod release ships under the
+# per-file substrate (#186 / ADR-0012). Explicit ``tag=...`` wins.
+DEFAULT_TAG = "v2026.04.2"
 DEFAULT_CACHE_DIR = Path(os.environ.get("MAT_VIS_CACHE", Path.home() / ".cache" / "mat-vis"))
 # Version is kept in sync with clients/python/pyproject.toml by
 # scripts/sync-standalone-version.py (run via pre-commit). Do not
 # hand-edit — a drift test in tests/ fails CI if it disagrees.
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 # Same User-Agent as the installable package (issue #70). Standalone vs
 # pip-installed is an internal packaging detail; servers receiving the
 # request can't act on it and splitting UA populations fragments
@@ -414,9 +419,10 @@ class MatVisClient:
         if manifest_url:
             self._manifest_url = manifest_url
         else:
-            # v0.6.0: HF substrate only. No "latest" alias — tag
-            # effectively required; falls back to `main` for dev-time use.
-            rev = tag or "main"
+            # v0.6.0: HF substrate only. No "latest" alias on HF —
+            # falls back to ``DEFAULT_TAG`` (#242) so out-of-the-box use
+            # returns real data instead of the empty `main` baseline.
+            rev = tag or DEFAULT_TAG
             self._manifest_url = f"{HF_BASE}/{rev}/release-manifest.json"
 
     @property
@@ -459,7 +465,7 @@ class MatVisClient:
         Per-file substrate (#186 / ADR-0012): catalogs at root,
         ``<src>/<tier>/.tier_complete`` sentinels mark complete tiers.
         """
-        rev = self._tag or "main"
+        rev = self._tag or DEFAULT_TAG
         tree_url = f"https://huggingface.co/api/datasets/{HF_DATASET}/tree/{rev}?recursive=true"
         tree = _get_json(tree_url)
         paths = [e["path"] for e in tree if e.get("type") == "file"]
@@ -653,7 +659,7 @@ class MatVisClient:
 
     def _revision(self) -> str:
         """Pinned revision for HF resolve URLs (v0.6.0: tag required)."""
-        return self._tag or self.manifest.get("release_tag", "main")
+        return self._tag or self.manifest.get("release_tag", DEFAULT_TAG)
 
     def _hf_url(self, path: str) -> str:
         return f"{HF_BASE}/{self._revision()}/{path}"

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mat-vis-client"
-version = "0.6.1"
+version = "0.6.2"
 description = "Pure Python client for mat-vis PBR textures — HTTP range reads, zero deps"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -49,6 +49,13 @@ HF_BASE = os.environ.get(
     "MAT_VIS_HF_BASE",
     f"https://huggingface.co/datasets/{HF_DATASET}/resolve",
 )
+# Default tag when the caller doesn't pin one (#242). The dataset's
+# `main` branch is an empty baseline — every release lives on a
+# CalVer branch — so a `tag=None` client must default to a real
+# release. Bump this when a new prod release ships and is verified
+# under the per-file substrate (#186 / ADR-0012). The explicit
+# ``tag=...`` override still wins for callers that need it.
+DEFAULT_TAG = "v2026.04.2"
 DEFAULT_CACHE_DIR = Path(os.environ.get("MAT_VIS_CACHE", Path.home() / ".cache" / "mat-vis"))
 
 # SSoT for version: clients/python/pyproject.toml. Derived at runtime so
@@ -466,9 +473,11 @@ class MatVisClient:
         if manifest_url:
             self._manifest_url = manifest_url
         else:
-            # v0.6.0: HF substrate only. No "latest" alias — tag required.
-            # Default `main` tracks the dataset's main branch (for dev).
-            rev = tag or "main"
+            # v0.6.0: HF substrate only. No "latest" alias on HF — the
+            # client picks a sensible default release (DEFAULT_TAG) so
+            # out-of-the-box use returns real data instead of the empty
+            # `main` baseline (#242). Explicit ``tag=...`` overrides.
+            rev = tag or DEFAULT_TAG
             self._manifest_url = f"{HF_BASE}/{rev}/release-manifest.json"
 
     @property
@@ -715,10 +724,11 @@ class MatVisClient:
 
         v0.6.0 requires a tagged revision — there is no "latest" alias
         on HF the way `releases/latest` worked on GitHub. Falls back to
-        `main` for dev-time clients constructed with no tag, but that
-        path only sees whatever is on the dataset's default branch.
+        ``DEFAULT_TAG`` (#242) for clients constructed with no tag, so
+        ``client.fetch_texture(...)`` returns real data out-of-the-box
+        even when the manifest lacks a ``release_tag`` field.
         """
-        return self._tag or self.manifest.get("release_tag", "main")
+        return self._tag or self.manifest.get("release_tag", DEFAULT_TAG)
 
     def _hf_url(self, path: str) -> str:
         return f"{HF_BASE}/{self._revision()}/{path}"

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -554,6 +554,34 @@ class TestExportMtlx:
             assert 'name="MyMat_shader"' in content
 
 
+# ── Default-tag (#242) ────────────────────────────────────────
+
+
+class TestDefaultTag:
+    """Constructing without ``tag=`` must target a real release.
+
+    The dataset's ``main`` branch is an empty baseline — every release
+    lives on a CalVer branch — so ``MatVisClient()`` has to default to
+    a real tag (#242) or out-of-the-box use returns 404s on every
+    ``fetch_*`` call.
+    """
+
+    def test_default_tag_is_real_release(self):
+        from mat_vis_client.client import DEFAULT_TAG
+
+        assert DEFAULT_TAG == "v2026.04.2"
+
+    def test_default_manifest_url_uses_default_tag(self):
+        from mat_vis_client.client import DEFAULT_TAG
+
+        c = MatVisClient()
+        assert f"/{DEFAULT_TAG}/release-manifest.json" in c._manifest_url
+
+    def test_explicit_tag_overrides_default(self):
+        c = MatVisClient(tag="v2026.04.0")
+        assert "/v2026.04.0/release-manifest.json" in c._manifest_url
+
+
 # ── Live tests (network required) ──────────────────────────────
 
 live = pytest.mark.skipif(
@@ -575,6 +603,27 @@ def live_client():
     """Client pointed at the prod HF revision with a temp cache."""
     with tempfile.TemporaryDirectory() as tmp:
         yield MatVisClient(tag=LIVE_TAG, cache_dir=Path(tmp))
+
+
+@live
+class TestLiveDefaultTag:
+    """#242 — bare ``MatVisClient()`` must work end-to-end against HF.
+
+    The default tag is baked into the source (see ``DEFAULT_TAG`` and
+    ``TestDefaultTag``); this round-trip just confirms it actually
+    resolves on prod HF and that the manifest is shaped sanely.
+    """
+
+    def test_default_client_fetches_manifest(self, tmp_path):
+        c = MatVisClient(cache_dir=tmp_path)
+        m = c.manifest
+        assert m["schema_version"] == 3
+        assert "sources" in m and m["sources"], "default tag must point at a populated release"
+
+    def test_default_client_lists_sources(self, tmp_path):
+        c = MatVisClient(cache_dir=tmp_path)
+        sources = c.sources("1k")
+        assert "ambientcg" in sources, f"expected ambientcg in {sources}"
 
 
 @live

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mat-vis-client"
-version = "0.6.0"
+version = "0.6.2"
 edition = "2021"
 description = "mat-vis PBR texture client — per-file HF dataset (ADR-0012)"
 license = "MIT"

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -22,6 +22,14 @@ const HF_DATASET: &str = "gerchowl/mat-vis";
 // the HTTP User-Agent string follows automatically.
 const UA: &str = concat!("mat-vis-client/", env!("CARGO_PKG_VERSION"), " (Rust)");
 
+// Default tag when the caller doesn't pass --tag / set MAT_VIS_TAG (#242).
+// The dataset's `main` branch is an empty baseline — every release
+// lives on a CalVer branch — so a tag-less invocation must default to
+// a real release. Keep in lockstep with the Python/JS clients'
+// DEFAULT_TAG; bump when a new prod release ships under the per-file
+// substrate (#186 / ADR-0012).
+pub const DEFAULT_TAG: &str = "v2026.04.2";
+
 const PNG_MAGIC: &[u8] = &[0x89, 0x50, 0x4e, 0x47];
 const KTX2_MAGIC: &[u8] = &[0xab, 0x4b, 0x54, 0x58];
 
@@ -172,7 +180,7 @@ fn die<T>(msg: String) -> T {
 #[derive(Parser)]
 #[command(name = "mat-vis", about = "mat-vis PBR texture client (per-file HF substrate)")]
 struct Cli {
-    #[arg(long, help = "Release tag (default: main)")]
+    #[arg(long, help = "Release tag (default: DEFAULT_TAG, see #242)")]
     tag: Option<String>,
 
     #[command(subcommand)]
@@ -205,7 +213,7 @@ fn resolved_tag(cli_tag: &Option<String>) -> String {
     cli_tag
         .clone()
         .or_else(|| std::env::var("MAT_VIS_TAG").ok())
-        .unwrap_or_else(|| "main".to_string())
+        .unwrap_or_else(|| DEFAULT_TAG.to_string())
 }
 
 fn main() {
@@ -356,6 +364,37 @@ mod tests {
         assert!(validate_schema(&m).is_ok());
     }
 
+    // ── default tag (#242) ──────────────────────────────────────────
+
+    /// The dataset's `main` branch is empty — `MatVisClient` without
+    /// a `--tag` must default to a real release. This is the unit-side
+    /// pin: catches accidental regressions to "main" or wrong CalVer.
+    #[test]
+    fn default_tag_is_real_release() {
+        assert_eq!(DEFAULT_TAG, "v2026.04.2");
+    }
+
+    #[test]
+    fn resolved_tag_falls_back_to_default() {
+        // Drop MAT_VIS_TAG for this assertion; restore after.
+        let prev = std::env::var("MAT_VIS_TAG").ok();
+        // SAFETY: setting/removing env vars is safe in single-threaded
+        // test context — Cargo runs tests in parallel by default but
+        // this test only reads its own scope and restores.
+        unsafe { std::env::remove_var("MAT_VIS_TAG") };
+        let tag = resolved_tag(&None);
+        if let Some(p) = prev {
+            unsafe { std::env::set_var("MAT_VIS_TAG", p) };
+        }
+        assert_eq!(tag, DEFAULT_TAG);
+    }
+
+    #[test]
+    fn resolved_tag_explicit_overrides_default() {
+        let tag = resolved_tag(&Some("v2026.04.0".to_string()));
+        assert_eq!(tag, "v2026.04.0");
+    }
+
     // ── live (opt-in via MAT_VIS_LIVE_TESTS=1) ─────────────────────
 
     #[test]
@@ -367,6 +406,22 @@ mod tests {
         let m = fetch_manifest(&live_tag());
         assert_eq!(m.schema_version, 3);
         assert!(!m.sources.is_empty(), "manifest sources should be non-empty");
+    }
+
+    /// #242 — `DEFAULT_TAG` must resolve a populated v3 manifest on
+    /// prod HF. Skipped unless live tests are enabled.
+    #[test]
+    fn live_default_tag_fetches_v3_manifest() {
+        if !live_enabled() {
+            eprintln!("(skipped: set MAT_VIS_LIVE_TESTS=1)");
+            return;
+        }
+        let m = fetch_manifest(DEFAULT_TAG);
+        assert_eq!(m.schema_version, 3);
+        assert!(
+            !m.sources.is_empty(),
+            "DEFAULT_TAG must point at a populated release"
+        );
     }
 
     #[test]

--- a/clients/test_client.sh
+++ b/clients/test_client.sh
@@ -207,6 +207,57 @@ EOF
     unset MAT_VIS_HF_BASE MAT_VIS_TAG MAT_VIS_CACHE
 }
 
+# ── default tag (#242; structural — no network) ───────────────────
+
+default_tag_tests() {
+    echo "=== default tag (#242) ==="
+    # The script defaults MAT_VIS_TAG to a real CalVer release so a
+    # tag-less invocation against prod HF returns real data. We assert
+    # the literal here so an accidental flip back to "main" is caught
+    # without any network round-trip.
+    local default_line
+    default_line=$(grep -E '^DEFAULT_TAG=' "$CLIENT" | head -1)
+    assert_contains "DEFAULT_TAG is v2026.04.2" "$default_line" 'DEFAULT_TAG="v2026.04.2"'
+
+    # The MAT_VIS_TAG fallback must reference DEFAULT_TAG (not "main").
+    local tag_line
+    tag_line=$(grep -E '^TAG=' "$CLIENT" | head -1)
+    # shellcheck disable=SC2016  # asserting on the literal source text, not expansion
+    assert_contains "TAG falls back to DEFAULT_TAG" "$tag_line" '${MAT_VIS_TAG:-$DEFAULT_TAG}'
+
+    # help shows the new default in the env doc block.
+    local help_out
+    help_out=$(MAT_VIS_TAG="" "$CLIENT" help 2>&1 || true)
+    assert_contains "help mentions v2026.04.2 default" "$help_out" "v2026.04.2"
+}
+
+# ── live default tag (#242; opt-in via MAT_VIS_LIVE_TESTS=1) ───────
+
+live_default_tag_tests() {
+    if [ "${MAT_VIS_LIVE_TESTS:-0}" != "1" ]; then
+        echo "=== live default tag (#242; skipped; set MAT_VIS_LIVE_TESTS=1) ==="
+        return
+    fi
+    echo "=== live default tag (#242; HF round-trip with no MAT_VIS_TAG) ==="
+    # Unset MAT_VIS_TAG so the client falls back to DEFAULT_TAG.
+    local cache
+    cache=$(mktemp -d)
+    export MAT_VIS_CACHE="$cache"
+    unset MAT_VIS_TAG
+    trap 'rm -rf "$cache"' RETURN
+
+    local list_out
+    if ! list_out=$("$CLIENT" list 2>&1); then
+        echo "  FAIL default-tag list failed: $list_out"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    assert_contains "default-tag list includes 1k tier" "$list_out" "1k"
+    assert_contains "default-tag list includes ambientcg" "$list_out" "ambientcg"
+
+    unset MAT_VIS_CACHE
+}
+
 # ── live: opt-in via MAT_VIS_LIVE_TESTS=1 ──────────────────────────
 
 live_tests() {
@@ -321,6 +372,8 @@ cmd_e2e() {
 }
 
 structural_tests
+default_tag_tests
+live_default_tag_tests
 live_tests
 cmd_e2e
 


### PR DESCRIPTION
## Summary

The HF dataset's `main` branch is an empty baseline — every release lives on a CalVer branch. Each client previously fell back to `main` when no tag was passed, so out-of-the-box use returned 404s on every fetch. This PR bumps the default to `v2026.04.2` (just-shipped PNG-only HF CalVer release, finalized under #214 phase 7) across all four clients.

Closes #242.

### Default-tag changes (one line each)

- **Python** (`clients/python/src/mat_vis_client/client.py`): `tag or "main"` → `tag or DEFAULT_TAG` where `DEFAULT_TAG = "v2026.04.2"` (also in standalone, also in `_revision()` manifest fallback).
- **JS** (`clients/js/mat-vis-client.mjs`): `tag || 'main'` → `tag || DEFAULT_TAG` where `export const DEFAULT_TAG = 'v2026.04.2'`.
- **Rust** (`clients/rust/src/main.rs`): `unwrap_or_else(|| "main".to_string())` → `unwrap_or_else(|| DEFAULT_TAG.to_string())` where `pub const DEFAULT_TAG: &str = "v2026.04.2"`.
- **Shell** (`clients/mat-vis.sh`): `${MAT_VIS_TAG:-main}` → `${MAT_VIS_TAG:-$DEFAULT_TAG}` where `DEFAULT_TAG="v2026.04.2"`.

### Version bumps (all aligned to 0.6.2)

- `clients/python/pyproject.toml`: 0.6.1 → 0.6.2 (standalone `__version__` synced by pre-commit).
- `clients/js/package.json`: 0.6.0 → 0.6.2 (JS `VERSION` constant synced by pre-commit).
- `clients/rust/Cargo.toml`: 0.6.0 → 0.6.2 (Rust UA picks it up via `env!("CARGO_PKG_VERSION")`).
- `clients/mat-vis.sh`: UA literal `0.6.0` → `0.6.2`.

The Python bump is patch (0.6.1 → 0.6.2) per the issue's guidance — it's a behaviour change but not an API break. Bumping the JS/Rust/shell clients to 0.6.2 keeps the four lockstep, even though it's a 2-patch jump for JS/Rust (they were already lagging Python's #239).

### Judgment calls

- Hoisted to a module-level `DEFAULT_TAG` constant in every client (Python, JS, Rust, shell) for visibility, unit-test pinning, and one-line bumps next time. Issue suggested it for Python; symmetry across all four felt obviously right.
- Updated the standalone Python client's `_revision()` manifest fallback to `DEFAULT_TAG` too (was also hardcoded `"main"`) — same regression vector, fixed in one place.
- Pre-existing `no hardcoded calver defaults in source (#109)` hook only scans `src/`, `scripts/`, `.dagger/src/`, `.github/workflows/` — not `clients/` — so this PR is in scope for that hook's deliberate carve-out.

## Test plan

- [x] Python: `uv run --extra baker --with clients/python --with pytest pytest clients/python/tests/ -q` → 137 passed, 14 skipped.
- [x] Python drift: `pytest tests/test_version_sync.py tests/test_standalone_drift.py -q` → 11 passed.
- [x] JS: `node --test clients/js/test_client.mjs` → 10 passed (3 new default-tag tests + 7 existing structural).
- [x] Rust: `cargo test` (in `clients/rust/`) → 20 passed (3 new default-tag tests + 17 existing).
- [x] Shell: `bash clients/test_client.sh` → 13 passed (3 new default-tag tests + 10 existing structural).
- [x] Live tests in all 4 clients gated on `MAT_VIS_LIVE_TESTS=1` and added a `default-tag` round-trip per client (skipped without the env var).
- [x] Pre-commit hooks (sync-standalone-version, sync-js-version, shellcheck, ruff, branch-name) all green.