### PR TITLE
bugfix(ci): disable Dagger's dagger.cloud OTel export (#262 partial)

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -94,6 +94,13 @@ permissions:
   contents: read
   issues: write          # needed by notify-on-failure composite action
 
+# #262: disable Dagger's dagger.cloud OTel export (5xx → SIGPIPE in CI).
+# Replace with self-hosted endpoint once #131 + #176 + the otlp-tailnet
+# composite action are wired in.
+env:
+  OTEL_SDK_DISABLED: "true"
+  DAGGER_NO_NAG: "1"
+
 # #235 hotfix: workflow-level budget — serialise *every* dispatch
 # against a given HF repo. Previously this was at workflow level, then
 # moved to job level by #233 to support matrix fan-out. The job-level

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,17 @@ on:  # yamllint disable-line rule:truthy
     branches: [main, dev]
     tags: ["v*"]
 
+# #262: Dagger ships traces + metrics to dagger.cloud by default.
+# That collector flakes (5xx) and the metric exporter then SIGPIPEs
+# the dagger CLI (exit 141), bricking otherwise-green CI runs (e.g.
+# the v0.6.0 tag run 25287958789). Until #262 lands a self-hosted
+# OTLP collector + wires it via .github/actions/otlp-tailnet, fully
+# disable the OTel SDK in CI. DAGGER_NO_NAG silences the cosmetic
+# "Setup tracing at dagger.cloud" line.
+env:
+  OTEL_SDK_DISABLED: "true"
+  DAGGER_NO_NAG: "1"
+
 jobs:
   ci:
     name: Lint + Test + Container smoke

--- a/.github/workflows/derive.yml
+++ b/.github/workflows/derive.yml
@@ -108,6 +108,13 @@ permissions:
   contents: read
   issues: write          # needed by notify-on-failure composite action
 
+# #262: disable Dagger's dagger.cloud OTel export (5xx → SIGPIPE in CI).
+# Replace with self-hosted endpoint once #131 + #176 + the otlp-tailnet
+# composite action are wired in.
+env:
+  OTEL_SDK_DISABLED: "true"
+  DAGGER_NO_NAG: "1"
+
 # #235 hotfix: workflow-level budget — see the matching block in
 # bake.yml. Job-level concurrency in #233 conflicted with matrix
 # siblings; reverted to workflow level + matrix.max-parallel: 1 below.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,13 @@ permissions:
   contents: read
   issues: write          # needed by notify-on-failure composite action
 
+# #262: disable Dagger's dagger.cloud OTel export (5xx → SIGPIPE in CI).
+# Replace with self-hosted endpoint once #131 + #176 + the otlp-tailnet
+# composite action are wired in.
+env:
+  OTEL_SDK_DISABLED: "true"
+  DAGGER_NO_NAG: "1"
+
 jobs:
   e2e:
     name: live round-trip against mat-vis-tst


### PR DESCRIPTION
## Why

Dagger's CLI exports traces + metrics to \`dagger.cloud\` by default. That hosted OTLP collector intermittently returns 5xx batches; the OTel HTTP exporter's retry logic then SIGPIPEs the parent \`dagger\` CLI process, which exits 141 and bricks the whole job. This has bitten:

- v0.6.0 tag CI run \`25287958789\` (Phase-7 release flow, manually re-run to recover)
- PR #267 first try (workspace fix that was unrelated to OTel)

## What

Add a workflow-level \`env\` block to every workflow that invokes \`dagger/dagger-for-github\`:

\`\`\`yaml
env:
  OTEL_SDK_DISABLED: \"true\"
  DAGGER_NO_NAG: \"1\"
\`\`\`

Applied to:

- \`.github/workflows/ci.yml\` (4 jobs use dagger)
- \`.github/workflows/bake.yml\`
- \`.github/workflows/derive.yml\`
- \`.github/workflows/e2e.yml\`

\`pypi.yml\` doesn't use dagger so it's untouched.

## What this does NOT do

This is a tactical bandaid, not the proper fix. It silences our OTel exports entirely — meaning **zero observability** until #262 lands a self-hosted OTLP collector and wires it via the existing \`.github/actions/otlp-tailnet\` composite action. The proper fix is:

1. Deploy \`grafana/otel-lgtm\` collector on Tailscale (#131)
2. Resolve the tagged auth-key rejection (#176)
3. Wire \`OTEL_EXPORTER_OTLP_ENDPOINT\` in workflows that should report (#262)

Once #262's stack is live, this PR's env block gets replaced with a pointer to the self-hosted endpoint instead of a global disable.

## Cosmetic side-effect

\`DAGGER_NO_NAG=1\` silences the \"Setup tracing at https://dagger.cloud/traces/setup\" banner the CLI prints at the end of every run. Purely aesthetic.

## Test plan

- [ ] CI on this PR is green (the same suite that hit SIGPIPE on #267)
- [ ] No more SIGPIPE / exit 141 in upcoming bake/derive/CI runs