### PR TITLE
feat(client): emissive + clearcoat scalar coverage in adapters (#302)

### DIFF
--- a/clients/python/src/mat_vis_client/adapters.py
+++ b/clients/python/src/mat_vis_client/adapters.py
@@ -52,6 +52,7 @@ def _to_data_uri(png_bytes: bytes) -> str:
 # adapter omits it. mat-vis#290.
 _KHR_IOR_DEFAULT = 1.5
 _KHR_TRANSMISSION_DEFAULT = 0.0
+_KHR_CLEARCOAT_DEFAULT = 0.0
 
 
 def _ior_at_default(ior: float | None) -> bool:
@@ -67,6 +68,11 @@ def _ior_at_default(ior: float | None) -> bool:
 def _transmission_at_default(t: float | None) -> bool:
     """True if ``t`` is None or matches the KHR spec default (0.0)."""
     return t is None or math.isclose(t, _KHR_TRANSMISSION_DEFAULT, abs_tol=1e-9)
+
+
+def _clearcoat_at_default(c: float | None) -> bool:
+    """True if ``c`` is None or matches the KHR_materials_clearcoat default (0.0)."""
+    return c is None or math.isclose(c, _KHR_CLEARCOAT_DEFAULT, abs_tol=1e-9)
 
 
 def _color_hex_to_int(hex_str: str) -> int:
@@ -153,6 +159,10 @@ def to_threejs(
         result["ior"] = scalars["ior"]
     if "transmission" in scalars and scalars["transmission"] is not None:
         result["transmission"] = scalars["transmission"]
+    if scalars.get("emissive") is not None:
+        result["emissive"] = list(scalars["emissive"])
+    if scalars.get("clearcoat") is not None:
+        result["clearcoat"] = scalars["clearcoat"]
 
     # Textures as data URIs
     for channel, prop in _THREEJS_TEX_MAP.items():
@@ -220,6 +230,21 @@ def to_gltf(
     if not _transmission_at_default(transmission):
         material.setdefault("extensions", {})["KHR_materials_transmission"] = {
             "transmissionFactor": transmission
+        }
+
+    # Emissive — core glTF 2.0 material field (NOT under an extension).
+    # Spec default is [0, 0, 0]; we emit on presence and let the no-op
+    # case (all zeros) through since callers may want explicit black.
+    emissive = scalars.get("emissive")
+    if emissive is not None:
+        material["emissiveFactor"] = list(emissive)
+
+    # Clearcoat extension — omit when zero/None (spec default), mirrors
+    # the KHR_materials_ior / _transmission suppression pattern.
+    clearcoat = scalars.get("clearcoat")
+    if not _clearcoat_at_default(clearcoat):
+        material.setdefault("extensions", {})["KHR_materials_clearcoat"] = {
+            "clearcoatFactor": clearcoat
         }
 
     # Textures
@@ -361,6 +386,13 @@ def _build_mtlx_tree(
         ET.SubElement(shader, "input", name="metallic", type="float", value=str(metalness))
     if "ior" in scalars and scalars["ior"] is not None:
         ET.SubElement(shader, "input", name="ior", type="float", value=str(scalars["ior"]))
+
+    # Emissive RGB on the shader scalar path. Texture-bound emission is
+    # already routed through the nodegraph above (channel "emission").
+    emissive = scalars.get("emissive")
+    if emissive is not None and "emission" not in tex_filenames:
+        rgb = ",".join(f"{c:g}" for c in tuple(emissive)[:3])
+        ET.SubElement(shader, "input", name="emissiveColor", type="color3", value=rgb)
 
     # Connect texture outputs to shader
     for usd_input, (out_name, mtlx_type) in output_refs.items():

--- a/clients/python/tests/test_adapters_emissive_clearcoat.py
+++ b/clients/python/tests/test_adapters_emissive_clearcoat.py
@@ -1,0 +1,131 @@
+"""Tests for emissive + clearcoat scalar coverage (ADR-0013 §Decision-3).
+
+py-mat's ``Vis`` dataclass exposes ``emissive`` (RGB float-3) and
+``clearcoat`` (float 0-1) as part of its public PBR-spec mirror.
+Adapters previously dropped both keys silently — only the five-key
+allowlist (metalness/roughness/color_hex/ior/transmission) flowed
+through. ADR-0013 expands the input schema to mirror Three.js
+MeshPhysicalMaterial + glTF 2.0.
+
+Output bindings:
+    | scalar    | to_threejs           | to_gltf                              | export_mtlx                                  |
+    |-----------|----------------------|--------------------------------------|----------------------------------------------|
+    | emissive  | result["emissive"]   | material["emissiveFactor"] (core)   | <input name="emissiveColor" type="color3">  |
+    | clearcoat | result["clearcoat"]  | KHR_materials_clearcoat extension    | (n/a — UsdPreviewSurface lacks clearcoat)   |
+
+clearcoat at the spec default 0.0 is omitted (no-op extension entry,
+mirroring the existing ior=1.5 / transmission=0.0 suppression pattern).
+
+#302.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+from mat_vis_client.adapters import export_mtlx, to_gltf, to_threejs
+
+
+class TestEmissiveToThreejs:
+    def test_emissive_emitted_as_array(self):
+        result = to_threejs({"emissive": (1.0, 0.5, 0.0)})
+        assert result["emissive"] == [1.0, 0.5, 0.0]
+
+    def test_emissive_list_input_accepted(self):
+        result = to_threejs({"emissive": [0.2, 0.4, 0.6]})
+        assert result["emissive"] == [0.2, 0.4, 0.6]
+
+    def test_emissive_absent_when_not_in_scalars(self):
+        result = to_threejs({})
+        assert "emissive" not in result
+
+    def test_emissive_absent_when_none(self):
+        result = to_threejs({"emissive": None})
+        assert "emissive" not in result
+
+
+class TestEmissiveToGltf:
+    def test_emissive_emitted_as_emissive_factor(self):
+        result = to_gltf({"emissive": (1.0, 0.5, 0.0)})
+        # emissiveFactor is a CORE glTF 2.0 material field — not under
+        # an extension. Lives at material["emissiveFactor"].
+        assert result["emissiveFactor"] == [1.0, 0.5, 0.0]
+
+    def test_emissive_absent_when_not_in_scalars(self):
+        result = to_gltf({})
+        assert "emissiveFactor" not in result
+
+    def test_emissive_absent_when_none(self):
+        result = to_gltf({"emissive": None})
+        assert "emissiveFactor" not in result
+
+
+class TestEmissiveExportMtlx:
+    def test_emissive_emits_color3_input(self, tmp_path: Path):
+        out = export_mtlx({"emissive": (1.0, 0.5, 0.0)}, output_dir=tmp_path)
+        xml = out.read_text()
+        # UsdPreviewSurface emissiveColor input — comma-separated RGB.
+        assert 'name="emissiveColor"' in xml
+        assert 'type="color3"' in xml
+        # Float formatting must be unambiguous; %g suppresses trailing zeros.
+        assert 'value="1,0.5,0"' in xml
+
+    def test_emissive_absent_when_not_in_scalars(self, tmp_path: Path):
+        out = export_mtlx({}, output_dir=tmp_path)
+        xml = out.read_text()
+        assert "emissiveColor" not in xml
+
+
+class TestClearcoatToThreejs:
+    def test_clearcoat_emitted(self):
+        result = to_threejs({"clearcoat": 0.5})
+        assert result["clearcoat"] == 0.5
+
+    def test_clearcoat_zero_emitted_explicitly(self):
+        # Three.js MeshPhysicalMaterial.clearcoat = 0 is a meaningful
+        # explicit "no clearcoat" — distinct from "absent". Three.js
+        # accepts the value either way; we emit on presence to keep the
+        # adapter dumb.
+        result = to_threejs({"clearcoat": 0.0})
+        assert result["clearcoat"] == 0.0
+
+    def test_clearcoat_absent_when_not_in_scalars(self):
+        result = to_threejs({})
+        assert "clearcoat" not in result
+
+    def test_clearcoat_absent_when_none(self):
+        result = to_threejs({"clearcoat": None})
+        assert "clearcoat" not in result
+
+
+class TestClearcoatToGltf:
+    def test_clearcoat_emits_khr_extension(self):
+        result = to_gltf({"clearcoat": 0.5})
+        ext = result["extensions"]["KHR_materials_clearcoat"]
+        assert ext["clearcoatFactor"] == 0.5
+
+    def test_clearcoat_at_default_omitted(self):
+        # Mirrors the ior=1.5 / transmission=0.0 default-suppression
+        # pattern: a KHR extension entry that exactly matches the spec
+        # default is a no-op and bloats output.
+        result = to_gltf({"clearcoat": 0.0})
+        assert "KHR_materials_clearcoat" not in result.get("extensions", {})
+
+    def test_clearcoat_absent_when_not_in_scalars(self):
+        result = to_gltf({})
+        assert "KHR_materials_clearcoat" not in result.get("extensions", {})
+
+    def test_clearcoat_absent_when_none(self):
+        result = to_gltf({"clearcoat": None})
+        assert "KHR_materials_clearcoat" not in result.get("extensions", {})
+
+
+class TestClearcoatMtlxSkipped:
+    """UsdPreviewSurface 1.38 has no clearcoat input — adapter drops it silently
+    with no error. (Future MaterialX shaders may; revisit then.)"""
+
+    def test_no_clearcoat_artifact_in_mtlx(self, tmp_path: Path):
+        out = export_mtlx({"clearcoat": 0.5}, output_dir=tmp_path)
+        xml = out.read_text()
+        assert "clearcoat" not in xml.lower()


### PR DESCRIPTION
## Summary

Adds first-class adapter support for two PBR scalars py-mat's ``Vis`` dataclass already exposes but the substrate silently dropped:

| scalar | to_threejs | to_gltf | export_mtlx |
|---|---|---|---|
| ``emissive`` (RGB float-3) | ``result["emissive"]=[r,g,b]`` | ``material["emissiveFactor"]=[r,g,b]`` (**core spec field**, not under an extension) | ``<input name="emissiveColor" type="color3" value="r,g,b"/>`` on the shader scalar path |
| ``clearcoat`` (float 0-1) | ``result["clearcoat"]=float`` | ``KHR_materials_clearcoat.clearcoatFactor`` (**omitted at spec default 0.0**) | n/a — UsdPreviewSurface lacks a clearcoat input |

The clearcoat default-suppression mirrors the existing ``ior=1.5`` / ``transmission=0.0`` pattern (no-op KHR extensions bloat output). Emissive is unconditionally emitted on presence — the all-zeros case is a meaningful explicit "black" rather than "absent".

Texture-bound emission still flows through the existing nodegraph; the new scalar-path emit only fires when no ``"emission"`` channel is bound.

## Why

py-mat's ``Vis.emissive`` and ``Vis.clearcoat`` are public-API fields ([py-mat 3.10+](https://github.com/MorePET/mat) ``Vis`` PBR-spec mirror). Downstream wrappers passed them in good faith; adapters dropped them silently. Build123d's ``MeshPhysicalMaterial`` consumer and any glTF-spec-compliant renderer (gltf-viewer, Babylon.js, Filament) lost the values.

## Test plan

- [x] 18 new pytest cases in ``test_adapters_emissive_clearcoat.py`` — per-scalar × per-adapter matrix, plus "absent when not in scalars" / "absent when None" pins, plus the clearcoat default-suppression and MTLX no-clearcoat-artifact pins.
- [x] ``uv run pytest tests/`` (client suite): 291 passed, 26 skipped, no regressions.

## Out of scope

- Linear-vs-sRGB colorspace handling on emissive RGB — held for the 0.7.0 cut where ``_srgb_to_linear`` lands.

Closes #302. Refs ADR-0013, #3.