### PR TITLE
bugfix(ci): bump live-test tag v2026.04.0 → v2026.04.2 (#249 follow-up)

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -272,7 +272,7 @@ class MatVisCi:
     async def test_client_python(
         self,
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
-        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.2",
         live: Annotated[
             bool,
             Doc("Set MAT_VIS_LIVE_TESTS=1 + MAT_VIS_LIVE_TAG=tag to enable @live tests (#248)"),
@@ -300,7 +300,7 @@ class MatVisCi:
     async def test_client_js(
         self,
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
-        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.2",
         live: Annotated[
             bool,
             Doc("Set MAT_VIS_LIVE_TESTS=1 + MAT_VIS_LIVE_TAG=tag to enable live tests (#248)"),
@@ -325,7 +325,7 @@ class MatVisCi:
     async def test_client_shell(
         self,
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
-        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.2",
         live: Annotated[
             bool,
             Doc("Set MAT_VIS_LIVE_TESTS=1 + MAT_VIS_LIVE_TAG=tag to enable live tests (#248)"),
@@ -351,7 +351,7 @@ class MatVisCi:
     async def test_client_rust(
         self,
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
-        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.2",
         live: Annotated[
             bool,
             Doc("Set MAT_VIS_LIVE_TESTS=1 + MAT_VIS_LIVE_TAG=tag to enable live tests (#248)"),
@@ -382,7 +382,7 @@ class MatVisCi:
     async def test_clients(
         self,
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
-        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.2",
         live: Annotated[
             bool,
             Doc("Forward MAT_VIS_LIVE_TESTS=1 + MAT_VIS_LIVE_TAG=tag to every client (#248)"),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           # in each language container so the @live / liveDescribe blocks
           # (incl. the #248 manifest-driven coverage matrix) actually run
           # against prod HF, not the structural-only stubs.
-          args: test-clients --src=. --tag=v2026.04.0 --live=true
+          args: test-clients --src=. --tag=v2026.04.2 --live=true
 
   # validate-release lives in promote-data-release.yml (pre-promotion gate)
   # and release-validate.yml (daily drift check). It tests the state of a


### PR DESCRIPTION
## Summary

#249's manifest-driven coverage suite fires the \`@live\` test blocks via \`MAT_VIS_LIVE_TESTS=1\`. The \`ci.yml\` \`client-tests\` job was passing \`--tag=v2026.04.0\`, and the dagger \`test_client_*\` fns defaulted to \`v2026.04.0\` per signature. **\`v2026.04.0\` doesn't exist on \`gerchowl/mat-vis\`** — refs are \`[v2026.04.2, main]\` after the v2026.04.1 sunset cleanup. Live blocks fail with:

\`\`\`
error: Failed to fetch https://huggingface.co/datasets/gerchowl/mat-vis/resolve/v2026.04.0/release-manifest.json
\`\`\`

Surfaced on [run 25172585927](https://github.com/MorePET/mat-vis/actions/runs/25172585927) — PR #249's own CI exposed the stale tag the moment its new live-coverage suite ran.

## Fix

Bump both surfaces to \`v2026.04.2\`:
- \`.github/workflows/ci.yml:48\` — \`--tag=v2026.04.0\` → \`--tag=v2026.04.2\`.
- \`.dagger/src/mat_vis_ci/main.py\` lines 275/303/328/354/385 — fn signature defaults.

Future CalVer bumps will need to touch both surfaces until we add a CalVer-injection mechanism (worth filing as a follow-up — bake.yml already accepts release-tag as input; the test-clients dispatch path doesn't yet).

## Test plan
- [x] yamllint + pre-commit clean
- [ ] CI's own \`client-tests\` job runs the live blocks against \`v2026.04.2\` and passes (proves the fix works for itself)