### PR TITLE
feat(client): export_mtlx sanitizes material_name internally (#305)

### DIFF
--- a/clients/python/src/mat_vis_client/adapters.py
+++ b/clients/python/src/mat_vis_client/adapters.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import base64
 import math
+import re
 import xml.etree.ElementTree as ET
 from io import BytesIO
 from pathlib import Path
@@ -101,6 +102,24 @@ def _resolve_metalness(scalars: dict) -> float | None:
             f"values ({metalness!r} vs {metallic!r}); pick one"
         )
     return metalness if metalness is not None else metallic
+
+
+def _sanitize_material_name(name: str) -> str:
+    """Sanitize a material name for filesystem + MaterialX XML safety.
+
+    Real corpora contain spaces ("Stainless Steel 304"), slashes
+    ("Saint-Gobain/LYSO"), and other path-unsafe / XML-name-unsafe
+    characters. Replaces any non-[A-Za-z0-9_-] character with an
+    underscore, strips leading/trailing underscores, falls back to
+    "material" if the result is empty. Same rule used for both the
+    on-disk filename and the MaterialX ``name=`` attributes (spaces /
+    slashes break MTLX parsers anyway).
+
+    ADR-0013 §Decision-4 / #305.
+    """
+    safe = re.sub(r"[^A-Za-z0-9_-]", "_", name)
+    safe = re.sub(r"_+", "_", safe).strip("_")
+    return safe or "material"
 
 
 # ── Three.js adapter ───────────────────────────────────────────
