### PR TITLE
test(e2e): manifest-driven per-(source,tier) fetch coverage (#248)

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -273,11 +273,15 @@ class MatVisCi:
         self,
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
         tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+        live: Annotated[
+            bool,
+            Doc("Set MAT_VIS_LIVE_TESTS=1 + MAT_VIS_LIVE_TAG=tag to enable @live tests (#248)"),
+        ] = False,
     ) -> str:
         """Run pytest on the Python reference client against a live release."""
         context = src or dag.host().directory(".")
         pip_cache = dag.cache_volume("pip-cache")
-        return await (
+        ctr = (
             dag.container()
             .from_("python:3.12-slim")
             .with_mounted_cache("/root/.cache/pip", pip_cache)
@@ -285,58 +289,79 @@ class MatVisCi:
             .with_workdir("/app/clients/python")
             .with_exec(["pip", "install", "--quiet", "pytest", "."])
             .with_env_variable("MAT_VIS_TAG", tag)
-            .with_exec(["pytest", "test_client.py", "-v"])
-            .stdout()
         )
+        if live:
+            ctr = ctr.with_env_variable("MAT_VIS_LIVE_TESTS", "1").with_env_variable(
+                "MAT_VIS_LIVE_TAG", tag
+            )
+        return await ctr.with_exec(["pytest", "test_client.py", "-v"]).stdout()
 
     @function
     async def test_client_js(
         self,
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
         tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+        live: Annotated[
+            bool,
+            Doc("Set MAT_VIS_LIVE_TESTS=1 + MAT_VIS_LIVE_TAG=tag to enable live tests (#248)"),
+        ] = False,
     ) -> str:
         """Run node --test on the JS reference client against a live release."""
         context = src or dag.host().directory(".")
-        return await (
+        ctr = (
             dag.container()
             .from_("node:22-slim")
             .with_mounted_directory("/app", context)
             .with_workdir("/app/clients/js")
             .with_env_variable("MAT_VIS_TAG", tag)
-            .with_exec(["node", "--test", "test_client.mjs"])
-            .stdout()
         )
+        if live:
+            ctr = ctr.with_env_variable("MAT_VIS_LIVE_TESTS", "1").with_env_variable(
+                "MAT_VIS_LIVE_TAG", tag
+            )
+        return await ctr.with_exec(["node", "--test", "test_client.mjs"]).stdout()
 
     @function
     async def test_client_shell(
         self,
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
         tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+        live: Annotated[
+            bool,
+            Doc("Set MAT_VIS_LIVE_TESTS=1 + MAT_VIS_LIVE_TAG=tag to enable live tests (#248)"),
+        ] = False,
     ) -> str:
         """Run bash test script for the shell reference client against a live release."""
         context = src or dag.host().directory(".")
-        return await (
+        ctr = (
             dag.container()
             .from_("alpine:3.20")
             .with_exec(["apk", "add", "--no-cache", "bash", "curl", "jq", "vim"])
             .with_mounted_directory("/app", context)
             .with_workdir("/app/clients")
             .with_env_variable("MAT_VIS_TAG", tag)
-            .with_exec(["bash", "test_client.sh"])
-            .stdout()
         )
+        if live:
+            ctr = ctr.with_env_variable("MAT_VIS_LIVE_TESTS", "1").with_env_variable(
+                "MAT_VIS_LIVE_TAG", tag
+            )
+        return await ctr.with_exec(["bash", "test_client.sh"]).stdout()
 
     @function
     async def test_client_rust(
         self,
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
         tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+        live: Annotated[
+            bool,
+            Doc("Set MAT_VIS_LIVE_TESTS=1 + MAT_VIS_LIVE_TAG=tag to enable live tests (#248)"),
+        ] = False,
     ) -> str:
         """Run cargo test for the Rust reference client against a live release."""
         context = src or dag.host().directory(".")
         cargo_cache = dag.cache_volume("cargo-registry")
         target_cache = dag.cache_volume("cargo-target")
-        return await (
+        ctr = (
             dag.container()
             .from_("rust:1.89-slim")
             .with_exec(["apt-get", "update", "-qq"])
@@ -346,25 +371,32 @@ class MatVisCi:
             .with_mounted_directory("/app", context)
             .with_workdir("/app/clients/rust")
             .with_env_variable("MAT_VIS_TAG", tag)
-            .with_exec(["cargo", "test", "--", "--test-threads=1"])
-            .stdout()
         )
+        if live:
+            ctr = ctr.with_env_variable("MAT_VIS_LIVE_TESTS", "1").with_env_variable(
+                "MAT_VIS_LIVE_TAG", tag
+            )
+        return await ctr.with_exec(["cargo", "test", "--", "--test-threads=1"]).stdout()
 
     @function
     async def test_clients(
         self,
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
         tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+        live: Annotated[
+            bool,
+            Doc("Forward MAT_VIS_LIVE_TESTS=1 + MAT_VIS_LIVE_TAG=tag to every client (#248)"),
+        ] = False,
     ) -> str:
         """Run all 4 reference client test suites in parallel."""
         context = src or dag.host().directory(".")
 
         import asyncio
 
-        py_task = asyncio.ensure_future(self.test_client_python(context, tag))
-        js_task = asyncio.ensure_future(self.test_client_js(context, tag))
-        sh_task = asyncio.ensure_future(self.test_client_shell(context, tag))
-        rs_task = asyncio.ensure_future(self.test_client_rust(context, tag))
+        py_task = asyncio.ensure_future(self.test_client_python(context, tag, live))
+        js_task = asyncio.ensure_future(self.test_client_js(context, tag, live))
+        sh_task = asyncio.ensure_future(self.test_client_shell(context, tag, live))
+        rs_task = asyncio.ensure_future(self.test_client_rust(context, tag, live))
 
         py_out, js_out, sh_out, rs_out = await asyncio.gather(py_task, js_task, sh_task, rs_task)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,11 @@ jobs:
         with:
           verb: call
           module: .dagger
-          args: test-clients --src=. --tag=v2026.04.0
+          # live=true exports MAT_VIS_LIVE_TESTS=1 + MAT_VIS_LIVE_TAG=<tag>
+          # in each language container so the @live / liveDescribe blocks
+          # (incl. the #248 manifest-driven coverage matrix) actually run
+          # against prod HF, not the structural-only stubs.
+          args: test-clients --src=. --tag=v2026.04.0 --live=true
 
   # validate-release lives in promote-data-release.yml (pre-promotion gate)
   # and release-validate.yml (daily drift check). It tests the state of a

--- a/clients/js/test_client.mjs
+++ b/clients/js/test_client.mjs
@@ -316,6 +316,46 @@ liveDescribe('live (set MAT_VIS_LIVE_TESTS=1; needs per-file prod tag)', () => {
     assert.deepStrictEqual([...magic], [0x89, 0x50, 0x4e, 0x47]);
     assert.ok(buf.byteLength > 1000);
   });
+
+  // #248: manifest-driven per-(source, tier) coverage. One manifest
+  // GET (post-#239 cache) drives every fetch. Sources that publish a
+  // tier in the manifest but have zero records carrying that tier are
+  // skipped — documented as expected (e.g. gpuopen on v2026.04.x).
+  it('every listed tier is fetchable', async () => {
+    const m = await client.manifest();
+    const sources = m.sources || {};
+    assert.ok(Object.keys(sources).length > 0, 'manifest must list sources');
+
+    const attempted = [];
+    const skippedEmpty = [];
+    for (const source of Object.keys(sources).sort()) {
+      const tiers = (sources[source] && sources[source].tiers) || {};
+      for (const tier of Object.keys(tiers).sort()) {
+        if (!tiers[tier] || tiers[tier].complete !== true) continue;
+        const mats = await client.materials(source, tier);
+        if (mats.length === 0) {
+          skippedEmpty.push([source, tier]);
+          continue;
+        }
+        const materialId = mats[0];
+        const buf = await client.fetchTexture(source, materialId, 'color', tier);
+        const head = new Uint8Array(buf, 0, 4);
+        const headHex = [...head].map((b) => b.toString(16).padStart(2, '0')).join('');
+        const isPng = head[0] === 0x89 && head[1] === 0x50 && head[2] === 0x4e && head[3] === 0x47;
+        const isKtx2 = head[0] === 0xab && head[1] === 0x4b && head[2] === 0x54 && head[3] === 0x58;
+        assert.ok(
+          isPng || isKtx2,
+          `(${source}, ${tier}, ${materialId}, magic_bytes_hex_first_4=${headHex}) — ` +
+            `expected PNG (89504e47) or KTX2 (ab4b5458) magic`,
+        );
+        attempted.push([source, tier]);
+      }
+    }
+    assert.ok(
+      attempted.length > 0,
+      `no complete (source, tier) pairs had non-empty material lists; skipped_empty=${JSON.stringify(skippedEmpty)}`,
+    );
+  });
 });
 
 // ── e2e (mat-vis-tst per-file substrate, #193) ─────────────────────

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -686,6 +686,64 @@ class TestLiveFetchTexture:
             live_client.fetch_texture("ambientcg", "NONEXISTENT_XYZ", "color", "1k")
 
 
+# ── #248: manifest-driven per-(source, tier) coverage ────────────
+
+
+PNG_MAGIC = b"\x89PNG"
+KTX2_MAGIC = b"\xabKTX"
+
+
+@live
+class TestLiveFullManifestCoverage:
+    """End-to-end coverage matrix derived from the live manifest.
+
+    For every ``(source, tier)`` pair the manifest declares
+    ``complete=True`` we resolve the material list and fetch the
+    ``color`` channel of the first entry, asserting PNG or KTX2 magic.
+    Sources whose materials list is empty for a given tier (e.g.
+    gpuopen tiers carry no per-tier records on v2026.04.x) are
+    skipped — this is documented as expected, not a regression.
+
+    A single manifest fetch drives the whole loop (post-#239 cache).
+    """
+
+    def test_every_listed_tier_is_fetchable(self, live_client):
+        manifest = live_client.manifest
+        sources = manifest.get("sources", {})
+        assert sources, "manifest must declare at least one source"
+
+        attempted: list[tuple[str, str]] = []
+        skipped_empty: list[tuple[str, str]] = []
+        for source, src_entry in sorted(sources.items()):
+            tiers = (src_entry or {}).get("tiers") or {}
+            for tier, tier_entry in sorted(tiers.items()):
+                if not (tier_entry or {}).get("complete"):
+                    continue
+                mats = live_client.materials(source, tier)
+                if not mats:
+                    # Some sources publish a tier in the manifest but
+                    # have zero records carrying that tier in their
+                    # per-source catalog (e.g. gpuopen on v2026.04.x).
+                    # Treat as expected, log via collected list.
+                    skipped_empty.append((source, tier))
+                    continue
+                material_id = mats[0]
+                data = live_client.fetch_texture(source, material_id, "color", tier)
+                head = data[:4]
+                head_hex = head.hex()
+                assert head.startswith(PNG_MAGIC) or head.startswith(KTX2_MAGIC), (
+                    f"({source!r}, {tier!r}, {material_id!r}, "
+                    f"magic_bytes_hex_first_4={head_hex!r}) — "
+                    f"expected PNG (89504e47) or KTX2 (ab4b5458) magic"
+                )
+                attempted.append((source, tier))
+
+        assert attempted, (
+            "manifest declared no complete (source, tier) pairs with "
+            f"non-empty material lists; skipped_empty={skipped_empty}"
+        )
+
+
 # ── Live regression guards for py-mat#90 (mat-vis#141 / #143 / #144) ──
 # These hit the real gpuopen release and verify the preferred UX
 # (``fetch_all_textures(source, name)``) works end-to-end. They skip

--- a/clients/rust/src/main.rs
+++ b/clients/rust/src/main.rs
@@ -445,6 +445,74 @@ mod tests {
         assert!(bytes.len() > 1000);
     }
 
+    /// #248 — manifest-driven per-(source, tier) coverage.
+    ///
+    /// Single manifest fetch (post-#239) drives every (source, tier)
+    /// where ``complete=true``. Sources that list a tier but have no
+    /// records carrying that tier in their per-source catalog are
+    /// skipped — documented as expected (e.g. gpuopen on v2026.04.x).
+    #[test]
+    fn live_every_listed_tier_is_fetchable() {
+        if !live_enabled() {
+            eprintln!("(skipped: set MAT_VIS_LIVE_TESTS=1)");
+            return;
+        }
+        let tag = live_tag();
+        let manifest = fetch_manifest(&tag);
+        assert!(!manifest.sources.is_empty(), "manifest must list sources");
+
+        let mut sources: Vec<&String> = manifest.sources.keys().collect();
+        sources.sort();
+
+        let mut attempted: Vec<(String, String)> = Vec::new();
+        let mut skipped_empty: Vec<(String, String)> = Vec::new();
+
+        for source in sources {
+            let src_entry = manifest.sources.get(source).expect("source");
+            let mut tiers: Vec<&String> = src_entry.tiers.keys().collect();
+            tiers.sort();
+            for tier in tiers {
+                let tier_entry = src_entry.tiers.get(tier).expect("tier");
+                let complete = tier_entry
+                    .as_object()
+                    .and_then(|o| o.get("complete"))
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                if !complete {
+                    continue;
+                }
+                let cat = fetch_catalog(&tag, source, &manifest);
+                let mid = cat
+                    .iter()
+                    .find(|e| e.available_tiers.iter().any(|t| t == tier))
+                    .map(|e| e.id.clone());
+                let Some(material_id) = mid else {
+                    skipped_empty.push((source.clone(), tier.clone()));
+                    continue;
+                };
+                assert_tier_complete(&tag, source, tier)
+                    .unwrap_or_else(|e| panic!("sentinel missing for ({source}, {tier}): {e}"));
+                let bytes = fetch_texture_bytes(&tag, source, &material_id, "color", tier)
+                    .unwrap_or_else(|e| panic!("({source}, {tier}, {material_id}) fetch: {e}"));
+                let head = &bytes[..4.min(bytes.len())];
+                let head_hex: String = head.iter().map(|b| format!("{b:02x}")).collect();
+                let ok = bytes.starts_with(PNG_MAGIC) || bytes.starts_with(KTX2_MAGIC);
+                assert!(
+                    ok,
+                    "({source}, {tier}, {material_id}, magic_bytes_hex_first_4={head_hex:?}) — \
+                     expected PNG (89504e47) or KTX2 (ab4b5458) magic"
+                );
+                attempted.push((source.clone(), tier.clone()));
+            }
+        }
+
+        assert!(
+            !attempted.is_empty(),
+            "no complete (source, tier) pairs had non-empty material lists; \
+             skipped_empty={skipped_empty:?}"
+        );
+    }
+
     // ── httpmock-based offline coverage (#199) ─────────────────────
     //
     // The HTTP-handling code paths (sentinel, fallback, magic-byte

--- a/clients/test_client.sh
+++ b/clients/test_client.sh
@@ -299,6 +299,65 @@ live_tests() {
         89504e47|ab4b5458) echo "  PASS PNG/KTX2 magic verified ($magic)"; PASS=$((PASS + 1)) ;;
         *) echo "  FAIL unexpected magic: $magic"; FAIL=$((FAIL + 1)) ;;
     esac
+
+    # #248: manifest-driven per-(source, tier) coverage.
+    # Single manifest GET drives every (source, tier) marked
+    # complete=true. Empty material lists are expected on some sources
+    # (e.g. gpuopen on v2026.04.x) and skipped, not failed.
+    local manifest_url manifest_json
+    manifest_url="https://huggingface.co/datasets/gerchowl/mat-vis/resolve/$MAT_VIS_TAG/release-manifest.json"
+    if ! manifest_json=$(curl -sfL -H "User-Agent: mat-vis-shell-test" "$manifest_url"); then
+        echo "  FAIL #248: failed to fetch manifest from $manifest_url"
+        FAIL=$((FAIL + 1))
+    else
+        local pairs attempted=0 skipped_empty=0 fails_248=0
+        # Emit "<source> <tier>" lines for every complete=true pair.
+        pairs=$(echo "$manifest_json" | jq -r \
+            '.sources | to_entries[] | . as $s |
+             ($s.value.tiers // {}) | to_entries[] |
+             select(.value.complete == true) |
+             "\($s.key) \(.key)"')
+        while IFS=' ' read -r src tier; do
+            [ -n "$src" ] || continue
+            local mats first
+            if ! mats=$("$CLIENT" materials "$src" "$tier" 2>/dev/null); then
+                echo "  FAIL #248: materials lookup failed for ($src, $tier)"
+                FAIL=$((FAIL + 1)); fails_248=$((fails_248 + 1))
+                continue
+            fi
+            first=$(echo "$mats" | head -1)
+            if [ -z "$first" ]; then
+                # Documented expected: some sources publish a tier but
+                # carry no records with that tier in their catalog.
+                skipped_empty=$((skipped_empty + 1))
+                continue
+            fi
+            local out_248="$cache/_248_${src}_${tier}.bin"
+            if ! "$CLIENT" fetch "$src" "$first" color "$tier" -o "$out_248" >/dev/null 2>&1; then
+                echo "  FAIL #248: fetch failed for ($src, $tier, $first)"
+                FAIL=$((FAIL + 1)); fails_248=$((fails_248 + 1))
+                continue
+            fi
+            local m4
+            m4=$(head -c4 "$out_248" | od -An -tx1 | tr -d ' \n')
+            case "$m4" in
+                89504e47|ab4b5458)
+                    attempted=$((attempted + 1))
+                    ;;
+                *)
+                    echo "  FAIL #248: ($src, $tier, $first, magic_bytes_hex_first_4=$m4) — expected PNG (89504e47) or KTX2 (ab4b5458) magic"
+                    FAIL=$((FAIL + 1)); fails_248=$((fails_248 + 1))
+                    ;;
+            esac
+        done <<< "$pairs"
+        if [ "$fails_248" -eq 0 ] && [ "$attempted" -gt 0 ]; then
+            echo "  PASS #248 manifest-driven coverage: $attempted (source,tier) pairs fetched, $skipped_empty empty pair(s) skipped"
+            PASS=$((PASS + 1))
+        elif [ "$fails_248" -eq 0 ] && [ "$attempted" -eq 0 ]; then
+            echo "  FAIL #248: no complete (source,tier) pair yielded a non-empty material list (skipped_empty=$skipped_empty)"
+            FAIL=$((FAIL + 1))
+        fi
+    fi
 }
 
 # ── e2e: opt-in via MAT_VIS_E2E=1 (mat-vis-tst per-file substrate, #193)


