### PR TITLE
bugfix(client): build123d#1270 follow-up hotfix bundle

### DIFF
--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -26,6 +26,7 @@ Usage as CLI:
 
 from __future__ import annotations
 
+import difflib
 import json
 import logging
 import os
@@ -168,14 +169,33 @@ class UnknownMaterialError(MaterialNotFoundError):
 class MaterialNotStagedError(MatVisError):
     """Material is in the index but the release asset isn't baked yet."""
 
-    def __init__(self, source: str, material_id: str, tier: str) -> None:
+    def __init__(
+        self,
+        source: str,
+        material_id: str,
+        tier: str,
+        *,
+        original_name: str | None = None,
+    ) -> None:
         self.source = source
         self.material_id = material_id
         self.tier = tier
-        super().__init__(
-            f"material {material_id!r} exists in {source!r} index "
-            f"but is not staged for tier {tier!r}. Needs a re-bake."
-        )
+        # ``original_name`` carries what the caller typed *before* name→id
+        # resolution (#280). When present and different from material_id
+        # we surface both so batch logs name which item broke.
+        self.original_name = original_name
+        if original_name is not None and original_name != material_id:
+            msg = (
+                f"material {original_name!r} (resolved id {material_id!r}) "
+                f"exists in {source!r} index but is not staged for "
+                f"tier {tier!r}. Needs a re-bake."
+            )
+        else:
+            msg = (
+                f"material {material_id!r} exists in {source!r} index "
+                f"but is not staged for tier {tier!r}. Needs a re-bake."
+            )
+        super().__init__(msg)
 
 
 class AmbiguousMaterialError(MatVisError):
@@ -979,12 +999,21 @@ class MatVisClient:
         norm_query = self._normalize_name(material_id)
         by_id: dict | None = None
         by_name: list[dict] = []
+
+        # Per-entry display name. v3 entries carry it under the
+        # ``mat_vis`` envelope; ambientcg/polyhaven flat-v2 entries
+        # carry it at the top level (#284). Fall back to the canonical
+        # id so the name-list never holds an empty string.
+        def _display_name(entry: dict) -> str:
+            envelope = entry.get("mat_vis") or {}
+            return envelope.get("name") or entry.get("name") or entry.get("id", "")
+
         for entry in idx:
             if not isinstance(entry, dict):
                 continue
             if entry.get("id") == material_id:
                 by_id = entry
-            entry_name = (entry.get("mat_vis") or {}).get("name") or ""
+            entry_name = _display_name(entry)
             if entry_name and self._normalize_name(entry_name) == norm_query:
                 by_name.append(entry)
 
@@ -994,27 +1023,53 @@ class MatVisClient:
         if by_id is not None:
             if _is_staged(by_id):
                 return material_id
+            # Direct-UUID path: original_name stays None so the legacy
+            # single-id message is preserved (#280).
             raise MaterialNotStagedError(source=source, material_id=material_id, tier=tier)
 
         if len(by_name) > 1:
+            # #286: surface human names (or fall back to id) so the
+            # disambiguation list is actually useful when names exist.
             raise AmbiguousMaterialError(
                 source=source,
                 name=material_id,
-                candidates=[e.get("id", "") for e in by_name if e.get("id")],
+                candidates=[_display_name(e) for e in by_name if e.get("id")],
             )
 
         if len(by_name) == 1:
             resolved = by_name[0].get("id", "")
             if _is_staged(by_name[0]):
                 return resolved
-            raise MaterialNotStagedError(source=source, material_id=resolved, tier=tier)
+            # #280: the user passed a name; carry it through so the
+            # error message names *which* material in their batch broke.
+            raise MaterialNotStagedError(
+                source=source,
+                material_id=resolved,
+                tier=tier,
+                original_name=material_id,
+            )
 
