### PR TITLE
feat(client): pack metallicRoughness texture per glTF spec (#91)

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -20,6 +20,13 @@ classifiers = [
 ]
 dependencies = []
 
+[project.optional-dependencies]
+# Enables glTF metallicRoughnessTexture packing in adapters.to_gltf().
+# Without this extra, to_gltf() emits a `_note_no_pillow` placeholder
+# when both metalness and roughness PNGs are present (it remains a
+# zero-dependency client by default).
+gltf = ["pillow>=10.0"]
+
 [project.scripts]
 mat-vis-client = "mat_vis_client.client:main"
 

--- a/clients/python/src/mat_vis_client/adapters.py
+++ b/clients/python/src/mat_vis_client/adapters.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import base64
 import xml.etree.ElementTree as ET
+from io import BytesIO
 from pathlib import Path
 
 from mat_vis_client.schema import (
@@ -22,6 +23,15 @@ from mat_vis_client.schema import (
     THREEJS_MAP as _THREEJS_TEX_MAP,
     USD_PREVIEW_MAP as _USD_PREVIEW_TEX_MAP,
 )
+
+# Pillow is a soft dependency — only needed to pack metalness/roughness
+# into a single glTF metallicRoughnessTexture (G=rough, B=metal, R=AO).
+# Install via the optional `[gltf]` extra. Without it, to_gltf() emits a
+# `_note_no_pillow` placeholder so consumers can detect the limitation.
+try:
+    from PIL import Image  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - exercised via monkeypatch
+    Image = None  # type: ignore[assignment]
 
 # Renderer-prop maps come from schema.CHANNELS — do not hand-maintain
 # parallel dicts here. Adding a channel is one edit in schema.py.
@@ -114,17 +124,15 @@ def to_gltf(
 
     Returns:
         Dict conforming to glTF 2.0 material schema. Textures are
-        embedded as base64 data URIs in the 'uri' field. Does NOT
-        pack metalness+roughness into a single texture (that requires
-        image compositing which needs PIL or similar). Instead, scalar
-        factors are used when separate maps are provided.
-
-    Note:
-        Full glTF compliance for metallicRoughnessTexture packing
-        requires image processing (PIL/Pillow). This adapter provides
-        a best-effort output using scalar factors and separate texture
-        references. For production glTF export, consider using a
-        library like pygltflib.
+        embedded as base64 data URIs in the 'uri' field. When both
+        metalness and roughness PNGs are present AND Pillow is
+        installed (via the ``[gltf]`` extra), the two channels are
+        packed into a single ``metallicRoughnessTexture`` per the
+        glTF 2.0 spec (R=AO if available else 255, G=roughness,
+        B=metalness). Without Pillow, a ``_note_no_pillow`` placeholder
+        is emitted instead and the separate textures are dropped from
+        the output (callers can install ``mat-vis-client[gltf]`` to
+        enable packing).
     """
     textures = textures or {}
     pbr: dict = {}
@@ -159,17 +167,60 @@ def to_gltf(
             else:
                 pbr[prop] = _tex_ref(textures[channel])
 
-    # metallicRoughnessTexture: only if BOTH metalness and roughness
-    # textures are available (proper packing needs image processing,
-    # so we note this limitation)
+    # metallicRoughnessTexture: pack metalness + roughness into one
+    # PNG per the glTF 2.0 spec (G=rough, B=metal, R=AO/255). Needs
+    # Pillow — install ``mat-vis-client[gltf]`` to enable.
     if "metalness" in textures and "roughness" in textures:
-        pbr["_note_metallicRoughnessTexture"] = (
-            "Separate metalness and roughness textures provided. "
-            "Pack into a single metallicRoughnessTexture (B=metal, G=rough) "
-            "for full glTF compliance."
-        )
+        if Image is None:
+            pbr["_note_no_pillow"] = (
+                "Pillow is required to pack metallicRoughnessTexture "
+                "(install `mat-vis-client[gltf]`). Separate metalness "
+                "and roughness PNGs were dropped from the output."
+            )
+        else:
+            packed_uri = _pack_metallic_roughness(
+                metalness_png=textures["metalness"],
+                roughness_png=textures["roughness"],
+                ao_png=textures.get("ao"),
+            )
+            pbr["metallicRoughnessTexture"] = {"source": {"uri": packed_uri}}
 
     return material
+
+
+def _pack_metallic_roughness(
+    *,
+    metalness_png: bytes,
+    roughness_png: bytes,
+    ao_png: bytes | None = None,
+) -> str:
+    """Pack metalness/roughness (and optional AO) into a glTF-compliant PNG.
+
+    Per glTF 2.0: R=occlusion, G=roughness, B=metalness. If AO is not
+    provided, R is filled with 255 (opaque white = no occlusion). The
+    metalness image's dimensions are the reference — both roughness and
+    AO are resized to match if they differ. Metalness is the reference
+    because it is the channel most likely to be authored at the
+    material's "true" resolution; roughness is often broadband.
+    """
+    assert Image is not None  # caller checks
+    metal = Image.open(BytesIO(metalness_png)).convert("L")
+    rough = Image.open(BytesIO(roughness_png)).convert("L")
+    if rough.size != metal.size:
+        rough = rough.resize(metal.size)
+
+    if ao_png is not None:
+        ao = Image.open(BytesIO(ao_png)).convert("L")
+        if ao.size != metal.size:
+            ao = ao.resize(metal.size)
+        r_channel = ao
+    else:
+        r_channel = Image.new("L", metal.size, 255)
+
+    packed = Image.merge("RGB", (r_channel, rough, metal))
+    buf = BytesIO()
+    packed.save(buf, format="PNG")
+    return _to_data_uri(buf.getvalue())
 
 
 # ── MaterialX adapter ──────────────────────────────────────────

--- a/clients/python/tests/test_adapters.py
+++ b/clients/python/tests/test_adapters.py
@@ -1,0 +1,111 @@
+"""Tests for mat_vis_client.adapters — focused on glTF packing.
+
+Covers the metallicRoughnessTexture packing path added for #91:
+    - Pack metalness + roughness into G/B channels (R = 255 fallback).
+    - Pack with AO into R channel when present.
+    - Fallback emits ``_note_no_pillow`` when Pillow is unavailable.
+"""
+
+from __future__ import annotations
+
+import base64
+from io import BytesIO
+
+import pytest
+
+from mat_vis_client import adapters
+from mat_vis_client.adapters import to_gltf
+
+PIL = pytest.importorskip("PIL")
+from PIL import Image  # noqa: E402  (after importorskip)
+
+
+def _gray_png(value: int, size: tuple[int, int] = (4, 4)) -> bytes:
+    """Build a uniform-grayscale PNG for use as a synthetic texture."""
+    img = Image.new("L", size, value)
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _decode_data_uri(data_uri: str) -> Image.Image:
+    """Decode a ``data:image/png;base64,...`` URI to a Pillow Image."""
+    assert data_uri.startswith("data:image/png;base64,")
+    payload = data_uri.split(",", 1)[1]
+    return Image.open(BytesIO(base64.b64decode(payload)))
+
+
+class TestMetallicRoughnessPacking:
+    """metalness + roughness must be packed per glTF 2.0 (G=rough, B=metal)."""
+
+    def test_packs_when_both_textures_present(self):
+        metal_png = _gray_png(0x80)
+        rough_png = _gray_png(0xC0)
+
+        result = to_gltf({}, {"metalness": metal_png, "roughness": rough_png})
+
+        pbr = result["pbrMetallicRoughness"]
+        assert "_note_metallicRoughnessTexture" not in pbr
+        assert "_note_no_pillow" not in pbr
+        assert "metallicRoughnessTexture" in pbr
+
+        uri = pbr["metallicRoughnessTexture"]["source"]["uri"]
+        packed = _decode_data_uri(uri)
+
+        assert packed.mode == "RGB"
+        assert packed.size == (4, 4)
+
+        r, g, b = packed.split()
+        # No AO map → R channel is 255 (no occlusion).
+        assert set(r.tobytes()) == {0xFF}
+        # G channel carries roughness.
+        assert set(g.tobytes()) == {0xC0}
+        # B channel carries metalness.
+        assert set(b.tobytes()) == {0x80}
+
+    def test_packs_ao_into_red_channel(self):
+        ao_png = _gray_png(0x40)
+        metal_png = _gray_png(0x80)
+        rough_png = _gray_png(0xC0)
+
+        result = to_gltf(
+            {},
+            {"ao": ao_png, "metalness": metal_png, "roughness": rough_png},
+        )
+
+        pbr = result["pbrMetallicRoughness"]
+        uri = pbr["metallicRoughnessTexture"]["source"]["uri"]
+        packed = _decode_data_uri(uri)
+
+        r, g, b = packed.split()
+        # AO occupies the R channel.
+        assert set(r.tobytes()) == {0x40}
+        assert set(g.tobytes()) == {0xC0}
+        assert set(b.tobytes()) == {0x80}
+
+        # AO is also still emitted as occlusionTexture (top-level material).
+        assert "occlusionTexture" in result
+
+    def test_resizes_roughness_to_metalness_dimensions(self):
+        """Mismatched sizes resolve by resizing to the metalness reference."""
+        metal_png = _gray_png(0x80, size=(4, 4))
+        rough_png = _gray_png(0xC0, size=(8, 8))
+
+        result = to_gltf({}, {"metalness": metal_png, "roughness": rough_png})
+        uri = result["pbrMetallicRoughness"]["metallicRoughnessTexture"]["source"]["uri"]
+        packed = _decode_data_uri(uri)
+        assert packed.size == (4, 4)
+
+    def test_fallback_when_pillow_unavailable(self, monkeypatch):
+        """Without Pillow, emit a ``_note_no_pillow`` marker instead."""
+        monkeypatch.setattr(adapters, "Image", None)
+
+        result = to_gltf(
+            {},
+            {"metalness": _gray_png(0x80), "roughness": _gray_png(0xC0)},
+        )
+
+        pbr = result["pbrMetallicRoughness"]
+        assert "metallicRoughnessTexture" not in pbr
+        assert "_note_no_pillow" in pbr
+        assert "Pillow" in pbr["_note_no_pillow"]

--- a/uv.lock
+++ b/uv.lock
@@ -457,6 +457,10 @@ name = "mat-vis-client"
 version = "0.6.3"
 source = { editable = "clients/python" }
 
+[package.metadata]
+requires-dist = [{ name = "pillow", marker = "extra == 'gltf'", specifier = ">=10.0" }]
+provides-extras = ["gltf"]
+
 [[package]]
 name = "materialx"
 version = "1.39.4"


### PR DESCRIPTION
## Summary

- `mat_vis_client.adapters.to_gltf()` now packs metalness + roughness PNGs into a single glTF-compliant `metallicRoughnessTexture` (R=AO/255, G=roughness, B=metalness) instead of emitting a `_note_metallicRoughnessTexture` placeholder.
- Pillow is a soft dependency exposed via a new `[gltf]` extra (`pip install mat-vis-client[gltf]`); without it the function emits a `_note_no_pillow` marker so callers can detect the limitation. The default zero-dependency posture is preserved.
- Metalness is the dimensional reference; roughness/AO are resized to match if they differ.

## Test plan

- [x] `uv run --extra dev pytest clients/python/tests/test_adapters.py -v` (4 tests, all pass locally)
  - packing emits R=255 when no AO map is provided
  - AO map populates the R channel when present
  - mismatched-size roughness is resized to metalness dimensions
  - missing-Pillow path emits `_note_no_pillow`
- [x] Pre-push hook ran the full client suite (222 passed, 25 skipped) before push.
- [ ] CI checks (Dagger `test-client-python`, lint, etc.) green.

Closes #91.