### PR TITLE
feat(baker): release-matrix as canonical (source × tier) source-of-truth (#306 P0)

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -9,6 +9,8 @@ Usage:
     dagger call smoke-materialx      # verify MaterialX import (heavy)
     dagger call smoke-baker          # verify baker container (#135)
     dagger call bake                 # per-file hf-bake → atomic HF commit (#136 / ADR-0012)
+    dagger call bake-matrix          # bake every cell in a release line (#306)
+    dagger call release-matrix       # JSON cells for a release line (#306)
     dagger call smoke-bake           # dry-run bake against gerchowl/mat-vis-tst (#136)
     dagger call derive               # per-file hf-derive (resize) (#204)
     dagger call derive-ktx-2         # per-file hf-derive-ktx2 (#204; #240)
@@ -677,6 +679,128 @@ class MatVisCi:
             allow_prod=allow_prod,
         )
         return await ctr.with_exec(argv).stdout()
+
+    # ── release matrix (mat-vis#306) ──────────────────────────────
+    #
+    # The (source × tier) cells that constitute a release line live in
+    # mat_vis_baker.release_matrix as a single Python module — the
+    # canonical source of truth. Dagger wraps the baker CLI subcommand
+    # `mat-vis-baker matrix list` rather than re-declaring the matrix
+    # here, so cells stay in one place and the Dagger module stays
+    # standalone (per the _bake_cli pattern: Dagger orchestrates,
+    # baker container holds the data + logic).
+
+    @function
+    async def release_matrix(
+        self,
+        line: Annotated[str, Doc("Release line, e.g. 'v2026.04'")],
+        context: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
+        filter_source: Annotated[
+            str,
+            Doc("Restrict to one source (empty = all). Spot-test selector for bake_matrix."),
+        ] = "",
+        filter_tier: Annotated[
+            str,
+            Doc("Restrict to one tier (empty = all). Spot-test selector for bake_matrix."),
+        ] = "",
+    ) -> str:
+        """Return the canonical (source × tier) cells for a release line as JSON.
+
+        Reads the matrix from `mat_vis_baker.release_matrix` via the
+        `mat-vis-baker matrix list` CLI subcommand. Output shape:
+
+            {"line": "v2026.04", "cells": [{"source": "ambientcg", "tier": "1k"}, ...]}
+
+        Filtering is applied baker-side (one CLI invocation; no
+        round-trip cost). Empty result is not an error — caller decides
+        what an empty filter means.
+        """
+        ctx = context or dag.host().directory(".")
+        ctr = self._baker_container(ctx)
+        argv = ["uv", "run", "mat-vis-baker", "matrix", "list", line]
+        if filter_source:
+            argv.extend(["--filter-source", filter_source])
+        if filter_tier:
+            argv.extend(["--filter-tier", filter_tier])
+        return await ctr.with_exec(argv).stdout()
+
+    @function
+    async def bake_matrix(
+        self,
+        context: Annotated[dagger.Directory, Doc("Project root directory")],
+        line: Annotated[str, Doc("Release line declared in mat_vis_baker.release_matrix")],
+        release_tag: Annotated[
+            str, Doc("Calver patch tag, e.g. v2026.04.3 (must match the line's CalVer prefix)")
+        ],
+        hf_token: Annotated[dagger.Secret, Doc("HF write token for the atomic push")],
+        filter_source: Annotated[
+            str, Doc("Bake only one source (empty = all cells in the line)")
+        ] = "",
+        filter_tier: Annotated[str, Doc("Bake only one tier (empty = all cells in the line)")] = "",
+        repo_id: Annotated[str, Doc("Target HF dataset repo")] = "gerchowl/mat-vis-tst",
+        allow_prod: Annotated[
+            bool, Doc("Opt-in flag required to target any non-*-tst repo (e.g. gerchowl/mat-vis)")
+        ] = False,
+        limit: Annotated[int, Doc("Per-cell max materials (0 = no limit)")] = 0,
+        offset: Annotated[int, Doc("Per-cell skip first N materials")] = 0,
+        batch_size: Annotated[int, Doc("Materials per atomic commit (count ceiling, #228)")] = 300,
+        batch_max_bytes: Annotated[
+            int,
+            Doc(
+                "Bytes per atomic commit (default 700 MiB). #228: flush trips on first-of-N-or-bytes."
+            ),
+        ] = 700 * 1024 * 1024,
+        dry_run: Annotated[bool, Doc("Build locally; skip HF push")] = False,
+    ) -> str:
+        """Bake every cell in a release line, sequentially.
+
+        Reads cells via `release_matrix(line)`, applies `filter_source`
+        and/or `filter_tier`, then dispatches `bake()` per cell. Sequential
+        so a per-cell failure surfaces with the cell that produced it
+        (and so the GH-Actions concurrency queue can't drop middle cells
+        — the bake.yml-side latest-pending-only quirk that bit us during
+        v2026.04.3 verification).
+
+        Returns one stdout block per cell, separated by
+        `=== <source>×<tier> ===` headers; first failing cell raises
+        and aborts the rest.
+        """
+        import json
+
+        # Reuse release_matrix() to keep matrix-source-of-truth single.
+        # That's an extra container call but it's cheap (CLI+JSON), and
+        # bake_matrix is a long-running orchestration anyway.
+        matrix_json = await self.release_matrix(
+            line=line,
+            context=context,
+            filter_source=filter_source,
+            filter_tier=filter_tier,
+        )
+        cells = json.loads(matrix_json)["cells"]
+        if not cells:
+            raise ValueError(
+                f"bake_matrix: no cells matched line={line!r} "
+                f"filter_source={filter_source!r} filter_tier={filter_tier!r}"
+            )
+
+        sections: list[str] = []
+        for cell in cells:
+            out = await self.bake(
+                context=context,
+                source=cell["source"],
+                tier=cell["tier"],
+                release_tag=release_tag,
+                hf_token=hf_token,
+                repo_id=repo_id,
+                allow_prod=allow_prod,
+                limit=limit,
+                offset=offset,
+                batch_size=batch_size,
+                batch_max_bytes=batch_max_bytes,
+                dry_run=dry_run,
+            )
+            sections.append(f"=== {cell['source']}×{cell['tier']} ===\n{out}")
+        return "\n\n".join(sections)
 
     @function
     async def test_e2e(

--- a/src/mat_vis_baker/__main__.py
+++ b/src/mat_vis_baker/__main__.py
@@ -151,6 +151,36 @@ def cmd_pack_mtlx(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_matrix_list(args: argparse.Namespace) -> int:
+    """Print the canonical (source × tier) cells for a release line as JSON.
+
+    Reads from ``mat_vis_baker.release_matrix`` (mat-vis#306). Output is
+    a single JSON object with ``line`` and ``cells`` keys; consumers
+    (Dagger, scripts) parse with ``json.loads``.
+    """
+    import json
+
+    from mat_vis_baker.release_matrix import filter_cells, get_release
+
+    try:
+        release = get_release(args.line)
+    except KeyError as exc:
+        log.error("matrix list: %s", exc)
+        return 2
+
+    cells = filter_cells(
+        release.cells,
+        source=args.filter_source or "",
+        tier=args.filter_tier or "",
+    )
+    payload = {
+        "line": release.line,
+        "cells": [{"source": c.source, "tier": c.tier} for c in cells],
+    }
+    print(json.dumps(payload))
+    return 0
+
+
 def cmd_fetch(args: argparse.Namespace) -> int:
     """Fetch only — download textures from upstream."""
     fetch = _get_fetcher(args.source)
@@ -364,6 +394,30 @@ def main() -> int:
     )
     p_dfr.add_argument("--release-tag", required=True)
     p_dfr.add_argument("--limit", type=int, default=None, help="Process only first N materials")
+
+    p_matrix = sub.add_parser(
+        "matrix",
+        help="Inspect the canonical (source × tier) release matrix (mat-vis#306)",
+    )
+    matrix_sub = p_matrix.add_subparsers(dest="matrix_command", required=True)
+    p_matrix_list = matrix_sub.add_parser(
+        "list",
+        help="Print canonical cells for a release line as JSON",
+    )
+    p_matrix_list.add_argument(
+        "line",
+        help="Release line, e.g. 'v2026.04' (the CalVer prefix; covers all .X patches)",
+    )
+    p_matrix_list.add_argument(
+        "--filter-source",
+        default="",
+        help="Restrict output to one source (empty = all sources)",
+    )
+    p_matrix_list.add_argument(
+        "--filter-tier",
+        default="",
+        help="Restrict output to one tier (empty = all tiers)",
+    )
 
     p_fetch = sub.add_parser("fetch", help="Fetch textures from upstream")
     p_fetch.add_argument("source", choices=SOURCES)
@@ -646,6 +700,9 @@ def main() -> int:
         return cmd_derive_from_release(args)
     if args.command == "fetch":
         return cmd_fetch(args)
+    if args.command == "matrix":
+        if args.matrix_command == "list":
+            return cmd_matrix_list(args)
     if args.command == "catalog":
         return cmd_catalog(args)
     if args.command == "derive-ktx2":

--- a/src/mat_vis_baker/release_matrix.py
+++ b/src/mat_vis_baker/release_matrix.py
@@ -1,0 +1,172 @@
+"""Canonical declaration of (source × tier) cells per release line.
+
+Per mat-vis#306: the (source × tier) cells that constitute a release
+line live HERE, in a single Python module — not scattered across
+``bake.yml`` runtime expansions, dispatcher heads, or shell scripts.
+
+Why a Python module (vs TOML / pyproject stanza) — picked from the
+spike's three options:
+
+- **Drift safety:** at import time we cross-check every declared
+  source against ``mat_vis_baker.sources.KNOWN_SOURCES`` and fail
+  fast if the matrix references a source that doesn't exist as an
+  importable module. TOML can't do this without a separate validator
+  step.
+- **Type-checked, testable, refactor-friendly.** ``mypy`` /
+  ``ruff`` see the data; tests just import + assert.
+- **Consumers stay honest.** The Dagger ``release_matrix(line)``
+  function reads from this module; clients that want the canonical
+  cells for a release line ``import mat_vis_baker.release_matrix``
+  rather than parsing a workflow YAML.
+
+Schema:
+
+    Cell(source, tier)   — one (source × tier) bake target.
+    Release(line, cells) — the full set of cells for a release line.
+
+The release line is a CalVer prefix (e.g. ``"v2026.04"``) and
+groups patch-level cuts (``v2026.04.0``, ``.1``, ``.2``, ``.3``,
+``v2026.04.X``) — the cell shape is stable across patches by
+design. A new line (``v2026.05``) gets its own ``Release`` entry
+when its cell shape diverges (e.g. adding ``polyhaven 2k``).
+
+Filtering (for spot-tests):
+
+    filter_cells(release.cells, source="gpuopen")
+    filter_cells(release.cells, tier="1k")
+    filter_cells(release.cells, source="polyhaven", tier="1k")
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mat_vis_baker.common import VALID_TIERS
+from mat_vis_baker.sources import KNOWN_SOURCES, SCALAR_SOURCES, TEXTURED_SOURCES
+
+# Tier accepted as the "no-texture" sentinel for scalar-only sources.
+SCALAR_TIER: str = "scalar"
+
+# All tier strings the matrix may reference. Pinned to the existing
+# baker tier vocabulary plus the scalar sentinel — a typo here will
+# trip the import-time validator below.
+_VALID_CELL_TIERS: frozenset[str] = frozenset(VALID_TIERS) | {SCALAR_TIER}
+
+
+@dataclass(frozen=True, slots=True)
+class Cell:
+    """One (source × tier) bake target.
+
+    Equality + hashing are structural — two cells with the same
+    ``(source, tier)`` are the same cell. That makes deduping trivial
+    and lets cells live in sets / be dict keys.
+    """
+
+    source: str
+    tier: str
+
+
+@dataclass(frozen=True, slots=True)
+class Release:
+    """The full set of cells that constitute a release line.
+
+    ``cells`` is a tuple (not list) so the declaration is immutable
+    after the dataclass is constructed — preventing accidental mutation
+    by a consumer.
+    """
+
+    line: str
+    cells: tuple[Cell, ...]
+
+
+# Canonical declarations. ADD a new line as a new key; do NOT mutate
+# an existing line's cell shape after the first cut on it has shipped
+# (the cell shape is the contract that #295 content-drift gate
+# verifies against).
+_RELEASES: dict[str, Release] = {
+    "v2026.04": Release(
+        line="v2026.04",
+        cells=(
+            Cell("ambientcg", "1k"),
+            Cell("polyhaven", "1k"),
+            Cell("gpuopen", "1k"),
+            Cell("physicallybased", SCALAR_TIER),
+        ),
+    ),
+}
+
+
+def _validate_release(release: Release) -> None:
+    """Fail fast if a declared cell references an unknown source/tier
+    or a source/tier mismatch (textured-source asking for ``scalar``,
+    or scalar-source asking for ``1k``)."""
+    seen: set[Cell] = set()
+    for cell in release.cells:
+        if cell in seen:
+            raise ValueError(f"release {release.line!r}: duplicate cell {cell.source}×{cell.tier}")
+        seen.add(cell)
+
+        if cell.source not in KNOWN_SOURCES:
+            raise ValueError(
+                f"release {release.line!r}: cell references unknown source "
+                f"{cell.source!r} (known: {sorted(KNOWN_SOURCES)})"
+            )
+        if cell.tier not in _VALID_CELL_TIERS:
+            raise ValueError(
+                f"release {release.line!r}: cell {cell.source!r} references "
+                f"unknown tier {cell.tier!r} (valid: {sorted(_VALID_CELL_TIERS)})"
+            )
+
+        # Source/tier compatibility — the structural drift safety the
+        # spike pitfalls call out.
+        if cell.source in TEXTURED_SOURCES and cell.tier == SCALAR_TIER:
+            raise ValueError(
+                f"release {release.line!r}: textured source {cell.source!r} cannot "
+                f"target tier {SCALAR_TIER!r}"
+            )
+        if cell.source in SCALAR_SOURCES and cell.tier != SCALAR_TIER:
+            raise ValueError(
+                f"release {release.line!r}: scalar source {cell.source!r} must "
+                f"target tier {SCALAR_TIER!r}, not {cell.tier!r}"
+            )
+
+
+# Validate at module import — a typo in _RELEASES surfaces immediately
+# rather than at next bake dispatch.
+for _r in _RELEASES.values():
+    _validate_release(_r)
+
+
+def known_lines() -> tuple[str, ...]:
+    """Names of all declared release lines, in declaration order."""
+    return tuple(_RELEASES.keys())
+
+
+def get_release(line: str) -> Release:
+    """Return the canonical ``Release`` for a release line.
+
+    Raises ``KeyError`` with a helpful message if the line is unknown.
+    """
+    if line not in _RELEASES:
+        raise KeyError(f"unknown release line {line!r}; known lines: {known_lines()}")
+    return _RELEASES[line]
+
+
+def filter_cells(
+    cells: tuple[Cell, ...],
+    *,
+    source: str = "",
+    tier: str = "",
+) -> tuple[Cell, ...]:
+    """Filter cells by source and/or tier (empty string = no filter).
+
+    Returns a tuple in the same order as the input. An empty result is
+    not an error — the caller decides what "no cells matched my filter"
+    means (spot-test that should target everything? typo?).
+    """
+    out = cells
+    if source:
+        out = tuple(c for c in out if c.source == source)
+    if tier:
+        out = tuple(c for c in out if c.tier == tier)
+    return out

--- a/src/mat_vis_baker/sources/__init__.py
+++ b/src/mat_vis_baker/sources/__init__.py
@@ -1,0 +1,33 @@
+"""Registry of known material sources.
+
+The single source of truth for "what sources does this baker know about."
+Edit ``KNOWN_SOURCES`` when adding a new source module under
+``mat_vis_baker.sources.``.
+
+Why a registry rather than ``glob('*.py')``: tests + release-matrix
+validation (mat-vis#306) want a stable, importable name they can pin
+against. A glob would silently include test fixtures, half-finished
+modules, etc.
+"""
+
+from __future__ import annotations
+
+KNOWN_SOURCES: frozenset[str] = frozenset(
+    {
+        "ambientcg",
+        "polyhaven",
+        "gpuopen",
+        "physicallybased",
+    }
+)
+
+# Sources that produce textured per-tier output. The release matrix
+# (mat-vis#306) validates per-cell tier choices against this set.
+TEXTURED_SOURCES: frozenset[str] = frozenset({"ambientcg", "polyhaven", "gpuopen"})
+
+# Sources that ship as scalar-only (no per-tier textures).
+SCALAR_SOURCES: frozenset[str] = frozenset({"physicallybased"})
+
+assert TEXTURED_SOURCES | SCALAR_SOURCES == KNOWN_SOURCES, (
+    "every source must be either TEXTURED_SOURCES or SCALAR_SOURCES"
+)

--- a/tests/test_release_matrix.py
+++ b/tests/test_release_matrix.py
@@ -1,0 +1,169 @@
+"""Tests for mat_vis_baker.release_matrix (mat-vis#306)."""
+
+from __future__ import annotations
+
+import pytest
+
+from mat_vis_baker.release_matrix import (
+    SCALAR_TIER,
+    Cell,
+    Release,
+    _validate_release,
+    filter_cells,
+    get_release,
+    known_lines,
+)
+from mat_vis_baker.sources import KNOWN_SOURCES, SCALAR_SOURCES, TEXTURED_SOURCES
+
+
+# ── canonical declarations ────────────────────────────────────────
+
+
+def test_v2026_04_line_declared():
+    """The v2026.04 line must be declared (current production)."""
+    assert "v2026.04" in known_lines()
+
+
+def test_v2026_04_covers_all_known_sources():
+    """Every KNOWN_SOURCES entry must appear in the v2026.04 line —
+    drift safety: adding a source to the registry without adding it
+    to the matrix would silently exclude it from cuts."""
+    line = get_release("v2026.04")
+    sources_in_line = {c.source for c in line.cells}
+    assert sources_in_line == KNOWN_SOURCES, (
+        f"v2026.04 cells reference {sources_in_line}, but KNOWN_SOURCES is {KNOWN_SOURCES}"
+    )
+
+
+def test_v2026_04_textured_sources_use_texture_tiers():
+    line = get_release("v2026.04")
+    for cell in line.cells:
+        if cell.source in TEXTURED_SOURCES:
+            assert cell.tier != SCALAR_TIER, (
+                f"textured source {cell.source!r} must not target {SCALAR_TIER!r}"
+            )
+
+
+def test_v2026_04_scalar_sources_use_scalar_tier():
+    line = get_release("v2026.04")
+    for cell in line.cells:
+        if cell.source in SCALAR_SOURCES:
+            assert cell.tier == SCALAR_TIER, (
+                f"scalar source {cell.source!r} must target {SCALAR_TIER!r}"
+            )
+
+
+# ── get_release / known_lines ─────────────────────────────────────
+
+
+def test_get_release_returns_immutable_tuple():
+    line = get_release("v2026.04")
+    assert isinstance(line.cells, tuple)
+
+
+def test_get_release_unknown_raises_helpful_keyerror():
+    with pytest.raises(KeyError, match="unknown release line"):
+        get_release("v9999.99")
+
+
+def test_known_lines_returns_tuple():
+    assert isinstance(known_lines(), tuple)
+
+
+# ── filter_cells ──────────────────────────────────────────────────
+
+
+def test_filter_cells_no_filter_returns_all():
+    cells = get_release("v2026.04").cells
+    assert filter_cells(cells) == cells
+
+
+def test_filter_cells_by_source():
+    cells = get_release("v2026.04").cells
+    out = filter_cells(cells, source="gpuopen")
+    assert len(out) == 1
+    assert out[0].source == "gpuopen"
+
+
+def test_filter_cells_by_tier():
+    cells = get_release("v2026.04").cells
+    out = filter_cells(cells, tier=SCALAR_TIER)
+    assert len(out) == 1
+    assert out[0].source in SCALAR_SOURCES
+
+
+def test_filter_cells_by_both_source_and_tier():
+    cells = get_release("v2026.04").cells
+    out = filter_cells(cells, source="ambientcg", tier="1k")
+    assert len(out) == 1
+    assert out[0] == Cell("ambientcg", "1k")
+
+
+def test_filter_cells_no_match_is_empty_not_error():
+    cells = get_release("v2026.04").cells
+    assert filter_cells(cells, source="nonexistent") == ()
+
+
+def test_filter_cells_preserves_input_order():
+    cells = (
+        Cell("ambientcg", "1k"),
+        Cell("polyhaven", "1k"),
+        Cell("gpuopen", "1k"),
+    )
+    out = filter_cells(cells, tier="1k")
+    assert out == cells
+
+
+# ── _validate_release: drift-safety failure modes ────────────────
+
+
+def test_validate_rejects_unknown_source():
+    bad = Release(line="test", cells=(Cell("nonexistent_source", "1k"),))
+    with pytest.raises(ValueError, match="unknown source"):
+        _validate_release(bad)
+
+
+def test_validate_rejects_unknown_tier():
+    bad = Release(line="test", cells=(Cell("ambientcg", "9999k"),))
+    with pytest.raises(ValueError, match="unknown tier"):
+        _validate_release(bad)
+
+
+def test_validate_rejects_textured_source_with_scalar_tier():
+    bad = Release(line="test", cells=(Cell("gpuopen", SCALAR_TIER),))
+    with pytest.raises(ValueError, match="textured source.*cannot target"):
+        _validate_release(bad)
+
+
+def test_validate_rejects_scalar_source_with_texture_tier():
+    bad = Release(line="test", cells=(Cell("physicallybased", "1k"),))
+    with pytest.raises(ValueError, match="scalar source.*must target"):
+        _validate_release(bad)
+
+
+def test_validate_rejects_duplicate_cell():
+    bad = Release(
+        line="test",
+        cells=(Cell("gpuopen", "1k"), Cell("gpuopen", "1k")),
+    )
+    with pytest.raises(ValueError, match="duplicate cell"):
+        _validate_release(bad)
+
+
+# ── Cell / Release dataclass behavior ────────────────────────────
+
+
+def test_cell_is_hashable():
+    cells: set[Cell] = {Cell("a", "1k"), Cell("a", "1k"), Cell("b", "1k")}
+    assert len(cells) == 2  # dedup by structural equality
+
+
+def test_cell_is_immutable():
+    c = Cell("ambientcg", "1k")
+    with pytest.raises(Exception):
+        c.source = "polyhaven"  # type: ignore[misc]
+
+
+def test_release_cells_is_tuple_not_list():
+    r = get_release("v2026.04")
+    assert isinstance(r.cells, tuple)


### PR DESCRIPTION
## Summary

P0 of #306. Single Python module declares the (source × tier) cells per release line, with import-time validation, CLI exposure, and Dagger functions wrapping the CLI. Replaces the "lives in the dispatcher's head" model that bit us during v2026.04.3 verification (manual sequential dispatches, GH concurrency dropping middle cells).

**Picked Python module** over TOML / pyproject stanza per the spike fork-in-road. Reason: import-time drift safety. Declaring a cell that references an unknown source/tier or a source-tier mismatch raises \`ValueError\` at module import. TOML can't do this without a separate validator step.

## What lands

- \`src/mat_vis_baker/release_matrix.py\` — canonical declaration; \`v2026.04\` line registered with all 4 sources.
- \`src/mat_vis_baker/sources/__init__.py\` — \`KNOWN_SOURCES\` / \`TEXTURED_SOURCES\` / \`SCALAR_SOURCES\` registry. Module was empty before; now it's the source-of-truth registry the matrix validates against.
- \`mat-vis-baker matrix list <line>\` CLI subcommand → JSON; supports \`--filter-source\` / \`--filter-tier\` for spot-tests.
- \`release_matrix(line, ...)\` Dagger function — thin wrapper around the CLI.
- \`bake_matrix(context, line, release_tag, ..., filter_source, filter_tier, ...)\` Dagger function — reads cells via \`release_matrix\`, dispatches \`bake()\` per cell **sequentially**. Sequential by design: per-cell failures surface with their cell; GH-Actions concurrency queue can't drop middle cells.
- 21-test suite covering canonical declarations, drift-safety failure modes, filter_cells semantics, and Cell/Release dataclass behavior.

## Pattern

Matrix lives in baker (source of truth + type-checked + testable); CLI exposes it; Dagger wraps the CLI. Same shape as existing \`bake()\` wrapping \`mat-vis-baker hf-bake\`. The Dagger module stays standalone — no path-dep coupling — per the established \`_bake_cli\` convention.

## Out of scope (follow-up PR)

- \`bake.yml\` body migration to \`dagger call bake-matrix\`. Will land as a separate PR once this foundation is reviewable. Existing \`bake.yml\` keeps working unchanged.
- #295 content-drift gate — depends on this PR landing first to read the expected-set from the matrix.

## Test plan

- [x] \`uv run --with . mat-vis-baker matrix list v2026.04\` returns JSON with all 4 cells
- [x] \`--filter-source gpuopen\` returns just gpuopen cell
- [x] Unknown line returns exit 2 with helpful error
- [x] 21/21 unit tests green
- [x] Full test suite (468 passed, 16 skipped)
- [ ] CI runs the new test_release_matrix.py module