### PR TITLE
docs: rewrite README for v0.6.0 actual shipped substrate (#244)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,56 +2,57 @@
 
 **PBR texture data factory for [MorePET/mat][mat].**
 
-Curates ~3 000 PBR materials from four open sources, bakes them to
+Curates ~3 260 PBR materials from four open sources, bakes them to
 flat PNGs, and hosts the output as a per-file Hugging Face dataset
 (``huggingface.co/datasets/gerchowl/mat-vis``, ADR-0012). Consumers
-fetch individual textures with one plain HTTP GET — no rowmap, no
-range read, no pyarrow, no binary deps.
+fetch individual textures with one plain HTTP GET — no range
+reads, no pyarrow, no binary deps.
 
-```python
+```bash
 pip install mat-vis-client
 ```
 
 ```python
 from mat_vis_client import MatVisClient
 
-client = MatVisClient()                                      # auto-discovers latest release
-png = client.fetch_texture("ambientcg", "Rock064", "color")  # 1k PNG bytes, one HTTP GET
-results = client.search(category="wood")                      # filter by category
+client = MatVisClient()                                         # defaults to v2026.04.2
+mats = client.materials("ambientcg", "1k")
+png  = client.fetch_texture("ambientcg", mats[0], "color", "1k")  # PNG bytes, one HTTP GET
+results = client.search(category="wood")                          # filter by category
 ```
 
 ## Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│  IN GIT (this repo, ~40 MB, reviewable)                        │
+│  IN GIT (this repo, ~40 MB, reviewable)                         │
 │                                                                 │
-│  index/*.json        — material metadata per source             │
-│  mtlx/<source>/*.mtlx — MaterialX XML (gpuopen originals)      │
-│  src/mat_vis_baker/  — fetch → bake → pack pipeline             │
-│  clients/            — Python, JS, Rust, Shell reference clients│
-│  .dagger/            — Dagger CI pipeline                       │
+│  index/*.json         — material metadata per source            │
+│  mtlx/<source>/*.mtlx — MaterialX XML (gpuopen originals)       │
+│  src/mat_vis_baker/   — fetch → bake → push pipeline            │
+│  clients/             — Python, JS, Rust, Shell reference clients│
+│  .dagger/             — Dagger CI pipeline                      │
 └─────────────────────────────────────────────────────────────────┘
         │
-        ▼  Dagger bake pipeline (per-file substrate, ADR-0012)
+        ▼  Dagger / GH Actions bake (per-file substrate, ADR-0012)
 ┌─────────────────────────────────────────────────────────────────┐
-│  ON HUGGING FACE DATASETS (calver tag: v2026.04.0)             │
+│  ON HUGGING FACE DATASETS — gerchowl/mat-vis @ v2026.04.2       │
 │                                                                 │
-│  <source>/<tier>/<material_id>/<channel>.png  — texture file    │
-│  <source>/<tier>/.tier_complete               — tier sentinel   │
-│  <source>.json                                — material catalog│
-│  physicallybased.json                         — scalar props    │
+│  release-manifest.json                       — top-level index  │
+│  <source>.json                               — material catalog │
+│  <source>/<tier>/<material_id>/<channel>.png — texture file     │
+│  <source>/<tier>/.tier_complete              — tier sentinel    │
 └─────────────────────────────────────────────────────────────────┘
         │
         ▼  one plain HTTP GET per texture (stdlib urllib, zero deps)
 ┌─────────────────────────────────────────────────────────────────┐
-│  CONSUMER                                                      │
+│  CONSUMER                                                       │
 │                                                                 │
-│  pip install mat-vis-client      (PyPI, zero deps)             │
-│  — or —                                                        │
-│  <script src="mat-vis-client.mjs">  (browser/Node)             │
-│  — or —                                                        │
-│  curl + jq (mat-vis.sh)                                        │
+│  pip install mat-vis-client      (PyPI, zero deps)              │
+│  — or —                                                         │
+│  <script src="mat-vis-client.mjs">  (browser/Node)              │
+│  — or —                                                         │
+│  curl + jq (mat-vis.sh)                                         │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -60,24 +61,27 @@ results = client.search(category="wood")                      # filter by catego
 | Source | Materials | License | Content |
 |---|---|---|---|
 | [ambientcg](https://ambientcg.com) | ~1 965 | CC0-1.0 | PNG textures |
-| [polyhaven](https://polyhaven.com) | ~752 | CC0-1.0 | PNG textures |
-| [gpuopen](https://matlib.gpuopen.com) | ~300 | per-material | MaterialX + PNG textures |
+| [polyhaven](https://polyhaven.com) | ~756 | CC0-1.0 | PNG textures |
+| [gpuopen](https://matlib.gpuopen.com) | ~454 | per-material | MaterialX + PNG textures |
 | [physicallybased.info](https://physicallybased.info) | ~86 | CC0-1.0 | scalar only (IOR, roughness, color) |
 
 ## Resolution tiers
 
 All tiers share the per-file substrate and client API. Each tier is
-the upstream's native resolution — sub-1k tiers below the natively-
-served set are out-of-scope for v0.6.0 (the tar-era resize derive
-pipeline was retired in #189; per-file derive is future work).
+served as a flat tree of PNGs under `<source>/<tier>/<material>/`.
+The latest release `v2026.04.2` ships 4 PNG tiers (1k, 512, 256, 128)
+across ambientcg, polyhaven, and gpuopen, plus the scalar-only
+physicallybased catalog. Sub-1k tiers are produced by `hf-derive`
+(no upstream re-fetch); the 2k tier exists upstream and is rolled
+out per-source as the bake schedule allows.
 
-| Tier | Per material | Status |
+| Tier | Per material | Status (v2026.04.2) |
 |---|---|---|
-| 128 | ~10 KB | released (ambientcg, polyhaven) |
-| 256 | ~40 KB | released (ambientcg, polyhaven) |
-| 512 | ~150 KB | released (ambientcg, polyhaven) |
-| 1k | ~2 MB | released (ambientcg, polyhaven, gpuopen) |
-| 2k | ~10 MB | released (polyhaven); ambientcg + gpuopen baking |
+| 128 | ~10 KB  | released (ambientcg, polyhaven, gpuopen) |
+| 256 | ~40 KB  | released (ambientcg, polyhaven, gpuopen) |
+| 512 | ~150 KB | released (ambientcg, polyhaven, gpuopen) |
+| 1k  | ~2 MB   | released (ambientcg, polyhaven, gpuopen) |
+| 2k  | ~10 MB  | future — staged per-source |
 
 ## Client usage
 
@@ -91,7 +95,7 @@ of curl lines. Pick based on runtime needs.
 | ---------------------------------------------- | :----------: | :----------: | :----------: | :---: | :--: |
 | `fetch_texture` (per-file PNG GET)             | ✅           | ✅           | ✅           | ✅    | —    |
 | Catalog discovery                              | ✅           | ✅           | ✅           | ✅    | —    |
-| Per-material materials list                    | ✅           | ✅           | ✅           | —     | —    |
+| Per-source materials list                      | ✅           | ✅           | ✅           | —     | —    |
 | Local file cache (`~/.cache/mat-vis/`)         | ✅           | —            | —            | —     | —    |
 | Cache soft-cap + `MAT_VIS_CACHE_MAX_SIZE`      | ✅           | —            | —            | —     | —    |
 | Per-file size cap (`MAT_VIS_MAX_FETCH_SIZE`)   | ✅           | —            | —            | —     | —    |
@@ -114,7 +118,7 @@ clients have what you need.
 ```python
 from mat_vis_client import MatVisClient
 
-client = MatVisClient()
+client = MatVisClient()  # defaults to v2026.04.2 (post-#243)
 
 # fetch a single texture channel
 png = client.fetch_texture("ambientcg", "Rock064", "color", tier="1k")
@@ -160,9 +164,13 @@ mat_vis_fetch ambientcg Rock064 color 1k > rock064.png
 ### SQL (DuckDB / pyarrow)
 
 ```sql
+-- The per-source catalog is a JSON sidecar, served directly from HF
+-- with the same one-GET semantics as the PNGs (ADR-0012).
 SELECT id, source, category FROM
-  'https://github.com/MorePET/mat-vis/releases/download/v2026.04.0/mat-vis-ambientcg-1k-ceramic.parquet'
-WHERE category = 'ceramic'
+  read_json_auto(
+    'https://huggingface.co/datasets/gerchowl/mat-vis/resolve/v2026.04.2/ambientcg.json'
+  )
+WHERE category = 'ceramic';
 ```
 
 ## Development
@@ -175,19 +183,46 @@ WHERE category = 'ceramic'
 
 ### Local bake
 
+The pipeline lives in `mat-vis-baker`. Each command writes to a
+scratch `work_dir` and pushes per-file artifacts to the HF dataset
+in atomic commits (one batch = one commit, bounded by count
+*and* bytes per #228; see `--batch-size` / `--batch-max-bytes`).
+
 ```bash
 uv sync
 source .venv/bin/activate
 
-# bake a single source + tier
-mat-vis-baker all ambientcg 1k ./output --release-tag v2026.04.0
+# bake a single (source, tier) and push to HF (default repo: gerchowl/mat-vis).
+# Scratch repos (*-tst) are the default safety net; --allow-prod is required
+# for the canonical dataset.
+mat-vis-baker hf-bake ambientcg 1k ./work \
+  --release-tag v2026.04.2 \
+  --repo-id gerchowl/mat-vis-tst
 
-# derive smaller tiers from a release
-mat-vis-baker derive-from-release v2026.04.0 512 ./output-512
+# derive a smaller PNG tier from an existing per-file HF tier (no upstream
+# re-fetch). source-tier must already be baked; target-tier must be ≤ source-tier.
+mat-vis-baker hf-derive \
+  --source ambientcg --source-tier 1k --target-tier 512 \
+  --release-tag v2026.04.2 --work-dir ./work \
+  --repo-id gerchowl/mat-vis-tst
 
-# generate catalog from release
-mat-vis-baker catalog-from-release v2026.04.0 --output-dir .
+# inspect available subcommands (fetch, catalog, pack-mtlx, hf-derive-ktx2, ...)
+mat-vis-baker --help
 ```
+
+### Workflows
+
+Production bakes run via two GitHub Actions dispatches:
+
+- `.github/workflows/bake.yml` — `workflow_dispatch` with `sources` (one or
+  more, or `sources=all`) × `tier`. Fans out via a matrix; matrix siblings
+  serialize within one dispatch via `max-parallel: 1` (post-#235), so the
+  HF commit-rate budget (128/hr/repo) stays comfortable.
+- `.github/workflows/derive.yml` — same matrix shape, same serialization,
+  for `hf-derive` runs (sub-1k tiers off an existing 1k bake).
+
+Both default to the canonical `gerchowl/mat-vis` repo and require the
+release tag as a dispatch input.
 
 ### Operator's guide: orphan LFS cleanup
 
@@ -203,7 +238,7 @@ but housekeeping-friendly.
 mat-vis-baker audit-orphans --repo gerchowl/mat-vis-tst
 
 # Pin to a specific revision.
-mat-vis-baker audit-orphans --repo gerchowl/mat-vis-tst --revision v2026.05.0
+mat-vis-baker audit-orphans --repo gerchowl/mat-vis-tst --revision v2026.04.2
 
 # Delete orphans (interactive: type DELETE to confirm).
 mat-vis-baker audit-orphans --repo gerchowl/mat-vis-tst --delete
@@ -222,37 +257,44 @@ MAT_VIS_AUDIT_FORCE=1 mat-vis-baker audit-orphans \
 # smoke test
 dagger call -m .dagger smoke --src=.
 
-# full bake + release upload
+# full bake + HF push
 dagger call -m .dagger bake-and-release \
   --src=. --source=ambientcg --tier=1k \
-  --release-tag=v2026.04.0 --registry-pass=env:GITHUB_TOKEN
+  --release-tag=v2026.04.2 --registry-pass=env:GITHUB_TOKEN
 ```
 
 ## Versioning
 
-- **Data releases**: calver (`v2026.04.0`) — tied to upstream source updates
-- **Code/client releases**: semver (`v0.1.0`) — API changes
+- **Data releases**: calver (`v2026.04.2`) — tied to upstream source updates
+- **Code/client releases**: semver (`v0.6.x`) — API changes
 
 ## Key design decisions
 
-Architecture is captured in [`docs/decisions/`](docs/decisions/):
+Architecture is captured in [`docs/decisions/`](docs/decisions/). The
+substrate that landed at v0.6.0 is described in the newer ADRs; the
+earlier ones (ADR-0001…0007) describe storage predecessors that were
+retired in #189.
 
-1. [**ADR-0001**](docs/decisions/0001-storage-architecture-json-index-parquet-textures.md)
-   — Three-layer storage: JSON indexes + .mtlx in git,
-   Parquet bundles as Release assets, rowmap for byte-level access.
-2. [**ADR-0002**](docs/decisions/0002-hosting-github-releases-watch-and-pr.md)
-   — GitHub Releases hosting (free, CDN-backed); weekly
-   watch for upstream change detection.
-3. [**ADR-0003**](docs/decisions/0003-resolution-tiers-and-partitioning.md)
-   — Per (source x tier) Parquet files; category partitioning
-   with dynamic size splitting to stay under GitHub's 2 GB limit.
-4. [**ADR-0004**](docs/decisions/0004-access-modes-lazy-local-cache-default.md)
-   — Lazy local cache at `~/.cache/mat-vis/` as default;
-   prefetch and no-cache modes opt-in.
+1. [**ADR-0007**](docs/decisions/0007-substrate-move-to-hf-datasets-and-tar-container.md)
+   — Substrate move from GitHub Releases to Hugging Face Datasets
+   (the original container layout has since been superseded; see
+   ADR-0012).
+2. [**ADR-0008**](docs/decisions/0008-dataset-tree-as-source-of-truth.md)
+   — The dataset tree (not a sidecar manifest) is the source of truth
+   for what's published.
+3. [**ADR-0010**](docs/decisions/0010-sharded-pipeline-via-gh-matrix.md)
+   — Per (source × tier) bake jobs fanned out via GitHub Actions
+   matrix; one job = one HF push.
+4. [**ADR-0011**](docs/decisions/0011-mat-vis-curated-plus-upstream-mirror.md)
+   — Two-layer index record: curated `mat_vis.*` block + optional
+   verbatim `upstream` mirror.
+5. [**ADR-0012**](docs/decisions/0012-per-file-substrate-drop-tar.md)
+   — **Per-file substrate**: PNG-per-channel directly on HF, atomic
+   per-batch commits, `.tier_complete` sentinel, `release-manifest.json`
+   at root. Replaces the container layout from ADR-0007 (#189).
 
-Newer ADRs (0007–0011) reshape the substrate around the Hugging Face
-dataset + sharded Dagger pipeline + the two-layer index record.
-See the [ADR index](docs/decisions/README.md) for the full ordering.
+See the [ADR index](docs/decisions/README.md) for the full ordering,
+including the retired storage predecessors (ADR-0001…0006).
 
 ## Upstream metadata vocabulary
 
@@ -274,7 +316,7 @@ mat-vis is the **data factory**. [MorePET/mat][mat] is the
 |---|---|---|
 | What | Python API + material data | Data pipeline + hosting |
 | Source data | TOML (physical properties) | .mtlx + JSON (appearance) |
-| Artifact | PyPI wheel (~2 MB) | Parquet on GH Releases (GB) |
+| Artifact | PyPI wheel (~2 MB) | HF dataset (per-file PNGs) |
 | Versioning | semver (API-driven) | calver (upstream-driven) |
 | User installs? | yes (`pip install mat`) | `pip install mat-vis-client` |
 


### PR DESCRIPTION
## Summary

Closes #244. The README still described the pre-#189 parquet+tar substrate and referenced deleted CLI subcommands. Rewrote every reference to match v0.6.0 as actually shipped — same structure (intro, badges, what-it-is, install, quickstart, architecture, sources, tiers, client usage, dev, links), corrected content.

### Substrate change (before / after)

| | Before (in README) | After (this PR) |
|---|---|---|
| Hosting | `v2026.04.0`, GitHub Releases parquet | `v2026.04.2`, HF dataset `gerchowl/mat-vis` (per-file, ADR-0012) |
| Layout | parquet + tar + rowmap | `release-manifest.json` + `<source>.json` + `<source>/<tier>/<material>/<channel>.png` + `.tier_complete` |
| Tiers | 5 (incl. 2k for polyhaven) | 4 PNG tiers shipped (1k/512/256/128); 2k future |
| Baker CLI | `mat-vis-baker all` / `derive-from-release` / `catalog-from-release` (deleted) | `hf-bake` / `hf-derive` / `audit-orphans` |
| SQL example | parquet asset on GH Releases (404) | `read_json_auto` on `<source>.json` from HF |
| Workflows | not mentioned | `bake.yml` + `derive.yml` matrix dispatch with `max-parallel: 1` (post-#235/#236) |
| ADR roll-up | 0001–0004 (retired) | 0007 / 0008 / 0010 / 0011 / 0012 (with 0001–0006 noted as historical) |

### Verification

- Post-rewrite drift grep is empty:
  ```
  grep -nE "v2026\.04\.(0|1)|parquet|\.tar |rowmap|mat-vis-baker all|derive-from-release|catalog-from-release" README.md
  ```
- The 5-line Python quickstart was run locally against `gerchowl/mat-vis @ v2026.04.2`. Output:
  ```
  first mat: AcousticFoam001, total: 1966
  fetched 282134 bytes, magic: b'\x89PNG'
  ```
  (Local client is 0.6.1, so the test pinned `tag='v2026.04.2'` explicitly. The README example shows the bare `MatVisClient()` form per the post-#243 default-tag behavior shipped in 0.6.2.)

## Test plan

- [x] `grep -nE "v2026\.04\.(0|1)|parquet|\.tar |rowmap|mat-vis-baker all|derive-from-release|catalog-from-release" README.md` returns empty
- [x] Python quickstart fetches a real PNG end-to-end against the live HF dataset
- [x] `mat-vis-baker --help` confirms `hf-bake`, `hf-derive`, `audit-orphans` exist and accept the documented flags
- [ ] Reviewer skim for tone / accuracy