### PR TITLE
bugfix(ci): kitchen-sink OTel-null in workflows (#278)

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -94,12 +94,19 @@ permissions:
   contents: read
   issues: write          # needed by notify-on-failure composite action
 
-# #262: disable Dagger's dagger.cloud OTel export (5xx → SIGPIPE in CI).
-# Replace with self-hosted endpoint once #131 + #176 + the otlp-tailnet
-# composite action are wired in.
+# #262 / #278: disable Dagger's dagger.cloud OTel export at every layer.
+# OTEL_SDK_DISABLED reaches the dagger CLI but the Go engine kept ID-generating
+# (traceparent in error messages) → SIGPIPE on stdout collection. The four
+# extra envs leave the engine no exporter target and no auth. Replace with
+# self-hosted endpoint once #131 + #176 + the otlp-tailnet composite action
+# are wired in.
 env:
   OTEL_SDK_DISABLED: "true"
   DAGGER_NO_NAG: "1"
+  DAGGER_CLOUD_TOKEN: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: ""
+  OTEL_TRACES_EXPORTER: "none"
+  OTEL_METRICS_EXPORTER: "none"
 
 # #235 hotfix: workflow-level budget — serialise *every* dispatch
 # against a given HF repo. Previously this was at workflow level, then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,22 @@ on:  # yamllint disable-line rule:truthy
 # OTLP collector + wires it via .github/actions/otlp-tailnet, fully
 # disable the OTel SDK in CI. DAGGER_NO_NAG silences the cosmetic
 # "Setup tracing at dagger.cloud" line.
+#
+# #278: kitchen-sink null below — OTEL_SDK_DISABLED reaches the dagger CLI
+# but not consistently the Go engine subprocess; the engine kept ID-generating
+# (traceparent injected into error messages) and the resulting pipe could
+# SIGPIPE during stdout collection on completed sibling containers (run
+# 25370432027 reproduced this twice on the same content that PR #277 had
+# passed). The four extra envs (DAGGER_CLOUD_TOKEN, OTEL_EXPORTER_OTLP_ENDPOINT,
+# OTEL_TRACES_EXPORTER, OTEL_METRICS_EXPORTER) leave the engine no exporter
+# target and no auth even if SDK_DISABLED is ignored.
 env:
   OTEL_SDK_DISABLED: "true"
   DAGGER_NO_NAG: "1"
+  DAGGER_CLOUD_TOKEN: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: ""
+  OTEL_TRACES_EXPORTER: "none"
+  OTEL_METRICS_EXPORTER: "none"
 
 jobs:
   ci:

--- a/.github/workflows/derive.yml
+++ b/.github/workflows/derive.yml
@@ -108,12 +108,19 @@ permissions:
   contents: read
   issues: write          # needed by notify-on-failure composite action
 
-# #262: disable Dagger's dagger.cloud OTel export (5xx → SIGPIPE in CI).
-# Replace with self-hosted endpoint once #131 + #176 + the otlp-tailnet
-# composite action are wired in.
+# #262 / #278: disable Dagger's dagger.cloud OTel export at every layer.
+# OTEL_SDK_DISABLED reaches the dagger CLI but the Go engine kept ID-generating
+# (traceparent in error messages) → SIGPIPE on stdout collection. The four
+# extra envs leave the engine no exporter target and no auth. Replace with
+# self-hosted endpoint once #131 + #176 + the otlp-tailnet composite action
+# are wired in.
 env:
   OTEL_SDK_DISABLED: "true"
   DAGGER_NO_NAG: "1"
+  DAGGER_CLOUD_TOKEN: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: ""
+  OTEL_TRACES_EXPORTER: "none"
+  OTEL_METRICS_EXPORTER: "none"
 
 # #235 hotfix: workflow-level budget — see the matching block in
 # bake.yml. Job-level concurrency in #233 conflicted with matrix

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,12 +27,19 @@ permissions:
   contents: read
   issues: write          # needed by notify-on-failure composite action
 
-# #262: disable Dagger's dagger.cloud OTel export (5xx → SIGPIPE in CI).
-# Replace with self-hosted endpoint once #131 + #176 + the otlp-tailnet
-# composite action are wired in.
+# #262 / #278: disable Dagger's dagger.cloud OTel export at every layer.
+# OTEL_SDK_DISABLED reaches the dagger CLI but the Go engine kept ID-generating
+# (traceparent in error messages) → SIGPIPE on stdout collection. The four
+# extra envs leave the engine no exporter target and no auth. Replace with
+# self-hosted endpoint once #131 + #176 + the otlp-tailnet composite action
+# are wired in.
 env:
   OTEL_SDK_DISABLED: "true"
   DAGGER_NO_NAG: "1"
+  DAGGER_CLOUD_TOKEN: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: ""
+  OTEL_TRACES_EXPORTER: "none"
+  OTEL_METRICS_EXPORTER: "none"
 
 jobs:
   e2e:


### PR DESCRIPTION
## Summary
- Adds four envs to the workflow-level \`env:\` block in \`ci.yml\`, \`bake.yml\`, \`derive.yml\`, \`e2e.yml\` to force the Dagger Go engine into anonymous + no-exporter mode at every layer:
  - \`DAGGER_CLOUD_TOKEN: \"\"\`
  - \`OTEL_EXPORTER_OTLP_ENDPOINT: \"\"\`
  - \`OTEL_TRACES_EXPORTER: \"none\"\`
  - \`OTEL_METRICS_EXPORTER: \"none\"\`
- Closes #278. Mirrors the fallback plan in #262 with explicit exporter-name overrides (per OTel spec; respected by Go OTel SDKs that ignore \`OTEL_SDK_DISABLED\`).

## Why this is needed
- #268/#269 disabled OTel at workflow-env and Python-module layers; the Go engine kept generating trace IDs regardless (\`traceparent:a71ea5d9...\` in error messages). Stdout collection on completed sibling containers SIGPIPE'd as a result.
- Reproduced twice on dev push run [25370432027](https://github.com/MorePET/mat-vis/actions/runs/25370432027) (post-#277 commit 6e5d6756) — same content that PR #277's own CI [25370347699](https://github.com/MorePET/mat-vis/actions/runs/25370347699) passed cleanly. PR-event vs. push-event opposite outcomes on identical content is the smoking gun.

## Test plan
- [ ] CI on this PR passes (sanity check the new envs don't break the Dagger CLI itself)
- [ ] Post-merge dev push CI goes green on Client tests
- [ ] Three consecutive dev pushes land clean (no SIGPIPE recurrence)

Fixes #278.