### PR TITLE
bugfix(ci): collect test_clients results with return_exceptions=True (closes #307)

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -432,14 +432,31 @@ class MatVisCi:
         sh_task = asyncio.ensure_future(self.test_client_shell(context, tag, live))
         rs_task = asyncio.ensure_future(self.test_client_rust(context, tag, live))
 
-        py_out, js_out, sh_out, rs_out = await asyncio.gather(py_task, js_task, sh_task, rs_task)
+        # #307: collect results with `return_exceptions=True` so a single
+        # client failure doesn't orphan the other 3 containers (default
+        # `gather()` raises on the first exception, drops the rest, and
+        # CI never sees whether the siblings had real signal). Assemble
+        # a structured report and re-raise after all 4 resolve.
+        results = await asyncio.gather(py_task, js_task, sh_task, rs_task, return_exceptions=True)
+        labels = ("python", "js", "shell", "rust")
 
-        return (
-            f"=== python ===\n{py_out}\n"
-            f"=== js ===\n{js_out}\n"
-            f"=== shell ===\n{sh_out}\n"
-            f"=== rust ===\n{rs_out}"
-        )
+        sections: list[str] = []
+        failures: list[tuple[str, BaseException]] = []
+        for label, result in zip(labels, results, strict=True):
+            if isinstance(result, BaseException):
+                failures.append((label, result))
+                sections.append(f"=== {label} (FAILED: {result!r}) ===")
+            else:
+                sections.append(f"=== {label} ===\n{result}")
+
+        report = "\n".join(sections)
+        if failures:
+            failed_labels = ", ".join(label for label, _ in failures)
+            raise RuntimeError(
+                f"test_clients: {len(failures)}/{len(labels)} suite(s) failed "
+                f"({failed_labels}). Full report:\n\n{report}"
+            )
+        return report
 
     # ── integration test ──────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Closes #307. `test_clients` was using `asyncio.gather(...)` with the default `return_exceptions=False`, which raises on the first exception and silently drops the remaining tasks' results — so a single shell-suite failure (e.g. the #297 SIGPIPE flake) would orphan the python/js/rust containers and CI never saw whether the siblings had real signal.
- Switch to `return_exceptions=True`, assemble a per-suite section in the report (passes inline, failures tagged with the exception repr), then raise a single \`RuntimeError\` carrying all 4 outputs after every task resolves. Triage now sees every suite's stdout regardless of which one(s) failed.
- No behavior change on the all-pass path — the same concatenated report is returned.

## Spike provenance

Surfaced by the #297 spike (sub-agent review, Dagger SDK / IPC angle, 2026-05-07). Independent of the SIGPIPE root cause in #297; this fix applies regardless.

## Test plan

- [ ] CI's \`Client tests (all languages)\` job exits 0 when all 4 suites pass — same green output as today.
- [ ] If any suite fails, the raised RuntimeError's message contains stdout sections for ALL 4 suites (failed + passed), and no \"Task exception was never retrieved\" warning is emitted.