-        staged_ids = sorted(
-            e["id"] for e in idx if isinstance(e, dict) and _is_staged(e) and e.get("id")
+        # Build the "available materials at this tier" hint from the
+        # catalog. #286: prefer human names over UUIDs and surface
+        # close-matches before the full list.
+        staged_names = sorted(
+            _display_name(e) for e in idx if isinstance(e, dict) and _is_staged(e) and e.get("id")
         )
+        close = difflib.get_close_matches(material_id, staged_names, n=5, cutoff=0.6)
+        max_full = 50
+        if len(staged_names) > max_full:
+            shown = staged_names[:max_full]
+            shown.append(f"(... {len(staged_names) - max_full} more)")
+            available = shown
+        else:
+            available = staged_names
+        if close:
+            ordered = list(close) + [a for a in available if a not in close]
+        else:
+            ordered = available
         raise UnknownMaterialError(
             key=material_id,
-            available=staged_ids,
+            available=ordered,
             context=f"{source}/{tier}",
         )
 
@@ -1235,6 +1290,17 @@ class MatVisClient:
                 return cache_path.read_bytes()
 
         self._assert_tier_complete(source, tier)
+
+        # #287: emit one progress notice per real network fetch. Cache
+        # hits (returned above) stay silent. Library users wire their
+        # own progress UIs onto this logger.
+        log.info(
+            "Downloading %s/%s/%s @ %s ...",
+            source,
+            resolved,
+            channel,
+            tier,
+        )
 
         last_exc: Exception | None = None
         for ext in ("png", "ktx2"):
@@ -1668,14 +1734,44 @@ class VisAsset:
 
     @property
     def textures(self) -> dict[str, bytes]:
-        """Lazy channel -> PNG bytes mapping (cached after first access)."""
+        """Lazy channel -> PNG bytes mapping (cached after first access).
+
+        Scalar-only sources (``available_tiers=[]``, e.g.
+        ``physicallybased``) short-circuit to ``{}`` so ``to_threejs`` /
+        ``to_gltf`` produce a valid scalars-only material instead of
+        raising :class:`MaterialNotStagedError` from the texture-fetch
+        path (mat-vis#288).
+        """
         if self._textures_cache is None:
-            object.__setattr__(
-                self,
-                "_textures_cache",
-                self._client.fetch_all_textures(self._source, self._material_id, self._tier),
-            )
+            if self._is_scalar_only_entry():
+                fetched: dict[str, bytes] = {}
+            else:
+                fetched = self._client.fetch_all_textures(
+                    self._source, self._material_id, self._tier
+                )
+            object.__setattr__(self, "_textures_cache", fetched)
         return self._textures_cache
+
+    def _is_scalar_only_entry(self) -> bool:
+        """True if this asset's index entry advertises no staged tiers."""
+        try:
+            entries = self._client.index(self._source)
+        except Exception:
+            return False
+        if not isinstance(entries, list):
+            return False
+        norm = self._client._normalize_name(self._material_id)
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            if (
+                entry.get("id") == self._material_id
+                or self._client._normalize_name((entry.get("mat_vis") or {}).get("name") or "")
+                == norm
+            ):
+                tiers = entry.get("available_tiers")
+                return not tiers
+        return False
 
     def to_threejs(self) -> dict:
         """Return a Three.js ``MeshPhysicalMaterial`` parameter dict."""

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -26,6 +26,7 @@ Usage as CLI:
 
 from __future__ import annotations
 
+import difflib
 import json
 import logging
 import os
@@ -193,14 +194,35 @@ class MaterialNotStagedError(MatVisError):
     than treating this as a lookup failure.
     """
 
-    def __init__(self, source: str, material_id: str, tier: str) -> None:
+    def __init__(
+        self,
+        source: str,
+        material_id: str,
+        tier: str,
+        *,
+        original_name: str | None = None,
+    ) -> None:
         self.source = source
         self.material_id = material_id
         self.tier = tier
-        super().__init__(
-            f"material {material_id!r} exists in {source!r} index "
-            f"but is not staged for tier {tier!r}. Needs a re-bake."
-        )
+        # ``original_name`` is what the caller typed *before* name→id
+        # resolution (#280). When the user passed a UUID directly we
+        # leave this ``None`` and emit the legacy single-id message;
+        # when they passed a human name we surface both so a batch log
+        # tells you *which* item in the run broke without grepping.
+        self.original_name = original_name
+        if original_name is not None and original_name != material_id:
+            msg = (
+                f"material {original_name!r} (resolved id {material_id!r}) "
+                f"exists in {source!r} index but is not staged for "
+                f"tier {tier!r}. Needs a re-bake."
+            )
+        else:
+            msg = (
+                f"material {material_id!r} exists in {source!r} index "
+                f"but is not staged for tier {tier!r}. Needs a re-bake."
+            )
+        super().__init__(msg)
 
 
 class AmbiguousMaterialError(MatVisError):
@@ -1221,12 +1243,21 @@ class MatVisClient:
         norm_query = self._normalize_name(material_id)
         by_id: dict | None = None
         by_name: list[dict] = []
+
+        # Per-entry display name. v3 entries carry it under the
+        # ``mat_vis`` envelope; ambientcg/polyhaven flat-v2 entries
+        # carry it at the top level (#284). Fall back to the canonical
+        # id so the name-list never holds an empty string.
+        def _display_name(entry: dict) -> str:
+            envelope = entry.get("mat_vis") or {}
+            return envelope.get("name") or entry.get("name") or entry.get("id", "")
+
         for entry in idx:
             if not isinstance(entry, dict):
                 continue
             if entry.get("id") == material_id:
                 by_id = entry
-            entry_name = (entry.get("mat_vis") or {}).get("name") or ""
+            entry_name = _display_name(entry)
             if entry_name and self._normalize_name(entry_name) == norm_query:
                 by_name.append(entry)
 
@@ -1236,28 +1267,56 @@ class MatVisClient:
         if by_id is not None:
             if _is_staged(by_id):
                 return material_id
+            # Direct-UUID path: original_name stays None so the legacy
+            # single-id message is preserved (#280).
             raise MaterialNotStagedError(source=source, material_id=material_id, tier=tier)
 
         if len(by_name) > 1:
+            # #286: surface human names (or fall back to id) so the
+            # disambiguation list is actually useful when names exist.
             raise AmbiguousMaterialError(
                 source=source,
                 name=material_id,
-                candidates=[e.get("id", "") for e in by_name if e.get("id")],
+                candidates=[_display_name(e) for e in by_name if e.get("id")],
             )
 
         if len(by_name) == 1:
             resolved = by_name[0].get("id", "")
             if _is_staged(by_name[0]):
                 return resolved
-            raise MaterialNotStagedError(source=source, material_id=resolved, tier=tier)
+            # #280: the user passed a name; carry it through so the
+            # error message names *which* material in their batch broke.
+            raise MaterialNotStagedError(
+                source=source,
+                material_id=resolved,
+                tier=tier,
+                original_name=material_id,
+            )
 
-        # Build the "available materials at this tier" hint from the catalog.
-        staged_ids = sorted(
-            e["id"] for e in idx if isinstance(e, dict) and _is_staged(e) and e.get("id")
+        # Build the "available materials at this tier" hint from the
+        # catalog. #286: prefer human names over UUIDs and surface
+        # close-matches before the full list.
+        staged_names = sorted(
+            _display_name(e) for e in idx if isinstance(e, dict) and _is_staged(e) and e.get("id")
         )
+        close = difflib.get_close_matches(material_id, staged_names, n=5, cutoff=0.6)
+        # Cap the full-list to keep messages readable on big catalogs.
+        max_full = 50
+        if len(staged_names) > max_full:
+            shown = staged_names[:max_full]
+            shown.append(f"(... {len(staged_names) - max_full} more)")
+            available = shown
+        else:
+            available = staged_names
+        # Prepend close-matches when we have any: callers see the
+        # likely-typo first, before scrolling the full list.
+        if close:
+            ordered = list(close) + [a for a in available if a not in close]
+        else:
+            ordered = available
         raise UnknownMaterialError(
             key=material_id,
-            available=staged_ids,
+            available=ordered,
             context=f"{source}/{tier}",
         )
 
@@ -1533,6 +1592,17 @@ class MatVisClient:
         # ktx2 tier shape. If BOTH 404, surface the original error
         # type — callers (and tests) expect HTTPFetchError, not a
         # generic MatVisError, so the network-failure contract is stable.
+        # Emit one progress notice per real network fetch (#287). Cache
+        # hits returned above stay silent. Library users (build123d,
+        # Jupyter) wire this to their own UI; logger is silent by default.
+        log.info(
+            "Downloading %s/%s/%s @ %s ...",
+            source,
+            resolved,
+            channel,
+            tier,
+        )
+
         last_exc: Exception | None = None
         for ext in ("png", "ktx2"):
             url = self._per_file_url(source, tier, resolved, channel, ext)
@@ -1979,15 +2049,54 @@ class VisAsset:
     def textures(self) -> dict[str, bytes]:
         """Lazy channel -> PNG bytes mapping (cached after first access).
 
-        Calls :meth:`MatVisClient.fetch_all_textures` exactly once per instance.
+        Calls :meth:`MatVisClient.fetch_all_textures` exactly once per
+        instance — except for scalar-only sources (e.g. ``physicallybased``,
+        whose v3 index entries advertise ``available_tiers=[]``). For those
+        we short-circuit to ``{}`` so that ``to_threejs`` / ``to_gltf``
+        produce a valid scalars-only material instead of raising
+        :class:`MaterialNotStagedError` from the texture-fetch path
+        (mat-vis#288). Texture-bearing sources still go through
+        :meth:`_resolve_material_id` and raise on misuse.
         """
         if self._textures_cache is None:
-            object.__setattr__(
-                self,
-                "_textures_cache",
-                self._client.fetch_all_textures(self._source, self._material_id, self._tier),
-            )
+            if self._is_scalar_only_entry():
+                fetched: dict[str, bytes] = {}
+            else:
+                fetched = self._client.fetch_all_textures(
+                    self._source, self._material_id, self._tier
+                )
+            object.__setattr__(self, "_textures_cache", fetched)
         return self._textures_cache
+
+    def _is_scalar_only_entry(self) -> bool:
+        """True if this asset's index entry advertises no staged tiers.
+
+        Scalar-only sources (currently just ``physicallybased``, but the
+        check is shape-driven so future scalar-only sources will work)
+        publish ``available_tiers=[]`` for every entry — there are no
+        textures to fetch. Best-effort: a missing index or lookup error
+        falls back to ``False``, preserving the existing (loud) error
+        path through :meth:`fetch_all_textures`.
+        """
+        try:
+            entries = self._client.index(self._source)
+        except Exception:
+            return False
+        if not isinstance(entries, list):
+            return False
+        norm = self._client._normalize_name(self._material_id)
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            if (
+                entry.get("id") == self._material_id
+                or self._client._normalize_name((entry.get("mat_vis") or {}).get("name") or "")
+                == norm
+            ):
+                tiers = entry.get("available_tiers")
+                # Explicitly empty list (or missing) → scalar-only entry.
+                return not tiers
+        return False
 
     def to_threejs(self) -> dict:
         """Return a Three.js ``MeshPhysicalMaterial`` parameter dict.

--- a/clients/python/tests/test_asset.py
+++ b/clients/python/tests/test_asset.py
@@ -210,3 +210,81 @@ def test_visasset_importable_from_package_root():
     from mat_vis_client import VisAsset as Imported
 
     assert Imported is VisAsset
+
+
+# ── Scalar-only sources short-circuit texture fetch (mat-vis#288) ──
+
+
+def _scalar_only_index_entry(material_id: str) -> dict:
+    """Build a scalar-only v3 index entry (available_tiers=[]) like physicallybased."""
+    return {
+        "id": material_id,
+        "source": "physicallybased",
+        "mat_vis": {
+            "name": material_id,
+            "category": "metal",
+            "pbr": {
+                "color_rgb": [0.91, 0.92, 0.92],
+                "roughness": 0.5,
+                "metalness": 1.0,
+                "ior": 1.39,
+            },
+        },
+        "available_tiers": [],
+        "maps": [],
+    }
+
+
+def test_textures_returns_empty_for_scalar_only_source():
+    """VisAsset.textures must short-circuit when the index entry has
+    no staged tiers (scalar-only source like physicallybased), instead
+    of calling fetch_all_textures (which raises MaterialNotStagedError)."""
+    c = MatVisClient()
+    a = VisAsset(c, "physicallybased", "Aluminum", "1k")
+    entries = [_scalar_only_index_entry("Aluminum")]
+    with (
+        patch.object(c, "index", return_value=entries),
+        patch.object(c, "fetch_all_textures") as fetch_mock,
+    ):
+        assert a.textures == {}
+    fetch_mock.assert_not_called()
+
+
+def test_to_threejs_scalar_only_source_returns_scalars_no_textures():
+    """Repro for mat-vis#288: physicallybased + to_threejs should return
+    scalars-only output, not raise MaterialNotStagedError."""
+    c = MatVisClient()
+    a = VisAsset(c, "physicallybased", "Aluminum", "1k")
+    entries = [_scalar_only_index_entry("Aluminum")]
+    with patch.object(c, "index", return_value=entries):
+        result = a.to_threejs()
+    # Scalars come through.
+    assert result["type"] == "MeshPhysicalMaterial"
+    assert result.get("metalness") == 1.0
+    assert result.get("roughness") == 0.5
+    assert result.get("ior") == 1.39
+    assert "color" in result
+    # No texture maps were fetched.
+    for k in ("map", "normalMap", "roughnessMap", "metalnessMap", "aoMap"):
+        assert k not in result
+
+
+def test_textures_still_fetched_for_staged_source():
+    """Regression: textured sources (e.g. gpuopen Chrome staged for 1k)
+    must still route through fetch_all_textures normally."""
+    c = MatVisClient()
+    a = VisAsset(c, "gpuopen", "Chrome", "1k")
+    staged_entry = {
+        "id": "Chrome",
+        "source": "gpuopen",
+        "mat_vis": {"name": "Chrome", "pbr": {}},
+        "available_tiers": ["1k"],
+        "maps": ["color", "normal"],
+    }
+    expected = {"color": b"PNG-color", "normal": b"PNG-normal"}
+    with (
+        patch.object(c, "index", return_value=[staged_entry]),
+        patch.object(c, "fetch_all_textures", return_value=expected) as fetch_mock,
+    ):
+        assert a.textures == expected
+    fetch_mock.assert_called_once_with("gpuopen", "Chrome", "1k")

--- a/clients/python/tests/test_client_legacy.py
+++ b/clients/python/tests/test_client_legacy.py
@@ -791,8 +791,10 @@ class TestFriendlyNotFoundErrors:
         msg = str(exc.value)
         assert "material 'DOES_NOT_EXIST' not found" in msg
         assert "ambientcg/1k" in msg
-        assert "Rock064" in msg
-        assert "Metal032" in msg
+        # #286: available list now shows human names (with id fallback)
+        # — these v3 entries carry display names so we get those.
+        assert "Rough Granite" in msg
+        assert "Brushed Steel" in msg
 
     @patch("mat_vis_client.client._get_json", return_value=MOCK_INDEX_AMBIENTCG)
     @patch("mat_vis_client.client._get", side_effect=_mock_get)

--- a/clients/python/tests/test_download_progress.py
+++ b/clients/python/tests/test_download_progress.py
@@ -1,0 +1,109 @@
+"""Download-progress logging on cache miss (#287).
+
+bernhard-42 reports that ``show()`` over several uncached materials
+pauses for many seconds with no feedback (each baked-material fetch
+~0.8-1s). Library users (build123d, Jupyter, etc.) need a hook to know
+the client is actually doing work, not hung.
+
+Contract: ``fetch_texture`` emits ``log.info("Downloading ...")`` at the
+network boundary — once per real GET — and stays silent on cache hits.
+No tqdm dependency; pure stdlib logging so consumers wire up their own
+handlers / progress UIs.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mat_vis_client import MatVisClient
+
+
+MOCK_MANIFEST = {
+    "schema_version": 3,
+    "release_tag": "v2026.04.0",
+    "sources": {
+        "ambientcg": {
+            "catalog": "ambientcg.json",
+            "tiers": {"1k": {"complete": True}},
+        },
+    },
+}
+
+MOCK_INDEX = [
+    {
+        "id": "Rock064",
+        "source": "ambientcg",
+        "mat_vis": {"name": "Rock064", "category": "stone"},
+        "available_tiers": ["1k"],
+        "maps": ["color"],
+    }
+]
+
+TINY_PNG = b"\x89PNG\r\n\x1a\n" + b"data" + b"\xaeB`\x82"
+
+
+@pytest.fixture
+def tmp_cache():
+    tmp = Path(tempfile.mkdtemp(prefix="mat-vis-test-progress-"))
+    yield tmp
+    import shutil
+
+    shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _prime(client: MatVisClient) -> None:
+    client._manifest = MOCK_MANIFEST
+    client._indexes = {"ambientcg": MOCK_INDEX}
+    client._tier_complete[("ambientcg", "1k")] = True
+
+
+def test_fetch_texture_logs_download_on_cache_miss(tmp_cache, caplog):
+    """A network fetch must emit log.info('Downloading ...') with material id."""
+    c = MatVisClient(cache_dir=tmp_cache, tag="v2026.04.0")
+    _prime(c)
+
+    def fake_get(url, headers=None, return_final_url=False):
+        return (TINY_PNG, url) if return_final_url else TINY_PNG
+
+    with caplog.at_level(logging.INFO, logger="mat-vis-client"):
+        with patch("mat_vis_client.client._get", side_effect=fake_get):
+            c.fetch_texture("ambientcg", "Rock064", "color", tier="1k")
+
+    download_msgs = [r.getMessage() for r in caplog.records if "Downloading" in r.getMessage()]
+    assert download_msgs, (
+        f"expected a 'Downloading ...' info log on cache miss, "
+        f"got records: {[r.getMessage() for r in caplog.records]}"
+    )
+    msg = download_msgs[0]
+    assert "Rock064" in msg, f"download log must include material id, got: {msg!r}"
+    assert "color" in msg, f"download log must include channel, got: {msg!r}"
+    assert "1k" in msg, f"download log must include tier, got: {msg!r}"
+
+
+def test_fetch_texture_silent_on_cache_hit(tmp_cache, caplog):
+    """A cache hit must NOT emit a 'Downloading ...' log."""
+    c = MatVisClient(cache_dir=tmp_cache, tag="v2026.04.0")
+    _prime(c)
+
+    # Pre-seed cache so fetch_texture short-circuits before _get.
+    cache_path = c._cache_scope / "ambientcg" / "1k" / "Rock064" / "color.png"
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_bytes(TINY_PNG)
+
+    with caplog.at_level(logging.INFO, logger="mat-vis-client"):
+        # _get must never be called on a cache hit; if the implementation
+        # regresses and hits the network, the patch makes it loud.
+        with patch(
+            "mat_vis_client.client._get",
+            side_effect=AssertionError("cache hit must not touch network"),
+        ):
+            data = c.fetch_texture("ambientcg", "Rock064", "color", tier="1k")
+
+    assert data == TINY_PNG
+    download_msgs = [r.getMessage() for r in caplog.records if "Downloading" in r.getMessage()]
+    assert not download_msgs, f"cache hit must be silent, got 'Downloading' logs: {download_msgs}"

--- a/clients/python/tests/test_errors.py
+++ b/clients/python/tests/test_errors.py
@@ -291,8 +291,10 @@ def test_ambiguous_material_error_lists_candidates():
     with pytest.raises(AmbiguousMaterialError) as exc:
         client.fetch_all_textures("gpuopen", "Brick Wall", tier="1k")
     assert exc.value.source == "gpuopen"
-    assert sorted(exc.value.candidates) == ["uuid-a", "uuid-b"]
-    assert "uuid-a" in str(exc.value) and "uuid-b" in str(exc.value)
+    # #286: candidates list is now human names (with id fallback) — UUIDs
+    # were unhelpful when each entry had a perfectly good display name.
+    assert sorted(exc.value.candidates) == ["Brick Wall", "brick wall"]
+    assert "Brick Wall" in str(exc.value) and "brick wall" in str(exc.value)
 
 
 # ── fetch_texture surfaces typed errors ────────────────────────
@@ -347,3 +349,177 @@ def test_fetch_texture_404_raises_material_not_found_or_http_fetch_error():
         assert not isinstance(exc.value, urllib.error.HTTPError)
         # But HTTPFetchError carries the code
         assert exc.value.code == 404
+
+
+# ── Hotfix #280: MaterialNotStagedError keeps user-given name ──
+
+
+def test_material_not_staged_error_preserves_user_given_name():
+    """When the user passes a human name (not the UUID) and the resolved
+    entry exists but is unstaged, the raised error should preserve the
+    original name they typed — losing it makes batch debugging painful
+    (#280).
+    """
+    from mat_vis_client import MaterialNotStagedError
+
+    client = _client_with_index(
+        rowmap_materials={},  # nothing baked → unstaged
+        index_entries=[
+            {"id": "34f2c1f9-aaaa-bbbb-cccc-deadbeefcafe", "mat_vis": {"name": "Chrome"}},
+        ],
+    )
+    with pytest.raises(MaterialNotStagedError) as exc:
+        client.fetch_all_textures("gpuopen", "Chrome", tier="1k")
+    # Resolved id is still the canonical attribute (existing API).
+    assert exc.value.material_id == "34f2c1f9-aaaa-bbbb-cccc-deadbeefcafe"
+    # New: original_name field carries the user's input.
+    assert exc.value.original_name == "Chrome"
+    # And the error string mentions both — so a batch log shows which
+    # human-named material in the run hit this.
+    msg = str(exc.value)
+    assert "Chrome" in msg
+    assert "34f2c1f9-aaaa-bbbb-cccc-deadbeefcafe" in msg
+
+
+def test_material_not_staged_error_direct_uuid_unchanged():
+    """When the user passes the UUID directly, original_name is None and
+    the message is the legacy single-id form (back-compat)."""
+    from mat_vis_client import MaterialNotStagedError
+
+    client = _client_with_index(
+        rowmap_materials={},
+        index_entries=[{"id": "25b88a68", "name": "Aluminum"}],
+    )
+    with pytest.raises(MaterialNotStagedError) as exc:
+        client.fetch_all_textures("gpuopen", "25b88a68", tier="1k")
+    assert exc.value.material_id == "25b88a68"
+    assert exc.value.original_name is None
+    msg = str(exc.value)
+    # Legacy phrasing: no "(resolved id ...)" parenthetical.
+    assert "resolved id" not in msg
+
+
+# ── Hotfix #284: ambientCG/polyhaven flat-v2 name addressability ──
+
+
+def test_resolve_name_falls_back_to_top_level_name_field():
+    """ambientcg/polyhaven catalogs use a flat v2 schema with top-level
+    ``name`` (no ``mat_vis`` envelope). Name lookup must hit those too
+    (#284).
+    """
+    from unittest.mock import patch
+
+    client = _client_with_index(
+        rowmap_materials={"Bricks104": {"color": {"offset": 0, "length": 10}}},
+        # NB: no mat_vis envelope; flat top-level name field.
+        index_entries=[{"id": "Bricks104", "name": "Bricks 104"}],
+    )
+    with patch.object(client, "fetch_texture", return_value=b"\x89PNG") as ft:
+        out = client.fetch_all_textures("gpuopen", "Bricks 104", tier="1k")
+    assert out == {"color": b"\x89PNG"}
+    ft.assert_called_once_with("gpuopen", "Bricks104", "color", "1k")
+
+
+def test_resolve_name_prefers_mat_vis_name_over_top_level():
+    """When both ``mat_vis.name`` and top-level ``name`` are present, the
+    canonical envelope wins (v3 entries shouldn't regress)."""
+    from unittest.mock import patch
+
+    client = _client_with_index(
+        rowmap_materials={"abc": {"color": {"offset": 0, "length": 10}}},
+        index_entries=[
+            {
+                "id": "abc",
+                "name": "Top Level",
+                "mat_vis": {"name": "Envelope Name"},
+            }
+        ],
+    )
+    with patch.object(client, "fetch_texture", return_value=b""):
+        # Envelope name resolves
+        client.fetch_all_textures("gpuopen", "Envelope Name", tier="1k")
+
+
+# ── Hotfix #286: error lists show names + close-matches, not UUIDs ──
+
+
+def test_unknown_material_error_lists_names_not_uuids_with_close_matches():
+    """When the user typos a name (the bernhard repro: ``"TH Large Red
+    Bricks"`` missing the colon), the surfaced ``available`` list and
+    the rendered message should contain human names — and prioritize
+    a close-match suggestion (#286).
+    """
+    import re
+    from mat_vis_client import UnknownMaterialError
+
+    client = _client_with_index(
+        rowmap_materials={
+            "uuid-aa-aaaaaaaa-aaaa-aaaaaaaaaaaa": {"color": {"offset": 0, "length": 10}},
+            "uuid-bb-bbbbbbbb-bbbb-bbbbbbbbbbbb": {"color": {"offset": 0, "length": 10}},
+            "uuid-cc-cccccccc-cccc-cccccccccccc": {"color": {"offset": 0, "length": 10}},
+        },
+        index_entries=[
+            {
+                "id": "uuid-aa-aaaaaaaa-aaaa-aaaaaaaaaaaa",
+                "mat_vis": {"name": "TH: Large Red Bricks"},
+            },
+            {
+                "id": "uuid-bb-bbbbbbbb-bbbb-bbbbbbbbbbbb",
+                "mat_vis": {"name": "TH: Small Red Bricks"},
+            },
+            {"id": "uuid-cc-cccccccc-cccc-cccccccccccc", "mat_vis": {"name": "Concrete Slab"}},
+        ],
+    )
+    with pytest.raises(UnknownMaterialError) as exc:
+        client.fetch_all_textures("gpuopen", "TH Large Red Bricks", tier="1k")
+
+    msg = str(exc.value)
+    # Close match should appear in message (and ideally before any
+    # full-list dump).
+    assert "TH: Large Red Bricks" in msg
+    # No raw UUID-looking strings should be in the message.
+    assert not re.search(r"uuid-[a-f0-9-]{8,}", msg)
+    # Available list should also be names, not UUIDs.
+    assert "TH: Large Red Bricks" in exc.value.available
+    assert all(not a.startswith("uuid-") for a in exc.value.available)
+
+
+def test_unknown_material_error_caps_full_list_when_huge():
+    """A 200-entry catalog should not vomit all 200 names into the
+    message — cap it (#286)."""
+    from mat_vis_client import UnknownMaterialError
+
+    rowmap = {f"uuid-{i:03d}": {"color": {"offset": 0, "length": 10}} for i in range(200)}
+    entries = [
+        {"id": f"uuid-{i:03d}", "mat_vis": {"name": f"NameThing{i:03d}"}} for i in range(200)
+    ]
+    client = _client_with_index(rowmap_materials=rowmap, index_entries=entries)
+    with pytest.raises(UnknownMaterialError) as exc:
+        client.fetch_all_textures("gpuopen", "totally-unknown-key-xyz", tier="1k")
+    msg = str(exc.value)
+    # Sentinel that we truncated (allow either format).
+    assert "more)" in msg or "..." in msg
+    # And the full message shouldn't contain *every* name.
+    assert msg.count("NameThing") < 200
+
+
+def test_ambiguous_material_error_lists_names():
+    """Ambiguous-name candidates should be listed by human name when
+    available, not raw ids (#286)."""
+    from mat_vis_client import AmbiguousMaterialError
+
+    client = _client_with_index(
+        rowmap_materials={
+            "uuid-x": {"color": {"offset": 0, "length": 10}},
+            "uuid-y": {"color": {"offset": 0, "length": 10}},
+        },
+        index_entries=[
+            # Two distinct flat-v2 entries that normalize to the same name.
+            {"id": "uuid-x", "name": "Brick Wall"},
+            {"id": "uuid-y", "name": "brick wall"},
+        ],
+    )
+    with pytest.raises(AmbiguousMaterialError) as exc:
+        client.fetch_all_textures("gpuopen", "Brick Wall", tier="1k")
+    # Candidates should be names, not UUIDs.
+    assert any("Brick" in c for c in exc.value.candidates)

--- a/justfile.project
+++ b/justfile.project
@@ -85,22 +85,24 @@ clean-artifacts:
 # Two invocations because the two `tests/` dirs both have __init__.py
 # and pytest's rootdir discovery conflates them in one run.
 # `--with clients/python` adds the mat-vis-client wheel to the same
-# env (tests/test_version_sync.py imports it). `--reinstall-package`
-# forces a rebuild from clients/python/ even when the cached archive
-# is stale, so signature drift catches pre-CI.
+# env (tests/test_version_sync.py imports it). UV_NO_CACHE=1 is
+# required: `--reinstall-package` does NOT invalidate path-based
+# `--with` dependencies in uv's archive cache, so without no-cache
+# the recipe runs against a stale wheel and fails to catch source
+# changes that would land in CI.
 [group('test')]
 test-all *args:
-    MAT_VIS_LIVE_TESTS=1 uv run --reinstall-package mat-vis-client \
+    MAT_VIS_LIVE_TESTS=1 UV_NO_CACHE=1 uv run --reinstall-package mat-vis-client \
         --with clients/python pytest tests/ {{ args }}
-    MAT_VIS_LIVE_TESTS=1 uv run --reinstall-package mat-vis-client \
+    MAT_VIS_LIVE_TESTS=1 UV_NO_CACHE=1 uv run --reinstall-package mat-vis-client \
         --with clients/python --with pytest pytest clients/python {{ args }}
 
 # Run only fast tests (no network). Default for pre-push hook.
 [group('test')]
 test-fast *args:
-    uv run --reinstall-package mat-vis-client \
+    UV_NO_CACHE=1 uv run --reinstall-package mat-vis-client \
         --with clients/python pytest tests/ {{ args }}
-    uv run --reinstall-package mat-vis-client \
+    UV_NO_CACHE=1 uv run --reinstall-package mat-vis-client \
         --with clients/python --with pytest pytest clients/python {{ args }}
 
 # Sync every client's version literal from its package manifest


### PR DESCRIPTION
## Summary

Five client-side hotfixes off bernhard-42's build123d#1270 review thread. All on existing substrate — no re-bake required, ships in a mat-vis-client patch release.

- **#280** — `MaterialNotStagedError` now preserves the user-given name when name resolution succeeds but the resolved entry isn't staged. Adds optional `original_name` kwarg + dual-id message; direct-UUID path emits the legacy single-id form unchanged (back-compat).
- **#284** — `_resolve_material_id` falls back to the top-level `name` field so ambientcg/polyhaven flat-v2 entries become name-addressable, matching the gpuopen UX shipped in #143. Bypasses the v3-schema migration tail (tracked separately).
- **#286** — `UnknownMaterialError` + `AmbiguousMaterialError` list display names instead of UUIDs, prepend `difflib.get_close_matches(n=5, cutoff=0.6)` before the full list, and cap full output at 50 entries with a `(... N more)` tail.
- **#287** — `fetch_texture` emits one `log.info("Downloading {source}/{id}/{channel} @ {tier} ...")` per cache miss at the network boundary. Cache hits stay silent. No tqdm dependency.
- **#288** — `VisAsset.textures` short-circuits to `{}` for scalar-only index entries (`available_tiers=[]`), so `to_threejs` / `to_gltf` produce a valid scalars-only material on `physicallybased` instead of raising `MaterialNotStagedError`. Texture-bearing sources still route through the strict resolver.

10 new tests (red-green TDD) + 2 existing tests realigned from UUID-listing to name-listing per #286, with rationale comments in-place.

## Bonus

- Mirrored all five fixes to `mat_vis_client_standalone.py` (single-file mirror) — `test_standalone_drift` (signature parity gate) stays green.
- Fixed pre-push hook bug: `just test-fast` recipe was running against a stale uv wheel cache (`--reinstall-package` doesn't invalidate path-based deps). Added `UV_NO_CACHE=1` prefix. Without this, the standalone signature drift would not have been caught until CI.

## Test plan

- [x] `just test-fast` green (253 passed, 27 skipped — both invocations)
- [x] Red-green TDD for each fix (all new tests confirmed failing before the implementation, passing after)
- [x] Existing test suite untouched (only 2 tests adjusted with rationale comments where the contract intentionally changed)
- [x] Standalone signature parity preserved (`test_standalone_drift` green)
- [ ] CI green
- [ ] PyPI patch release after merge

## Out of scope (filed separately)

- **#285** (gpuopen baking errors) — real rework: baker doesn't populate `pbr=PBRBlock(...)`, `_bake_mtlx` is `NotImplementedError`. Requires substrate re-bake.
- **#284 schema migration** — proper fix is to migrate ambientcg/polyhaven fetchers to v3 nested `mat_vis.*` schema. The hotfix client fallback unblocks users today.
- **#282** (pymat `Vis` import path) — out-of-repo; filed on `MorePET/mat`.

Closes #280, closes #284, closes #286, closes #287, closes #288.