### PR TITLE
refactor(client): consolidate disjoint test_client.py suites (#274)

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -297,7 +297,15 @@ class MatVisCi:
             Doc("Set MAT_VIS_LIVE_TESTS=1 + MAT_VIS_LIVE_TAG=tag to enable @live tests (#248)"),
         ] = False,
     ) -> str:
-        """Run pytest on the Python reference client against a live release."""
+        """Run pytest on the Python reference client against a live release.
+
+        Test collection is driven by the package's ``testpaths = ["tests"]``
+        config — see ``clients/python/pyproject.toml``. #274 consolidated
+        the previously-disjoint top-level ``test_client.py`` and nested
+        ``tests/test_client.py`` suites under ``tests/``; the explicit
+        filename arg this function used to pass is no longer needed and
+        would have masked the nested suite again if reintroduced.
+        """
         context = src or dag.host().directory(".")
         pip_cache = dag.cache_volume("pip-cache")
         ctr = (
@@ -313,7 +321,7 @@ class MatVisCi:
             ctr = ctr.with_env_variable("MAT_VIS_LIVE_TESTS", "1").with_env_variable(
                 "MAT_VIS_LIVE_TAG", tag
             )
-        return await ctr.with_exec(["pytest", "test_client.py", "-v"]).stdout()
+        return await ctr.with_exec(["pytest", "-v"]).stdout()
 
     @function
     async def test_client_js(

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -40,7 +40,6 @@
   - changed-files:
       - any-glob-to-any-file:
           - tests/**
-          - clients/python/test_client.py
           - clients/**/test_*.mjs
           - clients/**/test_*.py
 

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -47,7 +47,8 @@ jobs:
       - name: Run full pytest suite (skip live network tests)
         env:
           MAT_VIS_SKIP_LIVE_TESTS: "1"
-        run: uv run --no-sync pytest tests/ clients/python/test_client.py
+        # #274 consolidated client tests under ``clients/python/tests/``.
+        run: uv run --no-sync pytest tests/ clients/python/tests/
 
   publish:
     name: Publish mat-vis-client to PyPI

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -34,3 +34,11 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mat_vis_client"]
+
+# Local pytest config so that ``pytest`` from ``clients/python`` picks
+# rootdir here and collects ``tests/`` (rather than walking up and
+# inheriting the project-root ``testpaths`` which points at the
+# top-level ``tests/`` dir). #274 — this matters once the Dagger
+# ``test_client_python`` function dropped its explicit filename arg.
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/clients/python/tests/_live.py
+++ b/clients/python/tests/_live.py
@@ -1,0 +1,39 @@
+"""Shared live-test config for the Python reference client suite.
+
+Hosts the single source of truth for:
+
+* the ``@live`` skip marker (set ``MAT_VIS_LIVE_TESTS=1`` to run);
+* the ``LIVE_TAG`` default (override via ``MAT_VIS_LIVE_TAG``).
+
+Until #274 these lived as duplicates in both ``test_client.py`` files,
+and the nested copy drifted to ``v2026.04.1`` after the v2026.04.2
+bump. Centralising here makes "which tag does this hit" a one-line
+answer. The matching ``live_client`` fixture lives in ``conftest.py``
+so pytest can auto-inject it without an explicit import.
+
+Underscore prefix marks this as internal to the suite; pytest will
+not collect it as a test module.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+# Skip-by-default marker for tests that hit the real HF dataset.
+live = pytest.mark.skipif(
+    os.environ.get("MAT_VIS_LIVE_TESTS") != "1",
+    reason=(
+        "set MAT_VIS_LIVE_TESTS=1 to run live tests against the prod HF dataset. "
+        "Disabled by default until prod is rebaked under the per-file substrate "
+        "(#186 / ADR-0012); the current prod tags are tar-substrate and the "
+        "v0.6 client has dropped tar support."
+    ),
+)
+
+
+# Default release tag for live tests. The top-level test_client.py
+# was the canonical source pre-#274 (the nested copy missed the
+# v2026.04.2 bump). Override at the shell with MAT_VIS_LIVE_TAG.
+LIVE_TAG = os.environ.get("MAT_VIS_LIVE_TAG", "v2026.04.2")

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -1,0 +1,31 @@
+"""Shared pytest fixtures for the Python reference client test suite.
+
+Hosts the ``live_client`` fixture that points a fresh ``MatVisClient``
+at the prod HF revision with a temp cache. The ``@live`` skip marker
+and ``LIVE_TAG`` default are imported from ``tests._live`` (kept in a
+plain module so the symbols can be referenced at class-decorator scope
+without relying on conftest reimport tricks).
+
+Pre-#274 both this dir's ``test_client.py`` and the now-deleted
+top-level copy carried their own ``live_client`` fixtures and
+``LIVE_TAG`` defaults; the nested one had drifted to ``v2026.04.1``
+after the prod bump.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mat_vis_client import MatVisClient
+
+from tests._live import LIVE_TAG
+
+
+@pytest.fixture
+def live_client():
+    """Client pointed at the prod HF revision with a temp cache."""
+    with tempfile.TemporaryDirectory() as tmp:
+        yield MatVisClient(tag=LIVE_TAG, cache_dir=Path(tmp))

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -7,7 +7,6 @@ Live tests hit the real release and are skipped with MAT_VIS_SKIP_LIVE_TESTS=1.
 from __future__ import annotations
 
 import json
-import os
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -731,26 +730,13 @@ class TestDefaultTag:
 
 
 # ── Live tests (network required) ──────────────────────────────
+#
+# The ``live`` marker and ``LIVE_TAG`` constant live in
+# ``tests/_live.py`` so a single override (or env-var bump) propagates
+# to every live module. The ``live_client`` fixture is in
+# ``tests/conftest.py`` and gets auto-injected. See #274.
 
-live = pytest.mark.skipif(
-    os.environ.get("MAT_VIS_LIVE_TESTS") != "1",
-    reason=(
-        "set MAT_VIS_LIVE_TESTS=1 to run live tests against the prod HF dataset. "
-        "Disabled by default until prod is rebaked under the per-file substrate "
-        "(#186 / ADR-0012); current prod tags are tar-substrate and the v0.6 "
-        "client has dropped tar support. See #179."
-    ),
-)
-
-
-LIVE_TAG = os.environ.get("MAT_VIS_LIVE_TAG", "v2026.04.1")
-
-
-@pytest.fixture
-def live_client():
-    """Client pointed at the prod HF revision with a temp cache."""
-    with tempfile.TemporaryDirectory() as tmp:
-        yield MatVisClient(tag=LIVE_TAG, cache_dir=Path(tmp))
+from tests._live import live  # noqa: E402
 
 
 @live

--- a/clients/python/tests/test_client_legacy.py
+++ b/clients/python/tests/test_client_legacy.py
@@ -1,7 +1,22 @@
-"""Tests for the Python reference client and adapters.
+"""Legacy half of the Python reference client suite (#274).
+
+Pre-#274 this lived as ``clients/python/test_client.py`` and was
+collected by an explicit ``pytest test_client.py -v`` arg from the
+Dagger ``test_client_python`` function. Its companion at
+``tests/test_client.py`` was collected by the standard pytest
+``testpaths`` config. The two suites had disjoint coverage and the
+nested ``LIVE_TAG`` had drifted to ``v2026.04.1`` after the prod bump.
+
+#274 consolidated both under ``tests/`` so a single ``pytest`` run
+collects everything and a single ``LIVE_TAG`` (``tests/_live.py``)
+governs the live skip-by-default suite. Class names overlap with
+``test_client.py`` (``TestLiveManifest`` etc.) — they remain distinct
+under pytest because the module path is part of the node ID. No tests
+were renamed during the move.
 
 Unit tests (mocked) run unconditionally.
-Live tests hit the real release and are skipped with MAT_VIS_SKIP_LIVE_TESTS=1.
+Live tests hit the real release and are skipped unless
+``MAT_VIS_LIVE_TESTS=1``.
 """
 
 from __future__ import annotations
@@ -11,13 +26,12 @@ import os
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
-import sys
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent))
-from mat_vis_client import MatVisClient, _in_range  # noqa: E402
-from adapters import (  # noqa: E402
+from mat_vis_client import MatVisClient
+from mat_vis_client.client import _in_range
+from mat_vis_client.adapters import (
     to_threejs,
     to_gltf,
     export_mtlx,
@@ -1314,28 +1328,16 @@ class TestMtlxSource:
 
 
 # ── Live tests (network required) ──────────────────────────────
-
-live = pytest.mark.skipif(
-    os.environ.get("MAT_VIS_LIVE_TESTS") != "1",
-    reason=(
-        "set MAT_VIS_LIVE_TESTS=1 to run live tests against the prod HF dataset. "
-        "Disabled by default until prod is rebaked under the per-file substrate "
-        "(#186 / ADR-0012); the current prod tags are tar-substrate and the "
-        "v0.6 client has dropped tar support."
-    ),
-)
+#
+# The ``live`` marker and ``LIVE_TAG`` constant live in
+# ``tests/_live.py``; the ``live_client`` fixture is in
+# ``tests/conftest.py``. Both modules in this dir share them. See #274.
 
 
-LIVE_TAG = os.environ.get("MAT_VIS_LIVE_TAG", "v2026.04.2")
+from tests._live import LIVE_TAG, live  # noqa: E402
+
 LIVE_SOURCE = "polyhaven"
 LIVE_TIER = "1k"
-
-
-@pytest.fixture
-def live_client():
-    """Client pointed at the scoped-proof HF revision with a temp cache."""
-    with tempfile.TemporaryDirectory() as tmp:
-        yield MatVisClient(tag=LIVE_TAG, cache_dir=Path(tmp))
 
 
 @live


### PR DESCRIPTION
## Summary

- Consolidated the two live, disjoint `test_client.py` files into the standard pytest layout under `clients/python/tests/`. Picked **Option B** (split by origin) because the suites share class names (`TestLiveManifest` etc.) with non-identical bodies — putting them in distinct modules preserves all 163 tests verbatim while pytest node IDs stay unique via module path.
- Hoisted the duplicated `@live` marker, `LIVE_TAG`, and `live_client` fixture into `tests/_live.py` + `tests/conftest.py`. The single `LIVE_TAG = "v2026.04.2"` default fixes the nested copy's drift to the (now-sunset) `v2026.04.1`.
- Dropped the explicit `pytest test_client.py -v` arg from the Dagger `test_client_python` function and added a local `[tool.pytest.ini_options] testpaths = ["tests"]` to `clients/python/pyproject.toml` so rootdir discovery resolves to the client's `tests/` rather than the project-root `tests/`. Also dropped the hardcoded `clients/python/test_client.py` paths from `.github/labeler.yml` and `.github/workflows/pypi.yml`.

## Test plan

- [x] `uv run --extra dev pytest clients/python -v` — 222 passed, 25 skipped (163 are the consolidated client suite: 90 legacy + 73 nested; the 25 skips are `@live` defaults).
- [x] `MAT_VIS_LIVE_TESTS=1 MAT_VIS_LIVE_TAG=v2026.04.2 uv run --extra dev pytest clients/python -v -m '' --tb=short` — 244 passed, 3 skipped (live tests round-trip prod HF in ~22s).
- [x] `grep -rn 'test_client.py' .github .dagger` — no path matches; only the `test_client_python` function name + a docstring history reference + the call site remain.
- [ ] CI client-tests job goes green (the verifier).

Closes #274.