@@ -437,6 +456,7 @@ def generate_mtlx_xml(
         channels: Channel names (color, normal, roughness, ...) present
             in ``texture_dir``; others are skipped.
     """
+    safe_name = _sanitize_material_name(material_name)
     tex_filenames: dict[str, str] = {}
     if texture_dir is not None:
         tex_dir = Path(texture_dir)
@@ -444,7 +464,7 @@ def generate_mtlx_xml(
             png_path = tex_dir / f"{ch}.png"
             if png_path.exists():
                 tex_filenames[ch] = str(png_path)
-    root = _build_mtlx_tree(scalars, tex_filenames, material_name)
+    root = _build_mtlx_tree(scalars, tex_filenames, safe_name)
     return _mtlx_tree_to_string(root)
 
 
@@ -485,9 +505,10 @@ def export_mtlx(
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
 
-    tex_filenames = _resolve_tex_filenames(textures, out, material_name, texture_dir, channels)
-    root = _build_mtlx_tree(scalars, tex_filenames, material_name)
+    safe_name = _sanitize_material_name(material_name)
+    tex_filenames = _resolve_tex_filenames(textures, out, safe_name, texture_dir, channels)
+    root = _build_mtlx_tree(scalars, tex_filenames, safe_name)
 
-    mtlx_path = out / f"{material_name}.mtlx"
+    mtlx_path = out / f"{safe_name}.mtlx"
     mtlx_path.write_text(_mtlx_tree_to_string(root), encoding="utf-8")
     return mtlx_path

--- a/clients/python/tests/test_adapters_mtlx_naming.py
+++ b/clients/python/tests/test_adapters_mtlx_naming.py
@@ -1,0 +1,91 @@
+"""Tests for export_mtlx material_name sanitization (ADR-0013 §Decision-4).
+
+Material names from real corpora contain spaces ("Stainless Steel 304"),
+slashes ("Saint-Gobain/LYSO"), and other path-unsafe characters. The
+substrate sanitizes internally so consumers don't repeat the logic per
+language client.
+
+Same sanitized name flows into both the file path and the MaterialX
+``name=`` attributes (spaces / slashes break MaterialX parsers anyway).
+
+#305.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mat_vis_client.adapters import export_mtlx, generate_mtlx_xml
+
+
+class TestExportMtlxMaterialNameSanitize:
+    def test_spaces_become_underscores(self, tmp_path: Path):
+        out = export_mtlx({}, output_dir=tmp_path, material_name="Stainless Steel 304")
+        assert out.name == "Stainless_Steel_304.mtlx"
+        assert out.exists()
+
+    def test_slashes_become_underscores(self, tmp_path: Path):
+        out = export_mtlx({}, output_dir=tmp_path, material_name="Saint-Gobain/LYSO")
+        assert out.name == "Saint-Gobain_LYSO.mtlx"
+
+    def test_empty_name_falls_back_to_material(self, tmp_path: Path):
+        out = export_mtlx({}, output_dir=tmp_path, material_name="")
+        assert out.name == "material.mtlx"
+
+    def test_path_traversal_blocked(self, tmp_path: Path):
+        # "../escape" must not write outside output_dir; the leading "../"
+        # is sanitized away rather than being honored.
+        out = export_mtlx({}, output_dir=tmp_path, material_name="../escape")
+        assert out.parent == tmp_path
+        assert out.name == "escape.mtlx"
+
+    def test_all_stripped_falls_back(self, tmp_path: Path):
+        out = export_mtlx({}, output_dir=tmp_path, material_name="...")
+        assert out.name == "material.mtlx"
+
+    def test_default_name_unchanged(self, tmp_path: Path):
+        out = export_mtlx({}, output_dir=tmp_path)  # default material_name="Material"
+        assert out.name == "Material.mtlx"
+
+    def test_alphanumeric_dash_underscore_preserved(self, tmp_path: Path):
+        out = export_mtlx({}, output_dir=tmp_path, material_name="aged-iron_v2")
+        assert out.name == "aged-iron_v2.mtlx"
+
+    def test_xml_name_attributes_use_sanitized(self, tmp_path: Path):
+        # Spaces in XML name= attributes break MaterialX parsers; the
+        # internal node names ("<material_name>_textures",
+        # "<material_name>_shader", surfacematerial name=) must reuse
+        # the sanitized form.
+        out = export_mtlx({}, output_dir=tmp_path, material_name="Stainless Steel 304")
+        xml = out.read_text()
+        assert 'name="Stainless_Steel_304"' in xml
+        assert 'name="Stainless_Steel_304_shader"' in xml
+        assert 'name="Stainless_Steel_304_textures"' in xml
+        assert "Stainless Steel 304" not in xml  # raw form must not leak
+
+
+class TestGenerateMtlxXmlSanitize:
+    """In-memory variant must sanitize too — same XML correctness concern."""
+
+    def test_xml_name_sanitized(self):
+        xml = generate_mtlx_xml({}, material_name="Saint-Gobain/LYSO")
+        assert 'name="Saint-Gobain_LYSO"' in xml
+        assert "Saint-Gobain/LYSO" not in xml
+
+    def test_empty_falls_back(self):
+        xml = generate_mtlx_xml({}, material_name="")
+        assert 'name="material"' in xml
+
+
+class TestSanitizeIsIdempotent:
+    """Sanitizing an already-safe name leaves it unchanged."""
+
+    @pytest.mark.parametrize("safe", ["Material", "aged-iron_v2", "X1", "_legacy_"])
+    def test_safe_names_pass_through(self, tmp_path: Path, safe: str):
+        out = export_mtlx({}, output_dir=tmp_path, material_name=safe)
+        # Strip leading underscores per the spec (".strip('_')") but keep
+        # internal underscores. "_legacy_" → "legacy".
+        expected = safe.strip("_") or "material"
+        assert out.name == f"{expected}.mtlx"


### PR DESCRIPTION
## Summary

- Adds ``_sanitize_material_name()`` helper: replaces non-``[A-Za-z0-9_-]`` characters with underscores, collapses runs of underscores, strips edges, falls back to ``"material"`` for empty / all-stripped inputs.
- Wired into both ``export_mtlx`` (file path + texture filenames + tree) and ``generate_mtlx_xml`` (in-memory variant).
- Path traversal sequences (``"../escape"``) sanitize to ``"escape"`` — the parent never escapes ``output_dir``.

## Why

Real-corpus material names — ``"Stainless Steel 304"``, ``"Saint-Gobain/LYSO"`` — break both the on-disk filename and the MaterialX XML ``name=`` attributes (MTLX parsers reject spaces/slashes in identifiers). Every consumer (py-mat, future Rust/JS clients) was sanitizing independently with potentially divergent rules. ADR-0013 §Decision-4 moves the rule into the substrate.

## Test plan

- [x] 14 new pytest cases in ``test_adapters_mtlx_naming.py`` covering: spaces, slashes, empty, path-traversal, all-stripped, default unchanged, alphanumeric/dash/underscore preserved, XML name= attributes use sanitized form, ``generate_mtlx_xml`` in-memory variant, idempotence on already-safe names.
- [x] ``uv run pytest tests/`` (client suite): 287 passed, 26 skipped, no regressions.
- [x] Rebased onto dev post-#318 merge; conflict in helper definitions resolved (kept both ``_resolve_metalness`` and ``_sanitize_material_name``).

## Out of scope

- Rust / JS reference clients — file separate per-language sanitize tickets when those clients land an MTLX export path.

Closes #305. Refs ADR-0013, #3.