### PR DESCRIPTION
## Summary

- One new live test in each of the 4 reference client suites (Python / JS / Rust / shell) that loops over every `(source, tier)` pair the live manifest flags `complete=True`, fetches `materials(source, tier)`, and round-trips a `color` texture for the first material, asserting PNG/KTX2 magic. Empty material lists (e.g. gpuopen entries without per-tier staging) are skipped as documented expected, not failed.
- Failure messages include `(source, tier, material_id, magic_bytes_hex_first_4)` so a CI log alone is enough to diagnose.
- Wires `MAT_VIS_LIVE_TESTS=1` + `MAT_VIS_LIVE_TAG=<tag>` into the dagger `test_client_*` functions via a new `live=False` flag, and flips `live=true` in `ci.yml` so the `@live` / `liveDescribe` / `live_*` blocks actually fire against prod HF instead of staying structural-only.

Closes #248.

## Verification

Ran each suite against `gerchowl/mat-vis@v2026.04.2`:

- **Python**: `pytest clients/python/tests/test_client.py::TestLiveFullManifestCoverage -v` → 1 passed in 15.3s
- **JS**: `node --test clients/js/test_client.mjs` → 16 passed (incl. new "every listed tier is fetchable" hitting 12 pairs in 10.5s)
- **Rust**: `cargo test live_every_listed_tier -- --test-threads=1` → 1 passed in 13.8s
- **Shell**: `bash clients/test_client.sh` → 21 passed, 0 failed (new `#248 manifest-driven coverage: 12 (source,tier) pairs fetched, 0 empty pair(s) skipped`)

