### PR TITLE
bugfix(baker): move glTF-MR neutral-multiplier conventions to baker (#290 follow-up)

### DIFF
--- a/clients/python/src/mat_vis_client/adapters.py
+++ b/clients/python/src/mat_vis_client/adapters.py
@@ -69,34 +69,6 @@ def _transmission_at_default(t: float | None) -> bool:
     return t is None or math.isclose(t, _KHR_TRANSMISSION_DEFAULT, abs_tol=1e-9)
 
 
-def _apply_metallic_colormap_convention(scalars: dict, textures: dict | None) -> dict:
-    """If metallic AND has colorMap AND no authored color, neutralize.
-
-    For three.js / glTF-MR: BaseColorFactor x BaseColorTexture is the
-    spec contract. When ``metalness >= 0.9`` and a color texture is
-    bound but no scalar color was authored, set color=[1,1,1] so the
-    texture is the sole color contributor (else the renderer's default
-    grey double-tints the texture). mat-vis#290 review consensus: the
-    convention belongs in the adapter, not the baker, so ``to_mtlx()``
-    can preserve authored truth.
-
-    Returns a shallow-copied dict — never mutates the caller's input.
-
-    Note: only ``color_hex`` is set on the returned dict; ``color_rgb``
-    is intentionally NOT written because neither :func:`to_threejs` nor
-    :func:`to_gltf` reads it (both consume ``color_hex`` only). Setting
-    it would be misleading dead state.
-    """
-    metalness = scalars.get("metalness") or 0
-    has_color_map = "color" in (textures or {})
-    color_unauthored = scalars.get("color_rgb") is None and scalars.get("color_hex") is None
-    if metalness >= 0.9 and has_color_map and color_unauthored:
-        out = {**scalars}
-        out["color_hex"] = "#FFFFFF"
-        return out
-    return scalars
-
-
 def _color_hex_to_int(hex_str: str) -> int:
     """Convert '#RRGGBB' hex string to an integer (Three.js color format).
 
@@ -140,10 +112,12 @@ def to_threejs(
     Recommended ergonomic alternative: ``client.asset(src, mid, tier).to_threejs()``.
     """
     textures = textures or {}
-    # Apply the metallic+colorMap neutralization convention BEFORE we
-    # read scalar fields (mat-vis#290). The helper returns the same
-    # dict if no convention applies, or a shallow copy with color set.
-    scalars = _apply_metallic_colormap_convention(scalars, textures)
+    # Adapter is dumb — substrate values flow through verbatim. The
+    # glTF-MR neutral-multiplier convention (color=[1,1,1] when a
+    # colorMap is bound, metalness=1.0 when a metalnessMap is bound)
+    # is materialized in the baker so every consumer (py / js / rust /
+    # shell adapters AND search-side `pbr.metalness` readers) inherits
+    # it from the substrate. mat-vis#290 baker-side follow-up.
 
     result: dict = {"type": "MeshPhysicalMaterial"}
 
@@ -195,10 +169,11 @@ def to_gltf(
     Recommended ergonomic alternative: ``client.asset(src, mid, tier).to_gltf()``.
     """
     textures = textures or {}
-    # Apply the metallic+colorMap neutralization convention BEFORE we
-    # read scalar fields (mat-vis#290). The helper returns the same
-    # dict if no convention applies, or a shallow copy with color set.
-    scalars = _apply_metallic_colormap_convention(scalars, textures)
+    # Adapter is dumb — substrate values flow through verbatim. The
+    # glTF-MR neutral-multiplier convention (color=[1,1,1] when a
+    # colorMap is bound, metalness=1.0 when a metalnessMap is bound)
+    # is materialized in the baker so every consumer inherits it from
+    # the substrate. mat-vis#290 baker-side follow-up.
 
     pbr: dict = {}
     material: dict = {"pbrMetallicRoughness": pbr}

--- a/clients/python/tests/test_adapters_metalcolormap.py
+++ b/clients/python/tests/test_adapters_metalcolormap.py
@@ -1,17 +1,23 @@
-"""Tests for the metallic+colorMap convention and KHR default suppression.
+"""Tests for the adapter-side glTF-format concerns (mat-vis#290 follow-up).
 
-Both behaviors land in ``adapters.py`` per the mat-vis#290 review:
+The metallic+colorMap / metalnessMap neutral-multiplier convention has
+moved to the baker (see ``tests/test_gpuopen_baker.py``) so every
+consumer — Python, JS, Rust, shell, plus the search-side
+``pbr.metalness`` readers — inherits it from the substrate without
+per-language reimplementation. The adapter is now dumb: substrate
+scalars flow through verbatim.
 
-  - When a material is metallic and a colorMap is bound but no scalar
-    color was authored, the adapter neutralizes baseColor to white so
-    the texture is the sole color contributor (else the renderer's
-    default mid-grey double-tints the texture).
+What STAYS adapter-side and is exercised here:
+
   - The KHR_materials_ior / KHR_materials_transmission extensions are
     omitted from glTF output when their values match the spec defaults
     (1.5 / 0.0). Emitting a no-op extension entry just bloats output.
-
-Convention belongs in the adapter layer (NOT the baker) so that the
-.mtlx round-trip preserves authored truth.
+    This is a glTF-format concern (extension emission policy), NOT a
+    substrate fact.
+  - Dumb-adapter contract: with raw scalars + textures the adapter
+    does NOT auto-inject neutralized colors anymore — callers feeding
+    raw scalars without baker treatment are responsible for the
+    multiplier convention themselves.
 """
 
 from __future__ import annotations
@@ -44,65 +50,7 @@ def _png_bytes() -> bytes:
     return buf.getvalue()
 
 
-WHITE_INT = 0xFFFFFF
-
-
-# ── metallic+colorMap → neutralize ─────────────────────────────
-
-
-def test_metallic_colormap_neutralizes_color_in_threejs():
-    result = to_threejs(
-        {"metalness": 1.0},
-        {"color": _png_bytes()},
-    )
-    assert result["color"] == WHITE_INT
-
-
-def test_metallic_colormap_neutralizes_color_in_gltf():
-    result = to_gltf(
-        {"metalness": 1.0},
-        {"color": _png_bytes()},
-    )
-    assert result["pbrMetallicRoughness"]["baseColorFactor"] == [1.0, 1.0, 1.0, 1.0]
-
-
-def test_authored_color_preserved_when_metallic():
-    """Don't override an authored color — only fill when None."""
-    result = to_threejs(
-        {"metalness": 1.0, "color_hex": "#E3E3E3"},
-        {"color": _png_bytes()},
-    )
-    # 0xE3E3E3 = 14935011 — not 0xFFFFFF.
-    assert result["color"] == 0xE3E3E3
-
-    result_gltf = to_gltf(
-        {"metalness": 1.0, "color_hex": "#E3E3E3"},
-        {"color": _png_bytes()},
-    )
-    bcf = result_gltf["pbrMetallicRoughness"]["baseColorFactor"]
-    assert bcf != [1.0, 1.0, 1.0, 1.0]
-
-
-def test_dielectric_never_neutralized():
-    """metalness=0 (or missing) → no convention applied."""
-    # No color at all → adapter doesn't synthesize one (existing behavior).
-    result = to_threejs({"metalness": 0.0}, {"color": _png_bytes()})
-    assert "color" not in result
-
-    result_none = to_threejs({}, {"color": _png_bytes()})
-    assert "color" not in result_none
-
-
-def test_no_colormap_never_neutralized():
-    """No colorMap bound → no convention applied (color stays unset)."""
-    result = to_threejs({"metalness": 1.0}, {})
-    assert "color" not in result
-
-    result_gltf = to_gltf({"metalness": 1.0}, {})
-    assert "baseColorFactor" not in result_gltf["pbrMetallicRoughness"]
-
-
-# ── KHR extension default suppression ──────────────────────────
+# ── KHR extension default suppression (adapter-side, format concern) ──
 
 
 def test_khr_ior_omitted_when_default():
@@ -126,29 +74,52 @@ def test_khr_transmission_emitted_when_authored():
     assert result["extensions"]["KHR_materials_transmission"] == {"transmissionFactor": 1.0}
 
 
-# ── Boundary cases: metallic threshold + authored color preservation ──
+# ── dumb-adapter contract: no auto-injection ──────────────────
 
 
-def test_metallic_threshold_at_exact_0_9_neutralizes():
-    """metalness == 0.9 is the threshold — must neutralize."""
-    result = to_threejs({"metalness": 0.9}, {"color": _png_bytes()})
-    assert result["color"] == WHITE_INT
+def test_to_threejs_does_not_auto_neutralize_color():
+    """Adapter does NOT inject color when only metalness + colorMap are passed.
 
-
-def test_metallic_threshold_just_below_0_9_does_not_neutralize():
-    """metalness == 0.89 — off-by-one: must NOT neutralize."""
-    result = to_threejs({"metalness": 0.89}, {"color": _png_bytes()})
+    The convention now lives in the baker. Callers who hand raw scalars
+    to the adapter (bypassing the substrate) get exactly what they passed
+    — no surprise color injection.
+    """
+    result = to_threejs(
+        {"metalness": 1.0},
+        {"color": _png_bytes()},
+    )
     assert "color" not in result
 
 
-def test_authored_color_rgb_preserved_when_metallic():
-    """color_rgb authored (without color_hex) → convention does NOT fire."""
-    result_gltf = to_gltf(
-        {"metalness": 1.0, "color_rgb": [0.89, 0.89, 0.89]},
+def test_to_gltf_does_not_auto_neutralize_color():
+    result = to_gltf(
+        {"metalness": 1.0},
         {"color": _png_bytes()},
     )
-    # Adapter only writes baseColorFactor when color_hex is set; with
-    # only color_rgb authored and the convention skipped, no factor is
-    # written — but critically the convention's white override does NOT
-    # fire (color_rgb is preserved as authored truth, not overwritten).
-    assert "baseColorFactor" not in result_gltf["pbrMetallicRoughness"]
+    assert "baseColorFactor" not in result["pbrMetallicRoughness"]
+
+
+def test_substrate_neutralized_color_flows_through():
+    """When the BAKER has already neutralized color_hex='#FFFFFF', the
+    adapter passes it through verbatim — no double-tint, no override.
+    """
+    result = to_threejs(
+        {"metalness": 1.0, "color_hex": "#FFFFFF"},
+        {"color": _png_bytes()},
+    )
+    assert result["color"] == 0xFFFFFF
+
+    result_gltf = to_gltf(
+        {"metalness": 1.0, "color_hex": "#FFFFFF"},
+        {"color": _png_bytes()},
+    )
+    assert result_gltf["pbrMetallicRoughness"]["baseColorFactor"] == [1.0, 1.0, 1.0, 1.0]
+
+
+def test_authored_color_preserved():
+    """Authored color flows through unchanged (it always did)."""
+    result = to_threejs(
+        {"metalness": 1.0, "color_hex": "#E3E3E3"},
+        {"color": _png_bytes()},
+    )
+    assert result["color"] == 0xE3E3E3

--- a/src/mat_vis_baker/common.py
+++ b/src/mat_vis_baker/common.py
@@ -426,6 +426,48 @@ class PBRBlock:
     complex_ior: list[float] | None = None  # 6-float wavelength-resolved
 
 
+def apply_pbr_neutral_multiplier_conventions(
+    pbr: PBRBlock,
+    textures: dict,
+) -> PBRBlock:
+    """glTF-MR neutral-multiplier conventions (mat-vis#290 follow-up).
+
+    When a PBR scalar input is texture-bound (the ``pbr`` field is ``None``)
+    AND the corresponding texture is present in the baked texture set,
+    write the glTF-MR neutral multiplier into the substrate so
+    ``renderer × texture = authored intent``. Three.js and the glTF-MR
+    spec multiply the scalar factor by the sampled texel; without the
+    convention the default scalar (mid-grey for ``baseColorFactor``,
+    ``0`` for ``metallicFactor``) double-tints / nulls the texture.
+    Mirrors MaterialX.TextureBaker post-eval semantics.
+    Materializing this fact at bake time keeps every consumer (py / js
+    / rust / shell adapters AND search-side ``pbr.metalness`` filters)
+    inheriting the convention from the substrate — no per-language
+    reimplementation, no per-adapter drift.
+
+    Texture channel naming follows :func:`normalize_channel` output:
+    ``color``, ``normal``, ``roughness``, ``metalness``, ``ao``,
+    ``displacement``, ``emission``. Authored scalars (non-``None``) are
+    NEVER overridden — the convention only fills genuine None gaps.
+
+    Roughness defaults to ``1.0`` in glTF-MR which happens to match
+    Three.js's renderer default, so the override is mostly a no-op for
+    rendering — but the substrate index needs it for query correctness
+    (``client.search(roughness>=...)`` should match materials with a
+    bound roughnessMap), and emitting it explicitly is spec-aligned and
+    informative.
+
+    Modifies ``pbr`` in place AND returns it so callers can chain.
+    """
+    if pbr.color_rgb is None and "color" in textures:
+        pbr.color_rgb = [1.0, 1.0, 1.0]
+    if pbr.metalness is None and "metalness" in textures:
+        pbr.metalness = 1.0
+    if pbr.roughness is None and "roughness" in textures:
+        pbr.roughness = 1.0
+    return pbr
+
+
 @dataclass
 class AttributionBlock:
     """Upstream attribution / licensing (SPDX where known)."""

--- a/src/mat_vis_baker/sources/ambientcg.py
+++ b/src/mat_vis_baker/sources/ambientcg.py
@@ -21,9 +21,11 @@ from mat_vis_baker.common import (
     DatesBlock,
     MaterialRecord,
     MatVisBlock,
+    PBRBlock,
     PhysicalBlock,
     UpstreamBlock,
     _filter_upstream,
+    apply_pbr_neutral_multiplier_conventions,
     check_zip_safety,
     normalize_category,
     normalize_channel,
@@ -334,6 +336,14 @@ def _fetch_one(entry: dict, tier: str, output_dir: Path, mtlx_dir: Path | None) 
         release_date = (entry.get("releaseDate") or "")[:10] or None
         description = entry.get("description") or None
 
+        # glTF-MR neutral-multiplier convention (mat-vis#290 follow-up):
+        # ambientcg doesn't expose scalar PBR properties upstream, so the
+        # helper is the only path that populates ``pbr.*`` fields — fills
+        # color/metalness/roughness with their glTF-MR neutral
+        # multipliers when the matching texture is in the baked set.
+        pbr = PBRBlock()
+        apply_pbr_neutral_multiplier_conventions(pbr, textures)
+
         return MaterialRecord(
             id=mid,
             source="ambientcg",
@@ -347,6 +357,7 @@ def _fetch_one(entry: dict, tier: str, output_dir: Path, mtlx_dir: Path | None) 
                     dimensions_m=_dimensions_m(entry),
                     max_resolution_px=_max_resolution_px(tier),
                 ),
+                pbr=pbr,
                 attribution=AttributionBlock(
                     license_spdx="CC0-1.0",
                     source_url=f"https://ambientcg.com/a/{mid}",

--- a/src/mat_vis_baker/sources/gpuopen.py
+++ b/src/mat_vis_baker/sources/gpuopen.py
@@ -40,6 +40,7 @@ from mat_vis_baker.common import (
     PhysicalBlock,
     UpstreamBlock,
     _filter_upstream,
+    apply_pbr_neutral_multiplier_conventions,
     check_zip_safety,
     normalize_category,
     normalize_channel,
@@ -345,11 +346,14 @@ def _fetch_one(
             upstream_id=mid,
             physical=PhysicalBlock(max_resolution_px=_max_resolution_px(tier)),
             # PBR scalars parsed from the .mtlx <standard_surface> shader
-            # at fetch time (mat-vis#290). Texture-bound inputs leave the
-            # corresponding PBRBlock field as None — adapters apply their
-            # own neutral defaults (e.g. baseColorFactor [1,1,1] when a
-            # colorMap is bound). On the failed-fetch path pbr=None and
-            # we fall back to the dataclass default (an empty PBRBlock).
+            # at fetch time (mat-vis#290). Texture-bound inputs whose
+            # matching texture shipped get the glTF-MR neutral multiplier
+            # written back into the PBRBlock at the call site (color=
+            # [1,1,1] when a colorMap is bound, metalness=1.0 when a
+            # metalnessMap is bound) — every consumer inherits the
+            # convention from the substrate, no adapter rework needed.
+            # On the failed-fetch path pbr=None and we fall back to the
+            # dataclass default (an empty PBRBlock).
             pbr=pbr if pbr is not None else PBRBlock(),
             attribution=AttributionBlock(
                 authors=_authors(mat),
@@ -413,6 +417,13 @@ def _fetch_one(
                 # mtlx, or any future parser failure) and continue without
                 # the parsed PBRBlock — texture_paths still flow through.
                 log.exception("%s: could not read mtlx for scalar parse", mid)
+
+        # glTF-MR neutral-multiplier convention (mat-vis#290 baker-side
+        # follow-up). Shared across all three texture sources via
+        # ``apply_pbr_neutral_multiplier_conventions`` — see common.py
+        # for the rationale and channel coverage.
+        if parsed_pbr is not None:
+            apply_pbr_neutral_multiplier_conventions(parsed_pbr, textures)
 
         texture_paths = dict(textures)
         if mtlx_path:

--- a/src/mat_vis_baker/sources/polyhaven.py
+++ b/src/mat_vis_baker/sources/polyhaven.py
@@ -18,9 +18,11 @@ from mat_vis_baker.common import (
     DatesBlock,
     MaterialRecord,
     MatVisBlock,
+    PBRBlock,
     PhysicalBlock,
     UpstreamBlock,
     _filter_upstream,
+    apply_pbr_neutral_multiplier_conventions,
     normalize_category,
     normalize_channel,
     retry_request,
@@ -336,6 +338,14 @@ def _fetch_one(
         cat = normalize_category(cat_str, [*cat_list[1:], *tags])
         description = meta.get("description") or None
 
+        # glTF-MR neutral-multiplier convention (mat-vis#290 follow-up):
+        # polyhaven doesn't currently parse PBR scalars from any source,
+        # so the helper is the only path that populates ``pbr.*`` fields
+        # — fills color/metalness/roughness with their glTF-MR neutral
+        # multipliers when the matching texture is in the baked set.
+        pbr = PBRBlock()
+        apply_pbr_neutral_multiplier_conventions(pbr, textures)
+
         return MaterialRecord(
             id=slug,
             source="polyhaven",
@@ -349,6 +359,7 @@ def _fetch_one(
                     dimensions_m=_dimensions_m(meta.get("dimensions")),
                     max_resolution_px=_max_resolution_px(meta.get("max_resolution")),
                 ),
+                pbr=pbr,
                 attribution=AttributionBlock(
                     authors=_authors(meta),
                     license_spdx="CC0-1.0",

--- a/tests/test_ambientcg_extractor.py
+++ b/tests/test_ambientcg_extractor.py
@@ -185,9 +185,14 @@ def test_fetch_one_builds_stable_mat_vis_shape(tmp_path: Path) -> None:
     assert rec.mat_vis.pbr is not None
     assert rec.mat_vis.attribution is not None
     assert rec.mat_vis.dates is not None
-    # pbr stays empty — ambientcg doesn't expose scalar PBR properties
-    assert rec.mat_vis.pbr.color_rgb is None
+    # ambientcg doesn't expose scalar PBR properties upstream, but the
+    # baker-side glTF-MR neutral-multiplier convention (mat-vis#290
+    # follow-up) populates color_rgb=[1,1,1] because _fake_zip_bytes()
+    # ships a *_Color.png. roughness/metalness stay None — no matching
+    # texture in this fixture.
+    assert rec.mat_vis.pbr.color_rgb == [1.0, 1.0, 1.0]
     assert rec.mat_vis.pbr.roughness is None
+    assert rec.mat_vis.pbr.metalness is None
 
 
 # ── upstream mirror (Phase C, mat-vis#152) ──────────────────────
@@ -262,3 +267,80 @@ def test_upstream_allowlist_locks_conservative_keyset() -> None:
     assert "dimensionX" in UPSTREAM_ALLOWLIST
     assert "downloadFolders" not in UPSTREAM_ALLOWLIST
     assert "previewLinks" not in UPSTREAM_ALLOWLIST
+
+
+# ── glTF-MR neutral-multiplier convention (mat-vis#290 follow-up) ──
+#
+# ambientcg doesn't expose scalar PBR properties upstream — the only
+# path that can populate ``pbr.*`` is the baker-side convention. These
+# tests pin that wire-up so the substrate carries spec-aligned scalars
+# whenever the matching texture is in the baked set, and stays
+# all-None otherwise.
+
+
+def _multi_channel_zip_bytes() -> bytes:
+    """ambientcg-shaped ZIP carrying Color + Metalness + Roughness PNGs."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for suffix in ("Color", "Metalness", "Roughness"):
+            zf.writestr(
+                f"Bricks097_1K-PNG/Bricks097_1K-PNG_{suffix}.png",
+                b"\x89PNG\r\n\x1a\nfake",
+            )
+    return buf.getvalue()
+
+
+def _normal_only_zip_bytes() -> bytes:
+    """ambientcg-shaped ZIP carrying ONLY a normal map — no PBR scalar texture."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(
+            "Bricks097_1K-PNG/Bricks097_1K-PNG_NormalGL.png",
+            b"\x89PNG\r\n\x1a\nfake",
+        )
+    return buf.getvalue()
+
+
+def test_ambientcg_pbr_convention_applied(tmp_path: Path) -> None:
+    """color + metalness + roughness textures → all three scalars filled."""
+    entry = _entry()
+    mock_resp = MagicMock(content=_multi_channel_zip_bytes())
+    with patch("mat_vis_baker.sources.ambientcg.retry_request", return_value=mock_resp):
+        rec = _fetch_one(entry, "1k", tmp_path, mtlx_dir=None)
+
+    assert rec.status == "ok"
+    assert set(rec.maps) >= {"color", "metalness", "roughness"}
+    assert rec.mat_vis.pbr.color_rgb == [1.0, 1.0, 1.0]
+    assert rec.mat_vis.pbr.metalness == 1.0
+    assert rec.mat_vis.pbr.roughness == 1.0
+
+
+def test_ambientcg_pbr_no_convention_when_no_pbr_texture(tmp_path: Path) -> None:
+    """Only a normal map shipped → all PBR scalars stay None."""
+    entry = _entry()
+    mock_resp = MagicMock(content=_normal_only_zip_bytes())
+    with patch("mat_vis_baker.sources.ambientcg.retry_request", return_value=mock_resp):
+        rec = _fetch_one(entry, "1k", tmp_path, mtlx_dir=None)
+
+    assert rec.status == "ok"
+    assert "normal" in rec.maps
+    assert "color" not in rec.maps
+    assert rec.mat_vis.pbr.color_rgb is None
+    assert rec.mat_vis.pbr.metalness is None
+    assert rec.mat_vis.pbr.roughness is None
+
+
+def test_ambientcg_pbr_all_none_on_failed_fetch(tmp_path: Path) -> None:
+    """Failed-fetch path (textures empty) → pbr stays the default
+    empty PBRBlock with everything None."""
+    entry = _entry()
+    with patch(
+        "mat_vis_baker.sources.ambientcg.retry_request",
+        side_effect=RuntimeError("boom"),
+    ):
+        rec = _fetch_one(entry, "1k", tmp_path, mtlx_dir=None)
+
+    assert rec.status == "failed"
+    assert rec.mat_vis.pbr.color_rgb is None
+    assert rec.mat_vis.pbr.metalness is None
+    assert rec.mat_vis.pbr.roughness is None

--- a/tests/test_gpuopen_baker.py
+++ b/tests/test_gpuopen_baker.py
@@ -110,3 +110,254 @@ def test_fetch_one_failed_path_keeps_empty_pbr(tmp_path: Path) -> None:
     assert pbr.roughness is None
     assert pbr.ior is None
     assert pbr.color_rgb is None
+
+
+# ── glTF-MR neutral-multiplier convention (baker-side, #290 follow-up) ──
+#
+# When a PBRBlock scalar field is left None by the parser (signaling
+# "this input is texture-bound") AND the matching texture actually
+# shipped, the baker writes the glTF-MR neutral multiplier into the
+# substrate so every consumer (adapters in any language, plus search-
+# side `pbr.metalness` filters) inherits the convention for free.
+#
+# Note on threshold: the OLD adapter helper gated the color convention
+# on ``metalness >= 0.9``. At the baker we just check "color_rgb is
+# None AND a color texture is bound" — color=[1,1,1] is the right
+# multiplier for ANY texture-controlled-only color (metallic AND
+# dielectric, since glTF-MR multiplies the same way regardless of
+# metalness). The metallic/dielectric distinction is implicit in the
+# PBRBlock's own ``metalness`` value; the convention is independent.
+
+
+_MTLX_BASE_COLOR_TEXTURE_BOUND = b"""<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="ng">
+    <image name="bc_img" type="color3">
+      <input name="file" type="filename" value="oak_basecolor.png"/>
+    </image>
+    <output name="bc_out" type="color3" nodename="bc_img"/>
+  </nodegraph>
+  <standard_surface name="oak_shader" type="surfaceshader">
+    <input name="base" type="float" value="1.0"/>
+    <input name="base_color" type="color3" nodegraph="ng" output="bc_out"/>
+    <input name="metalness" type="float" value="1.0"/>
+    <input name="specular_roughness" type="float" value="0.5"/>
+  </standard_surface>
+  <surfacematerial name="oak" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="oak_shader"/>
+  </surfacematerial>
+</materialx>
+"""
+
+
+_MTLX_METALNESS_TEXTURE_BOUND = b"""<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="ng">
+    <image name="m_img" type="float">
+      <input name="file" type="filename" value="oak_metalness.png"/>
+    </image>
+    <output name="m_out" type="float" nodename="m_img"/>
+  </nodegraph>
+  <standard_surface name="oak_shader" type="surfaceshader">
+    <input name="base" type="float" value="1.0"/>
+    <input name="base_color" type="color3" value="0.5, 0.5, 0.5"/>
+    <input name="metalness" type="float" nodegraph="ng" output="m_out"/>
+    <input name="specular_roughness" type="float" value="0.5"/>
+  </standard_surface>
+  <surfacematerial name="oak" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="oak_shader"/>
+  </surfacematerial>
+</materialx>
+"""
+
+
+_MTLX_AUTHORED_COLOR_AND_METAL = b"""<?xml version="1.0"?>
+<materialx version="1.38">
+  <standard_surface name="oak_shader" type="surfaceshader">
+    <input name="base" type="float" value="1.0"/>
+    <input name="base_color" type="color3" value="0.89, 0.89, 0.89"/>
+    <input name="metalness" type="float" value="0.5"/>
+    <input name="specular_roughness" type="float" value="0.5"/>
+  </standard_surface>
+  <surfacematerial name="oak" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="oak_shader"/>
+  </surfacematerial>
+</materialx>
+"""
+
+
+_MTLX_TEXTURE_BOUND_NO_TEXTURE = b"""<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="ng">
+    <image name="bc_img" type="color3">
+      <input name="file" type="filename" value="oak_basecolor.png"/>
+    </image>
+    <output name="bc_out" type="color3" nodename="bc_img"/>
+    <image name="m_img" type="float">
+      <input name="file" type="filename" value="oak_metalness.png"/>
+    </image>
+    <output name="m_out" type="float" nodename="m_img"/>
+  </nodegraph>
+  <standard_surface name="oak_shader" type="surfaceshader">
+    <input name="base" type="float" value="1.0"/>
+    <input name="base_color" type="color3" nodegraph="ng" output="bc_out"/>
+    <input name="metalness" type="float" nodegraph="ng" output="m_out"/>
+    <input name="specular_roughness" type="float" value="0.5"/>
+  </standard_surface>
+  <surfacematerial name="oak" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="oak_shader"/>
+  </surfacematerial>
+</materialx>
+"""
+
+
+def _zip_with(mtlx_bytes: bytes, *texture_basenames: str) -> bytes:
+    """Build a ZIP carrying the given mtlx + texture stubs."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("oak/material.mtlx", mtlx_bytes)
+        for tex in texture_basenames:
+            zf.writestr(f"oak/{tex}", b"\x89PNG\r\n\x1a\nfake")
+    return buf.getvalue()
+
+
+def test_metallic_colormap_neutralizes_color_when_texture_bound(tmp_path: Path) -> None:
+    """color_rgb is None (texture-bound) + color texture in baked records → [1,1,1]."""
+    mock_resp = MagicMock(content=_zip_with(_MTLX_BASE_COLOR_TEXTURE_BOUND, "oak_basecolor.png"))
+    with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
+        rec = _fetch_one(_mat(), "1k", tmp_path, mtlx_dir=None)
+
+    assert rec.status == "ok"
+    assert "color" in rec.maps
+    assert rec.mat_vis.pbr.color_rgb == [1.0, 1.0, 1.0]
+
+
+def test_metalness_neutralized_when_metalnessMap_bound(tmp_path: Path) -> None:
+    """metalness is None (texture-bound) + metalness texture shipped → 1.0."""
+    mock_resp = MagicMock(content=_zip_with(_MTLX_METALNESS_TEXTURE_BOUND, "oak_metalness.png"))
+    with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
+        rec = _fetch_one(_mat(), "1k", tmp_path, mtlx_dir=None)
+
+    assert rec.status == "ok"
+    assert "metalness" in rec.maps
+    assert rec.mat_vis.pbr.metalness == 1.0
+
+
+def test_authored_color_preserved_with_colormap(tmp_path: Path) -> None:
+    """Authored base_color + a color texture → authored value, NOT overridden."""
+    mock_resp = MagicMock(
+        content=_zip_with(_MTLX_AUTHORED_COLOR_AND_METAL, "oak_basecolor.png"),
+    )
+    with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
+        rec = _fetch_one(_mat(), "1k", tmp_path, mtlx_dir=None)
+
+    assert rec.mat_vis.pbr.color_rgb == [0.89, 0.89, 0.89]
+
+
+def test_authored_metalness_preserved_with_metalnessMap(tmp_path: Path) -> None:
+    """Authored metalness + a metalness texture → authored value, NOT overridden.
+
+    No metalness texture is needed for this test — just confirm a parsed
+    scalar isn't clobbered. We synthesize a ZIP with a basecolor (so the
+    fetch path is "ok") but no metalness texture; the convention stays
+    inert because parsed_pbr.metalness is already 0.5.
+    """
+    mock_resp = MagicMock(
+        content=_zip_with(_MTLX_AUTHORED_COLOR_AND_METAL, "oak_basecolor.png"),
+    )
+    with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
+        rec = _fetch_one(_mat(), "1k", tmp_path, mtlx_dir=None)
+
+    assert rec.mat_vis.pbr.metalness == 0.5
+
+
+def test_no_texture_no_convention(tmp_path: Path) -> None:
+    """Texture-bound (parser → None) + NO matching texture → field stays None.
+
+    The convention must NOT fire when the texture is missing: writing
+    [1,1,1] / 1.0 with no map present would lie about the substrate.
+    """
+    # mtlx says both base_color and metalness are texture-bound, but
+    # the ZIP ships NO image files → textures dict is empty.
+    mock_resp = MagicMock(content=_zip_with(_MTLX_TEXTURE_BOUND_NO_TEXTURE))
+    with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
+        rec = _fetch_one(_mat(), "1k", tmp_path, mtlx_dir=None)
+
+    # No textures shipped → fall through to the failed-fetch shorthand
+    # because _extract_from_zip returns no textures + an mtlx, the code
+    # takes the `needs_mtlx_bake` branch which DOES build a record.
+    assert rec.mat_vis.pbr.color_rgb is None
+    assert rec.mat_vis.pbr.metalness is None
+
+
+def test_dielectric_metallic_threshold(tmp_path: Path) -> None:
+    """No threshold at the baker — convention fires regardless of metalness.
+
+    The OLD adapter logic gated the color convention on ``metalness
+    >= 0.9``. At the baker we just check "color_rgb is None AND a
+    color texture is bound" because color=[1,1,1] is the right
+    multiplier for any texture-controlled-only color: glTF-MR
+    multiplies baseColorFactor × baseColorTexture identically for
+    metallic and dielectric materials, so a default-grey scalar would
+    double-tint the texture in EITHER case.
+
+    This dielectric (metalness=0.0) material with a texture-bound
+    color and a shipped colorMap therefore still gets color_rgb
+    neutralized to [1,1,1].
+    """
+    dielectric = _MTLX_BASE_COLOR_TEXTURE_BOUND.replace(
+        b'<input name="metalness" type="float" value="1.0"/>',
+        b'<input name="metalness" type="float" value="0.0"/>',
+    )
+    assert b'value="0.0"' in dielectric, "fixture rewrite failed"
+
+    mock_resp = MagicMock(content=_zip_with(dielectric, "oak_basecolor.png"))
+    with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
+        rec = _fetch_one(_mat(), "1k", tmp_path, mtlx_dir=None)
+
+    assert rec.mat_vis.pbr.metalness == 0.0  # parser preserved authored value
+    assert rec.mat_vis.pbr.color_rgb == [1.0, 1.0, 1.0]  # convention fired anyway
+
+
+# ── roughness symmetry (extends the convention to the third PBR slot) ──
+#
+# The original baker-side change covered color + metalness only. The
+# helper ``apply_pbr_neutral_multiplier_conventions`` now extends it to
+# roughness for symmetry: glTF-MR's ``roughnessFactor`` defaults to 1.0,
+# and the substrate index needs the explicit value for query
+# correctness — ``client.search()`` over ``pbr.roughness`` should match
+# materials with a bound roughnessMap.
+
+
+_MTLX_ROUGHNESS_TEXTURE_BOUND = b"""<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="ng">
+    <image name="r_img" type="float">
+      <input name="file" type="filename" value="oak_roughness.png"/>
+    </image>
+    <output name="r_out" type="float" nodename="r_img"/>
+  </nodegraph>
+  <standard_surface name="oak_shader" type="surfaceshader">
+    <input name="base" type="float" value="1.0"/>
+    <input name="base_color" type="color3" value="0.5, 0.5, 0.5"/>
+    <input name="metalness" type="float" value="0.0"/>
+    <input name="specular_roughness" type="float" nodegraph="ng" output="r_out"/>
+  </standard_surface>
+  <surfacematerial name="oak" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="oak_shader"/>
+  </surfacematerial>
+</materialx>
+"""
+
+
+def test_roughness_neutralized_when_roughnessMap_bound(tmp_path: Path) -> None:
+    """roughness is None (texture-bound) + roughness texture shipped → 1.0."""
+    mock_resp = MagicMock(
+        content=_zip_with(_MTLX_ROUGHNESS_TEXTURE_BOUND, "oak_roughness.png"),
+    )
+    with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
+        rec = _fetch_one(_mat(), "1k", tmp_path, mtlx_dir=None)
+
+    assert rec.status == "ok"
+    assert "roughness" in rec.maps
+    assert rec.mat_vis.pbr.roughness == 1.0

--- a/tests/test_pbr_conventions.py
+++ b/tests/test_pbr_conventions.py
@@ -1,0 +1,177 @@
+"""Unit tests for ``apply_pbr_neutral_multiplier_conventions``.
+
+Exercises the helper directly with every (field × texture × authored
+scalar) combination so a future change to the convention surface is
+caught immediately, independent of any individual fetcher.
+
+Convention contract (mat-vis#290 follow-up):
+- Iff ``pbr.<field>`` is None AND the matching channel is in the
+  texture set, write the glTF-MR neutral multiplier.
+- Authored (non-None) values are NEVER overridden.
+- Texture set with NO matching channel is a no-op.
+- Channels covered: ``color`` → ``color_rgb=[1,1,1]``,
+  ``metalness`` → ``metalness=1.0``, ``roughness`` → ``roughness=1.0``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mat_vis_baker.common import PBRBlock, apply_pbr_neutral_multiplier_conventions
+
+
+def _textures(*channels: str) -> dict[str, Path]:
+    """Build a fake texture-paths dict — values irrelevant, keys are."""
+    return {ch: Path(f"/tmp/{ch}.png") for ch in channels}
+
+
+# ── per-channel coverage ───────────────────────────────────────
+
+
+def test_color_neutralized_when_color_texture_present() -> None:
+    pbr = PBRBlock()
+    apply_pbr_neutral_multiplier_conventions(pbr, _textures("color"))
+    assert pbr.color_rgb == [1.0, 1.0, 1.0]
+
+
+def test_metalness_neutralized_when_metalness_texture_present() -> None:
+    pbr = PBRBlock()
+    apply_pbr_neutral_multiplier_conventions(pbr, _textures("metalness"))
+    assert pbr.metalness == 1.0
+
+
+def test_roughness_neutralized_when_roughness_texture_present() -> None:
+    """Symmetric third PBR slot — query correctness for the substrate."""
+    pbr = PBRBlock()
+    apply_pbr_neutral_multiplier_conventions(pbr, _textures("roughness"))
+    assert pbr.roughness == 1.0
+
+
+def test_all_three_channels_neutralized_simultaneously() -> None:
+    pbr = PBRBlock()
+    apply_pbr_neutral_multiplier_conventions(
+        pbr,
+        _textures("color", "metalness", "roughness"),
+    )
+    assert pbr.color_rgb == [1.0, 1.0, 1.0]
+    assert pbr.metalness == 1.0
+    assert pbr.roughness == 1.0
+
+
+# ── no-op cases ────────────────────────────────────────────────
+
+
+def test_empty_textures_is_noop() -> None:
+    pbr = PBRBlock()
+    apply_pbr_neutral_multiplier_conventions(pbr, {})
+    assert pbr.color_rgb is None
+    assert pbr.metalness is None
+    assert pbr.roughness is None
+
+
+def test_unrelated_textures_is_noop() -> None:
+    """Normal/AO/displacement/emission don't gate any PBR scalar."""
+    pbr = PBRBlock()
+    apply_pbr_neutral_multiplier_conventions(
+        pbr,
+        _textures("normal", "ao", "displacement", "emission"),
+    )
+    assert pbr.color_rgb is None
+    assert pbr.metalness is None
+    assert pbr.roughness is None
+
+
+# ── authored values are preserved ──────────────────────────────
+
+
+def test_authored_color_preserved() -> None:
+    pbr = PBRBlock(color_rgb=[0.5, 0.5, 0.5])
+    apply_pbr_neutral_multiplier_conventions(pbr, _textures("color"))
+    assert pbr.color_rgb == [0.5, 0.5, 0.5]
+
+
+def test_authored_metalness_preserved() -> None:
+    pbr = PBRBlock(metalness=0.3)
+    apply_pbr_neutral_multiplier_conventions(pbr, _textures("metalness"))
+    assert pbr.metalness == 0.3
+
+
+def test_authored_roughness_preserved() -> None:
+    pbr = PBRBlock(roughness=0.4)
+    apply_pbr_neutral_multiplier_conventions(pbr, _textures("roughness"))
+    assert pbr.roughness == 0.4
+
+
+def test_zero_authored_metalness_preserved() -> None:
+    """Authored 0.0 (dielectric) is NOT confused with None — must stay 0.0
+    even when a metalness texture is in the set. Truthiness traps would
+    overwrite this; the convention must use ``is None`` strictly.
+    """
+    pbr = PBRBlock(metalness=0.0)
+    apply_pbr_neutral_multiplier_conventions(pbr, _textures("metalness"))
+    assert pbr.metalness == 0.0
+
+
+def test_partial_authored_partial_neutralized() -> None:
+    """Authored color + texture-bound metalness → color preserved,
+    metalness filled."""
+    pbr = PBRBlock(color_rgb=[0.7, 0.2, 0.1])
+    apply_pbr_neutral_multiplier_conventions(pbr, _textures("color", "metalness"))
+    assert pbr.color_rgb == [0.7, 0.2, 0.1]
+    assert pbr.metalness == 1.0
+
+
+# ── return value ───────────────────────────────────────────────
+
+
+def test_returns_same_pbr_for_chaining() -> None:
+    """Helper returns the input PBRBlock to enable chained construction."""
+    pbr = PBRBlock()
+    result = apply_pbr_neutral_multiplier_conventions(pbr, _textures("color"))
+    assert result is pbr
+
+
+# ── adapter sync regression (audit-1 finding) ──────────────────
+
+
+def test_synthesizer_skips_scalar_input_when_metalness_texture_bound() -> None:
+    """Regression (audit-1 finding): when the baker injects
+    ``pbr.metalness=1.0`` AND a metalness texture exists, the .mtlx
+    synthesizer must NOT emit a *scalar* ``<input ... value="..."/>``
+    for that channel — it should emit only the nodegraph reference so
+    the texture is the sole driver.
+
+    Pins ``adapters._build_mtlx_tree`` behavior so a future change can't
+    silently regress the baker→adapter handshake.
+    """
+    from mat_vis_client.adapters import _build_mtlx_tree, _mtlx_tree_to_string
+
+    scalars = {"metalness": 1.0, "roughness": 1.0}
+    tex_filenames = {"metalness": "mat_metalness.png", "roughness": "mat_roughness.png"}
+
+    root = _build_mtlx_tree(scalars, tex_filenames, "mat")
+    xml = _mtlx_tree_to_string(root)
+
+    # No scalar value attribute on the metallic / roughness inputs —
+    # the nodegraph reference is the only contributor.
+    assert 'name="metallic" type="float" value="' not in xml
+    assert 'name="roughness" type="float" value="' not in xml
+    # Sanity: the nodegraph references DO exist (texture-driven).
+    assert 'name="metallic" type="float" nodegraph="mat_textures"' in xml
+    assert 'name="roughness" type="float" nodegraph="mat_textures"' in xml
+
+
+def test_synthesizer_emits_scalar_when_no_metalness_texture() -> None:
+    """Companion: with metalness scalar set but NO metalness texture,
+    the synthesizer DOES emit the scalar shader input. This is the
+    other half of the handshake — clears the regression test's claim."""
+    from mat_vis_client.adapters import _build_mtlx_tree, _mtlx_tree_to_string
+
+    scalars = {"metalness": 1.0, "roughness": 0.5}
+    tex_filenames: dict[str, str] = {}  # no textures at all
+
+    root = _build_mtlx_tree(scalars, tex_filenames, "mat")
+    xml = _mtlx_tree_to_string(root)
+
+    assert 'name="metallic" type="float" value="1.0"' in xml
+    assert 'name="roughness" type="float" value="0.5"' in xml

--- a/tests/test_polyhaven_extractor.py
+++ b/tests/test_polyhaven_extractor.py
@@ -218,3 +218,80 @@ def test_upstream_allowlist_locks_conservative_keyset() -> None:
     assert "authors" in UPSTREAM_ALLOWLIST
     assert "files_hash" not in UPSTREAM_ALLOWLIST
     assert "thumbnail_url" not in UPSTREAM_ALLOWLIST
+
+
+# ── glTF-MR neutral-multiplier convention (mat-vis#290 follow-up) ──
+#
+# Polyhaven doesn't expose scalar PBR properties upstream — the only
+# path that can populate ``pbr.*`` is the baker-side convention. These
+# tests pin that wire-up so the substrate carries spec-aligned scalars
+# whenever the matching texture is in the baked set, and stays
+# all-None otherwise.
+
+
+def _multi_channel_file_info(tier_key: str = "1k") -> dict:
+    """polyhaven ``/files/<slug>`` shape with color + metalness + roughness."""
+    return {
+        "Diffuse": {tier_key: {"png": {"url": "https://example.com/diff.png"}}},
+        "metal": {tier_key: {"png": {"url": "https://example.com/metal.png"}}},
+        "rough": {tier_key: {"png": {"url": "https://example.com/rough.png"}}},
+    }
+
+
+def test_polyhaven_pbr_convention_applied(tmp_path: Path) -> None:
+    """color + metalness + roughness textures → all three scalars filled."""
+    meta = _meta()
+    png_resp = MagicMock(content=b"\x89PNG\r\n\x1a\nfake")
+    with (
+        patch(
+            "mat_vis_baker.sources.polyhaven._fetch_files",
+            return_value=_multi_channel_file_info(),
+        ),
+        patch("mat_vis_baker.sources.polyhaven.retry_request", return_value=png_resp),
+    ):
+        rec = _fetch_one("wood_floor", meta, "1k", tmp_path)
+
+    assert rec.status == "ok"
+    assert set(rec.maps) >= {"color", "metalness", "roughness"}
+    assert rec.mat_vis.pbr.color_rgb == [1.0, 1.0, 1.0]
+    assert rec.mat_vis.pbr.metalness == 1.0
+    assert rec.mat_vis.pbr.roughness == 1.0
+
+
+def test_polyhaven_pbr_no_convention_when_no_texture(tmp_path: Path) -> None:
+    """No matching texture in the baked set → pbr scalar stays None.
+
+    Driven via the existing single-channel ``_file_info()`` helper —
+    only ``Diffuse`` ships, so color_rgb fills but metalness / roughness
+    must NOT.
+    """
+    meta = _meta()
+    png_resp = MagicMock(content=b"\x89PNG\r\n\x1a\nfake")
+    with (
+        patch("mat_vis_baker.sources.polyhaven._fetch_files", return_value=_file_info()),
+        patch("mat_vis_baker.sources.polyhaven.retry_request", return_value=png_resp),
+    ):
+        rec = _fetch_one("wood_floor", meta, "1k", tmp_path)
+
+    assert rec.status == "ok"
+    assert "color" in rec.maps
+    assert "metalness" not in rec.maps
+    assert "roughness" not in rec.maps
+    assert rec.mat_vis.pbr.color_rgb == [1.0, 1.0, 1.0]
+    assert rec.mat_vis.pbr.metalness is None
+    assert rec.mat_vis.pbr.roughness is None
+
+
+def test_polyhaven_pbr_all_none_on_failed_fetch(tmp_path: Path) -> None:
+    """Failed-fetch path (textures empty) → pbr stays the default
+    empty PBRBlock with everything None."""
+    meta = _meta()
+    with (
+        patch("mat_vis_baker.sources.polyhaven._fetch_files", return_value={}),
+    ):
+        rec = _fetch_one("wood_floor", meta, "1k", tmp_path)
+
+    assert rec.status == "failed"
+    assert rec.mat_vis.pbr.color_rgb is None
+    assert rec.mat_vis.pbr.metalness is None
+    assert rec.mat_vis.pbr.roughness is None


### PR DESCRIPTION
## Summary

#290 spike landed the parser + adapter conventions for the metallic+colorMap case. Two parallel post-cut audits + end-to-end tst verification revealed the **adapter placement was wrong** — the convention belongs in the baker. This PR fixes that AND extends to all three textured sources (the audits found polyhaven and ambientcg never populated `pbr=PBRBlock(...)` at all).

## Why move from adapter to baker

1. **Cross-language consistency** — JS / Rust / shell clients don't get the convention; each must re-implement. Convention in baker = every reader inherits from substrate for free.
2. **Search ranker correctness** — `client.search(metallic=True)` reads `pbr.metalness` from the substrate index, bypasses adapters. Today Aluminum Hexagon / Bronze Oxydized / Perforated Metal query as non-metallic. Baker-side fix makes the index itself correct.
3. **MaterialX standard** — `MaterialX.TextureBaker` post-eval semantics are exactly: terminal-as-image → emit neutral multiplier. We're matching the spec, not inventing.
4. **Round-1 reviewer's "to_mtlx truth" objection doesn't hold** — the synthesized .mtlx adapter at `adapters.py::_build_mtlx_tree` already guards `if metalness not in tex_filenames` and correctly suppresses scalar emission when textures are bound. No contradictory output.

## Shared helper

In `src/mat_vis_baker/common.py`:

```python
def apply_pbr_neutral_multiplier_conventions(pbr: PBRBlock, textures: dict) -> PBRBlock:
    if pbr.color_rgb is None and "color" in textures:
        pbr.color_rgb = [1.0, 1.0, 1.0]
    if pbr.metalness is None and "metalness" in textures:
        pbr.metalness = 1.0
    if pbr.roughness is None and "roughness" in textures:
        pbr.roughness = 1.0
    return pbr
```

Channel naming canonical via `normalize_channel` — uniform across gpuopen / polyhaven / ambientcg fetchers.

## 3-source coverage

- `gpuopen.py` — inline logic replaced with shared helper; gains roughness symmetry
- `polyhaven.py` — first time `pbr=PBRBlock()` constructed; convention applied
- `ambientcg.py` — same shape

## Adapter cleanup

- Deleted `_apply_metallic_colormap_convention` (no defensive no-op — would silently mask substrate bugs)
- KHR ior/transmission default-suppression in `to_gltf` STAYS (genuinely glTF-format-specific)

## Tests — 27 new, 710 total green

- `tests/test_pbr_conventions.py` (new, 14): full helper coverage including `metalness=0.0` truthiness trap, chaining, adapter handshake regression
- `test_polyhaven_extractor.py` (+3) and `test_ambientcg_extractor.py` (+3)
- `test_gpuopen_baker.py` (+1): roughness symmetry
- `test_adapters_metalcolormap.py` replaced with "dumb adapter" contract; KHR-suppression tests preserved

## Behavior change for direct adapter callers

`to_threejs({"metalness": 1.0}, {"color": png})` used to auto-inject `color=0xFFFFFF`; now returns no `color` key. Direct adapter callers must apply the convention themselves. Substrate-fed callers (`VisAsset.to_threejs()`) inherit it from the baked PBRBlock — no break for the normal path.

## Test plan

- [x] `just test-fast` green (447 baker + 263 client + 27 skipped)
- [ ] CI green
- [ ] After merge: re-bake tst with `limit=0` for gpuopen, polyhaven, ambientcg → verify Aluminum Hexagon, Bronze Oxydized, Perforated Metal, plus polyhaven + ambientcg materials all carry populated `pbr.*` for the texture-backed channels
- [ ] Verify `client.search` queries against tst now return the full metals set across all three sources

## Out of scope (filed separately)

- Stale `clients/python/adapters.py` duplicate (audit B5)
- Catalog wholesale-replace `available_tiers` clobber (audit; not PBR-specific)
- Cross-tier PBR invariance test
- `transmission × transmissionMap` symmetric (no transmission channel today)

Refs: build123d#1270, mat-vis#290, mat-vis#291, mat-vis#292.