### PR TITLE
bugfix(test): uv workspace for clients/python so test_version_sync passes locally (#263 follow-up)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,24 @@ dev = [
     "pytest>=7",
     "pytest-cov>=4",
     "ruff>=0.4",
+    # Editable install of the reference Python client so tests/ can
+    # import `mat_vis_client` without a manual `pip install -e
+    # clients/python`. Path-based source below — uv only resolves it
+    # when the `dev` extra is requested. Workspace mode would have
+    # made `clients/python` a mandatory member for every uv command,
+    # which breaks Containerfile's `uv pip install .[baker]` (the
+    # container only COPYs pyproject.toml + README + src/, not the
+    # client tree).
+    "mat-vis-client",
 ]
 
 [project.scripts]
 mat-vis-baker = "mat_vis_baker.__main__:main"
+
+[tool.uv.sources]
+# Path source resolved ONLY when the `dev` extra pulls mat-vis-client
+# in. Container builds (which install just `.[baker]`) never look here.
+mat-vis-client = { path = "clients/python", editable = true }
 
 [build-system]
 requires = ["hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -421,6 +421,7 @@ baker = [
     { name = "requests" },
 ]
 dev = [
+    { name = "mat-vis-client" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -437,6 +438,7 @@ observability = [
 [package.metadata]
 requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'baker'", specifier = ">=0.25" },
+    { name = "mat-vis-client", marker = "extra == 'dev'", editable = "clients/python" },
     { name = "materialx", marker = "extra == 'materialx'", specifier = ">=1.39" },
     { name = "openexr", marker = "extra == 'materialx'", specifier = ">=3.3" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.27" },
@@ -449,6 +451,11 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
 ]
 provides-extras = ["baker", "materialx", "observability", "dev"]
+
+[[package]]
+name = "mat-vis-client"
+version = "0.6.3"
+source = { editable = "clients/python" }
 
 [[package]]
 name = "materialx"


### PR DESCRIPTION
## Problem

\`tests/test_version_sync.py::test_client_runtime_version_matches_pyproject\` imports \`mat_vis_client\` to assert the client's runtime \`__version__\` matches its \`pyproject.toml\`. On a clean local checkout, \`uv sync --all-extras\` from the root only installed the **baker**, so the test died with:

\`\`\`
ModuleNotFoundError: No module named 'mat_vis_client'
\`\`\`

CI was masked because the dagger container runs the suite from inside a context where the client is installed separately. Surfaced during the #263 implementation as a "pre-existing test failure on clean checkout."

## Fix

Declare \`clients/python\` as a uv workspace member and add \`mat-vis-client\` to the root \`dev\` extra. After this, \`uv sync --all-extras\` from the repo root installs both the baker and the reference Python client editably in one pass — no \`pip install -e clients/python\` needed.

\`\`\`toml
[project.optional-dependencies]
dev = [
    ...,
    "mat-vis-client",  # via workspace below
]

[tool.uv.workspace]
members = ["clients/python"]

[tool.uv.sources]
mat-vis-client = { workspace = true }
\`\`\`

## Verification

\`\`\`
$ uv sync --all-extras
...
 + mat-vis-client==0.6.3 (from file:///.../clients/python)

$ uv run pytest tests/test_version_sync.py -v
7 passed in 0.12s

$ uv run pytest tests/ -q
357 passed, 16 skipped in 34.73s
\`\`\`

## Test plan

- [ ] CI green
- [ ] Reviewer can verify by deleting \`.venv/\`, running \`uv sync --all-extras\`, and confirming \`uv run pytest tests/test_version_sync.py\` passes without manual editable install