### PR TITLE
bugfix(clients): SIGPIPE-harden test_client.sh (closes #297)

### DIFF
--- a/clients/test_client.sh
+++ b/clients/test_client.sh
@@ -279,7 +279,10 @@ live_tests() {
 
     local mats first
     mats=$("$CLIENT" materials ambientcg 1k)
-    first=$(echo "$mats" | head -1)
+    # #297: avoid `echo "$mats" | head -1` — under `set -o pipefail`, when
+    # $mats exceeds the kernel pipe buffer (64 KiB on Linux) `head` exits
+    # after one line, the producer SIGPIPEs, and the script aborts 141.
+    IFS= read -r first <<< "$mats" || true
     [ -n "$first" ] || { echo "  FAIL materials list empty"; FAIL=$((FAIL + 1)); return; }
     echo "  PASS materials list non-empty (first=$first)"
     PASS=$((PASS + 1))
@@ -325,7 +328,10 @@ live_tests() {
                 FAIL=$((FAIL + 1)); fails_248=$((fails_248 + 1))
                 continue
             fi
-            first=$(echo "$mats" | head -1)
+            # #297: see comment at the structural-tests call site —
+            # `echo "$mats" | head -1` SIGPIPEs under pipefail when the
+            # producer exceeds the pipe buffer.
+            IFS= read -r first <<< "$mats" || true
             if [ -z "$first" ]; then
                 # Documented expected: some sources publish a tier but
                 # carry no records with that tier in their catalog.
@@ -398,7 +404,8 @@ cmd_e2e() {
         FAIL=$((FAIL + 1))
         return
     fi
-    first=$(echo "$mats" | head -1)
+    # #297: same pipefail+SIGPIPE hazard as the structural call site.
+    IFS= read -r first <<< "$mats" || true
     if [ -z "$first" ]; then
         echo "  FAIL polyhaven materials list empty (did the Python E2E suite bake the tag?)"
         FAIL=$((FAIL + 1))


### PR DESCRIPTION
## Summary

- Root-causes #297. The `Client tests (all languages)` flake is **not** a Dagger engine cold-pull race (as the issue body originally hypothesized); it is a real bash bug in `clients/test_client.sh`: `first=\$(echo \"\$mats\" | head -1)` under `set -euo pipefail` SIGPIPEs the producer once `\$mats` exceeds the 64 KiB kernel pipe buffer, and pipefail bubbles exit 141. Three call sites (lines 282, 328, 401), all in code paths that consume materials lists which routinely cross 64 KiB at 1k tier.
- Fix: replace each pipeline command-substitution with `IFS= read -r first <<< \"\$mats\" || true` (here-string, no pipe → no SIGPIPE class). `set -o pipefail` stays on for the rest of the script.
- 3-line diff. No behavioral change for materials-list parsing — `read -r` still grabs the first line up to the first newline; the `[ -n \"\$first\" ]` empty-list check still fires correctly.

## Spike provenance

Surfaced by 3-angle sub-agent review of #297 (bash/SIGPIPE specialist + Dagger SDK/IPC + CI reliability):
- All three agents converged that the cold-pull hypothesis is wrong (full PASS log → 141 → no summary line is the SIGPIPE fingerprint, not pull-time).
- Bash agent identified the exact culprit lines. Two follow-ups were also surfaced:
  - **#307** — `asyncio.gather` in `test_clients` orphans sibling client containers on first failure (separate correctness bug).
  - **(forthcoming PR)** — reusable `dagger-call.yml` workflow with `retry_on_exit_code: 141` for defense-in-depth.

## Test plan

- [ ] Push triggers CI; `Client tests (all languages)` job exits 0 cleanly with the summary line `\"X passed, 0 failed\"`.
- [ ] If a flake recurs on this PR or after merge, it is unrelated to #297's root cause and lives in #307 / runner-infra territory.