Each loop fetches 12 pairs on v2026.04.2 (3 sources × 4 complete tiers each — gpuopen catalog has 436 records carrying all 4 tiers; the 18 records without `available_tiers` don't show up in `materials()` so the empty-skip path is exercised in code but doesn't fire on this tag).

## Judgment calls

- The empty-tier skip path is implemented as documented (uses `materials()` returning `[]` as the trigger); on v2026.04.2 every complete tier has non-empty material lists, so the skip branch is dormant but ready for tags where it isn't.
- Added a `live=False` flag to the four dagger `test_client_*` functions plus the umbrella `test_clients`, defaulting off so callers that want structural-only behaviour are unchanged. `ci.yml` opts in with `--live=true` against the prod tag — same rationale as the issue's "set `MAT_VIS_LIVE_TESTS=1` when running against prod" note.
- Did not add a new workflow file: `e2e.yml` only drives the Python e2e bake/teardown via Dagger, while the 4 client tests live in `ci.yml`'s `client-tests` job, so that's where the live-tests env got wired.

## Test plan

- [x] Python live suite passes (`MAT_VIS_LIVE_TESTS=1 MAT_VIS_LIVE_TAG=v2026.04.2 pytest …::TestLiveFullManifestCoverage`)
- [x] JS live suite passes (`MAT_VIS_LIVE_TESTS=1 … node --test`)
- [x] Rust live test passes (`MAT_VIS_LIVE_TESTS=1 … cargo test live_every_listed_tier`)
- [x] Shell live block passes (`MAT_VIS_LIVE_TESTS=1 … bash clients/test_client.sh`)
- [x] Pre-commit hooks all green; pre-push skipped only for `test-fast` (worktree venv lacks `mat_vis_baker`)
- [ ] CI `client-tests` job exercises the new code paths once this PR is on a feature branch (will be visible after first run)