### PR TITLE
feat(client): accept 'metallic' as alias for 'metalness' in adapters (#303)

### DIFF
--- a/clients/python/src/mat_vis_client/adapters.py
+++ b/clients/python/src/mat_vis_client/adapters.py
@@ -85,6 +85,24 @@ def _color_hex_to_rgba(hex_str: str) -> list[float]:
     return [r / 255.0, g / 255.0, b / 255.0, 1.0]
 
 
+def _resolve_metalness(scalars: dict) -> float | None:
+    """Resolve the metalness scalar accepting ``metallic`` as a glTF-spec alias.
+
+    Three.js MeshPhysicalMaterial uses ``metalness``; glTF 2.0 spec calls
+    the JSON field ``metallicFactor`` and the property *metallic*; py-mat
+    stores it as ``metallic`` on its public ``Vis`` surface. Adapters
+    accept either input key. ADR-0013 §Decision-3 / #303.
+    """
+    metalness = scalars.get("metalness")
+    metallic = scalars.get("metallic")
+    if metalness is not None and metallic is not None and metalness != metallic:
+        raise ValueError(
+            "scalars contains both 'metalness' and 'metallic' with non-equal "
+            f"values ({metalness!r} vs {metallic!r}); pick one"
+        )
+    return metalness if metalness is not None else metallic
+
+
 # ── Three.js adapter ───────────────────────────────────────────
 
 
@@ -96,7 +114,9 @@ def to_threejs(
 
     Args:
         scalars: Material scalars. Expected keys (all optional):
-            - metalness (float 0-1)
+            - metalness (float 0-1) — also accepted as ``metallic``
+              (glTF-spec alias). Setting both with non-equal values
+              raises ValueError.
             - roughness (float 0-1)
             - color_hex (str '#RRGGBB')
             - ior (float)
@@ -122,8 +142,9 @@ def to_threejs(
     result: dict = {"type": "MeshPhysicalMaterial"}
 
     # Scalars
-    if "metalness" in scalars and scalars["metalness"] is not None:
-        result["metalness"] = scalars["metalness"]
+    metalness = _resolve_metalness(scalars)
+    if metalness is not None:
+        result["metalness"] = metalness
     if "roughness" in scalars and scalars["roughness"] is not None:
         result["roughness"] = scalars["roughness"]
     if "color_hex" in scalars and scalars["color_hex"] is not None:
@@ -179,8 +200,9 @@ def to_gltf(
     material: dict = {"pbrMetallicRoughness": pbr}
 
     # Scalar factors
-    if "metalness" in scalars and scalars["metalness"] is not None:
-        pbr["metallicFactor"] = scalars["metalness"]
+    metalness = _resolve_metalness(scalars)
+    if metalness is not None:
+        pbr["metallicFactor"] = metalness
     if "roughness" in scalars and scalars["roughness"] is not None:
         pbr["roughnessFactor"] = scalars["roughness"]
     if "color_hex" in scalars and scalars["color_hex"] is not None:
@@ -334,11 +356,9 @@ def _build_mtlx_tree(
             ET.SubElement(
                 shader, "input", name="roughness", type="float", value=str(scalars["roughness"])
             )
-    if "metalness" in scalars and scalars["metalness"] is not None:
-        if "metalness" not in tex_filenames:
-            ET.SubElement(
-                shader, "input", name="metallic", type="float", value=str(scalars["metalness"])
-            )
+    metalness = _resolve_metalness(scalars)
+    if metalness is not None and "metalness" not in tex_filenames:
+        ET.SubElement(shader, "input", name="metallic", type="float", value=str(metalness))
     if "ior" in scalars and scalars["ior"] is not None:
         ET.SubElement(shader, "input", name="ior", type="float", value=str(scalars["ior"]))
 

--- a/clients/python/tests/test_adapters_aliases.py
+++ b/clients/python/tests/test_adapters_aliases.py
@@ -1,0 +1,83 @@
+"""Tests for adapter input-key aliases (ADR-0013 §Decision-3).
+
+py-mat and other downstream wrappers store PBR scalars under glTF-spec
+names (``metallic``); mat-vis adapters historically accept only the
+Three.js naming (``metalness``). Every wrapper performs a manual
+rename at the boundary. ADR-0013 promotes the glTF name to a
+first-class accepted alias on the input side, with the canonical
+output name unchanged per adapter (Three.js: ``metalness``; glTF:
+``metallicFactor``; MTLX: ``metallic``).
+
+Conflict rule: setting both ``metallic`` and ``metalness`` with
+non-equal non-None values raises ``ValueError``. Equal values pass
+through silently. None on either side defers to the other.
+
+#303.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mat_vis_client.adapters import export_mtlx, to_gltf, to_threejs
+
+
+class TestMetallicAlias:
+    """``metallic`` (glTF spec) accepted as alias for ``metalness`` (Three.js)."""
+
+    def test_to_threejs_metallic_resolves_to_metalness(self):
+        result = to_threejs({"metallic": 0.8})
+        assert result["metalness"] == 0.8
+
+    def test_to_gltf_metallic_resolves_to_metallicFactor(self):
+        result = to_gltf({"metallic": 0.8})
+        assert result["pbrMetallicRoughness"]["metallicFactor"] == 0.8
+
+    def test_to_threejs_metallic_zero_distinguished_from_missing(self):
+        result = to_threejs({"metallic": 0.0})
+        assert result["metalness"] == 0.0
+
+    def test_to_threejs_metalness_still_works(self):
+        result = to_threejs({"metalness": 0.7})
+        assert result["metalness"] == 0.7
+
+    def test_to_threejs_both_keys_equal_values_pass(self):
+        result = to_threejs({"metalness": 0.5, "metallic": 0.5})
+        assert result["metalness"] == 0.5
+
+    def test_to_gltf_both_keys_equal_values_pass(self):
+        result = to_gltf({"metalness": 0.5, "metallic": 0.5})
+        assert result["pbrMetallicRoughness"]["metallicFactor"] == 0.5
+
+    def test_to_threejs_both_keys_conflict_raises(self):
+        with pytest.raises(ValueError, match="metalness.*metallic"):
+            to_threejs({"metalness": 0.7, "metallic": 0.9})
+
+    def test_to_gltf_both_keys_conflict_raises(self):
+        with pytest.raises(ValueError, match="metalness.*metallic"):
+            to_gltf({"metalness": 0.7, "metallic": 0.9})
+
+    def test_to_threejs_metalness_none_defers_to_metallic(self):
+        result = to_threejs({"metalness": None, "metallic": 0.6})
+        assert result["metalness"] == 0.6
+
+    def test_to_threejs_metallic_none_defers_to_metalness(self):
+        result = to_threejs({"metalness": 0.4, "metallic": None})
+        assert result["metalness"] == 0.4
+
+    def test_export_mtlx_metallic_resolves_to_metallic_input(self, tmp_path: Path):
+        # MTLX UsdPreviewSurface uses the glTF-spec name on its input —
+        # <input name="metallic" type="float" value="..."/>. So input
+        # alias and output name happen to coincide for this adapter; the
+        # test pins that ``metallic`` reaches the shader regardless of
+        # which input key the caller used.
+        mtlx_path = export_mtlx({"metallic": 0.8}, output_dir=tmp_path)
+        xml = mtlx_path.read_text()
+        assert 'name="metallic"' in xml
+        assert 'value="0.8"' in xml
+
+    def test_export_mtlx_both_keys_conflict_raises(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="metalness.*metallic"):
+            export_mtlx({"metalness": 0.7, "metallic": 0.9}, output_dir=tmp_path)


### PR DESCRIPTION
## Summary

- Adds ``_resolve_metalness()`` helper that accepts either ``metalness`` (Three.js) or ``metallic`` (glTF spec / py-mat) on input.
- Raises ``ValueError`` when both keys are set with non-equal non-None values; equal values pass; ``None`` on either side defers to the other.
- Wired through ``to_threejs``, ``to_gltf``, and ``export_mtlx`` so all three adapters share the same input contract.
- Output naming is unchanged per adapter (Three.js: ``metalness``, glTF: ``metallicFactor``, MTLX: ``metallic``).

## Why

py-mat's ``Vis`` field is named ``metallic`` (glTF-spec convention); every downstream wrapper has been doing a manual rename. ADR-0013 §Decision-3 promotes the glTF name to a first-class accepted alias on the input boundary. py-mat 0.6.5+ can drop its rename.

## Test plan

- [x] 12 new pytest cases in ``test_adapters_aliases.py`` covering: alias resolution per adapter, equal-values pass-through, conflict ValueError, ``None`` deference, zero-distinguished-from-missing.
- [x] ``uv run pytest tests/`` (client suite): 273 passed, 26 skipped, no regressions.
- [x] ``just test-fast`` (root + client): 447 passed, 16 skipped.

## Out of scope

- Output-shape changes (color int→string, baseColorFactor linear) — held for the 0.7.0 cut.
- Additional input aliases (``base_color_linear``, ``color_rgba``, ``emissive``, ``clearcoat``) — separate PRs per their issues.

Closes #303. Refs ADR-0013, #3.