### PR TITLE
bugfix(test): bump physicallybased proof + LIVE_TAG default to v2026.04.2 (#250 follow-up)

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -272,7 +272,7 @@ class MatVisCi:
     async def test_client_python(
         self,
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
-        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.2",
         live: Annotated[
             bool,
             Doc("Set MAT_VIS_LIVE_TESTS=1 + MAT_VIS_LIVE_TAG=tag to enable @live tests (#248)"),
@@ -300,7 +300,7 @@ class MatVisCi:
     async def test_client_js(
         self,
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
-        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.2",
         live: Annotated[
             bool,
             Doc("Set MAT_VIS_LIVE_TESTS=1 + MAT_VIS_LIVE_TAG=tag to enable live tests (#248)"),
@@ -325,7 +325,7 @@ class MatVisCi:
     async def test_client_shell(
         self,
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
-        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.2",
         live: Annotated[
             bool,
             Doc("Set MAT_VIS_LIVE_TESTS=1 + MAT_VIS_LIVE_TAG=tag to enable live tests (#248)"),
@@ -351,7 +351,7 @@ class MatVisCi:
     async def test_client_rust(
         self,
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
-        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.2",
         live: Annotated[
             bool,
             Doc("Set MAT_VIS_LIVE_TESTS=1 + MAT_VIS_LIVE_TAG=tag to enable live tests (#248)"),
@@ -382,7 +382,7 @@ class MatVisCi:
     async def test_clients(
         self,
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
-        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.0",
+        tag: Annotated[str, Doc("Release tag to test against")] = "v2026.04.2",
         live: Annotated[
             bool,
             Doc("Forward MAT_VIS_LIVE_TESTS=1 + MAT_VIS_LIVE_TAG=tag to every client (#248)"),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           # in each language container so the @live / liveDescribe blocks
           # (incl. the #248 manifest-driven coverage matrix) actually run
           # against prod HF, not the structural-only stubs.
-          args: test-clients --src=. --tag=v2026.04.0 --live=true
+          args: test-clients --src=. --tag=v2026.04.2 --live=true
 
   # validate-release lives in promote-data-release.yml (pre-promotion gate)
   # and release-validate.yml (daily drift check). It tests the state of a

--- a/clients/python/test_client.py
+++ b/clients/python/test_client.py
@@ -1279,7 +1279,7 @@ live = pytest.mark.skipif(
 )
 
 
-LIVE_TAG = os.environ.get("MAT_VIS_LIVE_TAG", "v2026.04.1")
+LIVE_TAG = os.environ.get("MAT_VIS_LIVE_TAG", "v2026.04.2")
 LIVE_SOURCE = "polyhaven"
 LIVE_TIER = "1k"
 
@@ -1358,9 +1358,14 @@ class TestLiveFetchTexture:
 
 @live
 def test_proof_phase_2_fetch_physicallybased_index_from_hf():
-    """Scalar catalog for physicallybased is fetchable from HF substrate."""
+    """Scalar catalog for physicallybased is fetchable from HF substrate.
+
+    Uses ``LIVE_TAG`` (env-overridable) so this stays current as
+    the prod release tag rolls forward; #250 surfaced a hardcoded
+    v2026.04.1 here that broke once that tag was sunset.
+    """
     with tempfile.TemporaryDirectory() as tmp:
-        client = MatVisClient(tag="v2026.04.1", cache_dir=Path(tmp))
+        client = MatVisClient(tag=LIVE_TAG, cache_dir=Path(tmp))
         idx = client.index("physicallybased")
     assert len(idx) >= 50, f"expected ≥50 PB entries, got {len(idx)}"
     assert all("id" in e and "source" in e for e in idx)


### PR DESCRIPTION
## Summary

#250's CI fix bumped the workflow + dagger fn defaults from v2026.04.0 to v2026.04.2 but missed two stale tag references in \`clients/python/test_client.py\`:

- \`LIVE_TAG\` default was \`v2026.04.1\` (sunset CalVer; refs on prod are now \`[v2026.04.2, main]\`).
- \`test_proof_phase_2_fetch_physicallybased_index_from_hf\` hardcoded \`tag=\"v2026.04.1\"\` instead of using \`LIVE_TAG\`.

Both surfaced when #248's manifest-driven coverage suite finally fired the \`@live\` blocks in CI ([run 25173045667](https://github.com/MorePET/mat-vis/actions/runs/25173045667)) and they 404'd against the deleted v2026.04.1 ref.

## Fix

1. \`LIVE_TAG\` default → \`\"v2026.04.2\"\`.
2. The proof test now reads \`LIVE_TAG\` so it rolls forward with the release tag (env-overridable for staging dispatches).

## Adjacent work

- One-shot manifest patch landed on \`gerchowl/mat-vis@v2026.04.2\` (commit \`63e84e2\`) to add the missing physicallybased entry. Proper code fix is filed as #251 — \`bake_scalar_source\` doesn't update release-manifest.json (legacy contract that worked pre-#239 when the client tree-walked).

## Test plan
- [x] Local unit suite green.
- [ ] Post-merge CI \`client-tests\` job's \`@live\` blocks pass (proves the fix works for itself + the manifest one-shot held).