### PR TITLE
feat(baker): pack + push <source>-mtlx.json atomically with catalog (#292)

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -155,8 +155,12 @@ from pathlib import Path
 out_dir = Path(sys.argv[1])
 
 # Catalog at work_dir root (v3 shape: list of entries with mat_vis block).
+# Skip release-manifest.json (object) and *-mtlx.json (object — material_id
+# -> XML map produced by mtlx_tier.pack_original_mtlx_json, mat-vis#292).
 catalog_files = [
-    p for p in out_dir.glob("*.json") if p.name != "release-manifest.json"
+    p
+    for p in out_dir.glob("*.json")
+    if p.name != "release-manifest.json" and not p.name.endswith("-mtlx.json")
 ]
 assert catalog_files, f"no per-source catalog JSON at {out_dir}"
 for cat in catalog_files:

--- a/src/mat_vis_baker/hf_bake_per_file.py
+++ b/src/mat_vis_baker/hf_bake_per_file.py
@@ -192,8 +192,22 @@ def _fetch_manifest_with_parent(api: HfApi, repo_id: str, revision: str) -> tupl
     return manifest, parent_sha
 
 
-def _merge_manifest_for_source(manifest: dict, source: str, tier: str, release_tag: str) -> dict:
-    """Layer this bake's (source, tier) into ``manifest`` and return it."""
+def _merge_manifest_for_source(
+    manifest: dict,
+    source: str,
+    tier: str,
+    release_tag: str,
+    *,
+    mtlx_filename: str | None = None,
+) -> dict:
+    """Layer this bake's (source, tier) into ``manifest`` and return it.
+
+    ``mtlx_filename`` (#292): when provided, stamp ``sources.<src>.mtlx``
+    so clients (`MatVisClient._fetch_mtlx_original_map`) read the bundled
+    upstream MaterialX JSON instead of guessing ``{source}-mtlx.json`` and
+    silently 404-caching an empty dict. Sources without upstream .mtlx
+    (e.g. ambientcg) leave the field absent.
+    """
     manifest["schema_version"] = 3
     manifest["release_tag"] = release_tag
     sources = manifest.setdefault("sources", {})
@@ -201,6 +215,8 @@ def _merge_manifest_for_source(manifest: dict, source: str, tier: str, release_t
     src_entry["catalog"] = f"{source}.json"
     tiers = src_entry.setdefault("tiers", {})
     tiers[tier] = {"complete": True}
+    if mtlx_filename is not None:
+        src_entry["mtlx"] = mtlx_filename
     return manifest
 
 
@@ -533,6 +549,35 @@ def bake_one_per_file(
     index = build_index(all_records, source)
     catalog_path.write_text(json.dumps(index, indent=2, ensure_ascii=False) + "\n")
 
+    # #292: pack upstream .mtlx files into ``<source>-mtlx.json`` and ship
+    # it alongside the catalog. Both gpuopen (writes
+    # ``mtlx_dir/gpuopen/<mid>/material.mtlx``) and polyhaven (writes
+    # ``mtlx_dir/polyhaven/<slug>.mtlx``) drop their upstream .mtlx into
+    # ``mtlx_dir`` during fetch, so we reuse ``pack_original_mtlx_json``
+    # to bundle them. Sources without upstream .mtlx (ambientcg) yield
+    # zero files; we skip the commit + manifest stamp in that case so
+    # the manifest doesn't advertise an empty file.
+    from mat_vis_baker.mtlx_tier import pack_original_mtlx_json
+
+    mtlx_json_path: Path | None = None
+    mtlx_filename: str | None = None
+    source_mtlx_dir = mtlx_dir / source
+    if source_mtlx_dir.is_dir() and any(source_mtlx_dir.rglob("*.mtlx")):
+        mtlx_json_path = pack_original_mtlx_json(
+            mtlx_dir=mtlx_dir,
+            source=source,
+            output_dir=work_dir,
+        )
+        # Only stamp the manifest if pack actually produced a non-empty map.
+        try:
+            packed = json.loads(mtlx_json_path.read_text())
+        except Exception:  # noqa: BLE001
+            packed = {}
+        if packed:
+            mtlx_filename = f"{source}-mtlx.json"
+        else:
+            mtlx_json_path = None
+
     # release-manifest.json — the entry point that JS/shell/Rust clients
     # fetch first. The Python client has a tree-fallback, but the static
     # file is the source of truth.
@@ -582,9 +627,35 @@ def bake_one_per_file(
         for attempt in range(max_retries):
             existing_manifest, parent_sha = _fetch_manifest_with_parent(api, repo_id, release_tag)
             merged = _merge_manifest_for_source(
-                existing_manifest, source, storage_tier, release_tag
+                existing_manifest,
+                source,
+                storage_tier,
+                release_tag,
+                mtlx_filename=mtlx_filename,
             )
             manifest_path.write_text(json.dumps(merged, indent=2, ensure_ascii=False) + "\n")
+            # #292: ship the packed upstream-MTLX JSON in the same atomic
+            # commit as catalog + manifest. The manifest entry that points
+            # at it lands in the same commit, so a client that sees the
+            # manifest field is guaranteed to find the file (no
+            # write-before-advertise race).
+            catalog_ops = [
+                CommitOperationAdd(
+                    path_in_repo=f"{source}.json",
+                    path_or_fileobj=str(catalog_path),
+                ),
+                CommitOperationAdd(
+                    path_in_repo="release-manifest.json",
+                    path_or_fileobj=str(manifest_path),
+                ),
+            ]
+            if mtlx_json_path is not None:
+                catalog_ops.append(
+                    CommitOperationAdd(
+                        path_in_repo=f"{source}-mtlx.json",
+                        path_or_fileobj=str(mtlx_json_path),
+                    )
+                )
             try:
                 # #225: 429 retry sits *inside* the CAS loop. The helper
                 # re-raises 412 unchanged so the precondition matcher
@@ -595,16 +666,7 @@ def bake_one_per_file(
                     source=source,
                     repo_id=repo_id,
                     repo_type="dataset",
-                    operations=[
-                        CommitOperationAdd(
-                            path_in_repo=f"{source}.json",
-                            path_or_fileobj=str(catalog_path),
-                        ),
-                        CommitOperationAdd(
-                            path_in_repo="release-manifest.json",
-                            path_or_fileobj=str(manifest_path),
-                        ),
-                    ],
+                    operations=catalog_ops,
                     commit_message=f"feat(data): {release_tag} — {source} catalog + manifest",
                     revision=release_tag,
                     parent_commit=parent_sha,

--- a/tests/test_hf_bake_per_file.py
+++ b/tests/test_hf_bake_per_file.py
@@ -648,3 +648,189 @@ class TestBytesAwareBatching:
             f"expected 2 texture commits across 3 unskipped materials "
             f"(batch_size=2); got {len(texture_calls)}"
         )
+
+
+# ── #292: upstream-MTLX pack-and-push ────────────────────────────────
+
+
+def _catalog_commit_call(api):
+    """Find the create_commit call that carries release-manifest.json
+    (the catalog + manifest commit, where the per-source ``mtlx`` field
+    and ``<source>-mtlx.json`` blob land)."""
+    for c in api.create_commit.call_args_list:
+        for op in c.kwargs["operations"]:
+            if op.path_in_repo == "release-manifest.json":
+                return c
+    raise AssertionError("no catalog+manifest commit found")
+
+
+class TestMtlxPackAndPush:
+    """#292: bake_one_per_file packs upstream .mtlx files into
+    ``<source>-mtlx.json`` and ships it in the same atomic commit as
+    the catalog + manifest, with ``sources.<src>.mtlx`` stamped on
+    the manifest. Without this wire-up, ``client.mtlx(...).original``
+    returns None for every gpuopen material in v2026.04.0/.1/.2."""
+
+    def test_packs_and_pushes_mtlx_when_fetcher_writes_files(self, tmp_path):
+        """Fetcher writes .mtlx files into ``mtlx_dir/<source>/...`` (the
+        layout both gpuopen and polyhaven use). The bake must (a) pack
+        them into ``<source>-mtlx.json``, (b) include the JSON blob in
+        the catalog commit, and (c) stamp ``sources.<src>.mtlx`` on the
+        release manifest."""
+        PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+        fake_records = [
+            _fake_record(f"mat_{i}", {"color": PNG_MAGIC + b"\x00" * 32}, tmp_path)
+            for i in range(2)
+        ]
+
+        def _writing_fetch(tier, textures_dir, *, limit=None, offset=0, mtlx_dir=None, **kw):
+            # Mirror the gpuopen fetch contract: write upstream .mtlx
+            # files into ``mtlx_dir/<source>/<mid>/material.mtlx`` so
+            # ``pack_original_mtlx_json`` can pick them up.
+            end = None if limit is None else offset + limit
+            slice_ = fake_records[offset:end]
+            if mtlx_dir is not None:
+                for rec in slice_:
+                    p = Path(mtlx_dir) / "polyhaven" / rec.id / "material.mtlx"
+                    p.parent.mkdir(parents=True, exist_ok=True)
+                    p.write_text(f"<materialx>{rec.id}</materialx>")
+            return slice_
+
+        with (
+            patch("mat_vis_baker.hf_bake_per_file._get_fetcher") as fetcher,
+            patch("mat_vis_baker.hf_bake_per_file.HfApi") as api_cls,
+            patch(
+                "mat_vis_baker.hf_bake_per_file.bake_material",
+                side_effect=lambda r, *a, **k: r,
+            ),
+        ):
+            fetcher.return_value = _writing_fetch
+            api = api_cls.return_value
+            api.list_repo_tree.return_value = []
+            # Empty manifest on first read → merge starts from {}.
+            api.hf_hub_download.side_effect = FileNotFoundError("no manifest yet")
+
+            bake_one_per_file(
+                source="polyhaven",
+                tier="1k",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                hf_token="t",
+                repo_id="gerchowl/mat-vis-tst",
+            )
+
+        # (a) The packed JSON must exist on disk.
+        packed_path = tmp_path / "polyhaven-mtlx.json"
+        assert packed_path.exists(), "expected polyhaven-mtlx.json packed in work_dir"
+        import json as _json
+
+        packed = _json.loads(packed_path.read_text())
+        assert set(packed.keys()) == {"mat_0", "mat_1"}
+        assert packed["mat_0"] == "<materialx>mat_0</materialx>"
+
+        # (b) The catalog+manifest commit must include the mtlx blob.
+        catalog_call = _catalog_commit_call(api)
+        commit_paths = {op.path_in_repo for op in catalog_call.kwargs["operations"]}
+        assert "polyhaven-mtlx.json" in commit_paths, (
+            f"polyhaven-mtlx.json missing from catalog commit; got {sorted(commit_paths)}"
+        )
+        # And it should be bundled with the catalog + manifest, atomically.
+        assert "polyhaven.json" in commit_paths
+        assert "release-manifest.json" in commit_paths
+
+        # (c) The committed manifest must stamp sources.polyhaven.mtlx.
+        manifest_op = next(
+            op
+            for op in catalog_call.kwargs["operations"]
+            if op.path_in_repo == "release-manifest.json"
+        )
+        manifest_payload = _json.loads(Path(manifest_op.path_or_fileobj).read_text())
+        assert manifest_payload["sources"]["polyhaven"]["mtlx"] == "polyhaven-mtlx.json"
+
+    def test_no_mtlx_files_means_no_blob_no_manifest_field(self, tmp_path):
+        """ambientcg-shaped sources don't ship upstream .mtlx. The bake
+        must NOT publish an empty ``<source>-mtlx.json`` and must NOT
+        stamp ``sources.<src>.mtlx`` on the manifest — both would
+        mislead clients into thinking originals are available."""
+        PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+        fake_records = [
+            _fake_record(f"mat_{i}", {"color": PNG_MAGIC + b"\x00" * 32}, tmp_path)
+            for i in range(2)
+        ]
+
+        with (
+            patch("mat_vis_baker.hf_bake_per_file._get_fetcher") as fetcher,
+            patch("mat_vis_baker.hf_bake_per_file.HfApi") as api_cls,
+            patch(
+                "mat_vis_baker.hf_bake_per_file.bake_material",
+                side_effect=lambda r, *a, **k: r,
+            ),
+        ):
+
+            def _sliced(tier, textures_dir, *, limit=None, offset=0, **kw):
+                end = None if limit is None else offset + limit
+                return fake_records[offset:end]
+
+            fetcher.return_value = _sliced
+            api = api_cls.return_value
+            api.list_repo_tree.return_value = []
+            api.hf_hub_download.side_effect = FileNotFoundError("no manifest yet")
+
+            bake_one_per_file(
+                source="polyhaven",
+                tier="1k",
+                release_tag="v0.0.0-test",
+                work_dir=tmp_path,
+                hf_token="t",
+                repo_id="gerchowl/mat-vis-tst",
+            )
+
+        catalog_call = _catalog_commit_call(api)
+        commit_paths = {op.path_in_repo for op in catalog_call.kwargs["operations"]}
+        assert "polyhaven-mtlx.json" not in commit_paths
+
+        import json as _json
+
+        manifest_op = next(
+            op
+            for op in catalog_call.kwargs["operations"]
+            if op.path_in_repo == "release-manifest.json"
+        )
+        manifest_payload = _json.loads(Path(manifest_op.path_or_fileobj).read_text())
+        assert "mtlx" not in manifest_payload["sources"]["polyhaven"]
+
+
+class TestMergeManifestMtlxField:
+    """Unit-level: ``_merge_manifest_for_source`` accepts an optional
+    ``mtlx_filename`` kwarg and stamps ``sources.<src>.mtlx`` only when
+    it's set. Locks the field name down so a future rename can't drift
+    out of sync with ``MatVisClient._fetch_mtlx_original_map``."""
+
+    def test_mtlx_filename_stamped_when_provided(self):
+        from mat_vis_baker.hf_bake_per_file import _merge_manifest_for_source
+
+        merged = _merge_manifest_for_source(
+            {}, "gpuopen", "1k", "v0.0.0-test", mtlx_filename="gpuopen-mtlx.json"
+        )
+        assert merged["sources"]["gpuopen"]["mtlx"] == "gpuopen-mtlx.json"
+        assert merged["sources"]["gpuopen"]["catalog"] == "gpuopen.json"
+
+    def test_mtlx_field_absent_when_not_provided(self):
+        from mat_vis_baker.hf_bake_per_file import _merge_manifest_for_source
+
+        merged = _merge_manifest_for_source({}, "ambientcg", "1k", "v0.0.0-test")
+        assert "mtlx" not in merged["sources"]["ambientcg"]
+
+    def test_mtlx_field_preserved_across_subsequent_tier_merges(self):
+        """If a later derive (KTX2 transcode) re-merges without the
+        kwarg, the previously-stamped mtlx field must NOT be wiped —
+        otherwise the catalog and the mtlx file fall out of sync after
+        a derive run."""
+        from mat_vis_baker.hf_bake_per_file import _merge_manifest_for_source
+
+        m = _merge_manifest_for_source(
+            {}, "gpuopen", "1k", "v0.0.0-test", mtlx_filename="gpuopen-mtlx.json"
+        )
+        m = _merge_manifest_for_source(m, "gpuopen", "ktx2-1k", "v0.0.0-test")
+        assert m["sources"]["gpuopen"]["mtlx"] == "gpuopen-mtlx.json"
+        assert "ktx2-1k" in m["sources"]["gpuopen"]["tiers"]


### PR DESCRIPTION
## Summary

Closes #292. Wires `pack_original_mtlx_json` into `bake_one_per_file` so every textured-source bake also publishes `<source>-mtlx.json` to HF, atomic with the catalog + manifest commit. Manifest now advertises `sources.<src>.mtlx`.

## Why

mat-vis#28 added the packer + CLI subcommand but never wired either into the release pipeline. v2026.04.0/.1/.2 all silently shipped without `<source>-mtlx.json` — `client.py::_fetch_mtlx_original_map` falls back to a guessed filename, hits 404, caches empty. `MtlxSource.original()` returns `None` for every gpuopen + polyhaven material today.

Discovered while spiking #290. The two should land in the same v2026.04.3 cut.

## Implementation choice

Reused `pack_original_mtlx_json(mtlx_dir, source, work_dir)` rather than building the mtlx map from `MaterialRecord.texture_paths["_mtlx"]`: gpuopen populates that key, **polyhaven does not** — its `_download_mtlx` writes `mtlx_dir/polyhaven/<slug>.mtlx` without touching the record. Building from records would silently miss every polyhaven mtlx.

## Atomicity

The mtlx blob is added as a third `CommitOperationAdd` to the existing catalog+manifest commit (not a separate commit), so the manifest never advertises a file the substrate doesn't have.

## Tests — 5 new

`tests/test_hf_bake_per_file.py`:
- `TestMtlxPackAndPush::test_packs_and_pushes_mtlx_when_fetcher_writes_files`
- `TestMtlxPackAndPush::test_no_mtlx_files_means_no_blob_no_manifest_field`
- `TestMergeManifestMtlxField` (×3) — set / unset / preserved-across-re-merge

## Test plan

- [x] `tests/test_hf_bake_per_file.py` — 20 passed
- [x] `just test-fast` — 420 baker + 267 client + 27 skipped
- [ ] CI green
- [ ] After v2026.04.3 cut: read `release-manifest.json` and confirm `sources.gpuopen.mtlx == "gpuopen-mtlx.json"`

## Visible behavior change after v2026.04.3 ships

`MtlxSource.original()` returns real upstream XML for gpuopen + polyhaven (previously always `None`).

## Out of scope

- Stale `gap-*` recipes in `justfile.project` (parquet-era, pre-v0.6.0; substrate is HF-only post-ADR-0012) — file separately
- ambientcg .mtlx synthesis (no upstream mtlx)
- `mat-vis-baker pack-mtlx` CLI subcommand kept as-is for ad-hoc local use

Closes #292. Refs: mat-vis#28, mat-vis#290, mat-vis#293.