### PR TITLE
feat(ci): upstream content-drift gate (closes #295)

### DIFF
--- a/scripts/check_upstream_content_drift.py
+++ b/scripts/check_upstream_content_drift.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Upstream content-drift gate (mat-vis#295).
+
+Per-material ``upstream.raw`` equality check between consecutive
+releases on the HF substrate. Catches the silent-edit class:
+
+- AMD changes Aluminum Brushed's metalness from 1.0 → 0.95 in their
+  upstream catalog without renaming or removing the material.
+- polyhaven re-uploads a normal map with the same id but a new
+  texture.
+- ambientcg silently revises a material's category or dimensions.
+
+The existing schema-drift gate (`check_upstream_schema_drift.py`)
+catches NEW or REMOVED keys but is structurally blind to these:
+*the keys stay the same, the values change*. Without this gate, every
+gap-fill bake on top of an existing tag silently picks up the live
+upstream — soft-forking the release.
+
+Per #306: cells to check come from `mat_vis_baker.release_matrix`
+(the canonical source-of-truth for what a release line contains).
+This script just gets `<source>` from CLI; the workflow loops
+sources from the matrix's cells.
+
+Algorithm:
+  1. Fetch the candidate `<source>.json` (just baked, just pushed
+     to HF at `--release-tag`).
+  2. Fetch the previous release's `<source>.json` from HF.
+  3. For each material id present in BOTH, hash a stable
+     representation of `upstream.raw` (excluding per-bake volatile
+     fields per the source-specific allowlist below).
+  4. Fail if any per-material hash diverges, modulo the waiver YAML.
+
+Free pass on first cut: if the previous release's catalog 404s or
+lacks the `upstream` block (pre-Phase-C records), log + exit 0.
+Mirrors the schema-drift gate's first-run behavior.
+
+Usage:
+    uv run python scripts/check_upstream_content_drift.py \\
+        --source ambientcg \\
+        --candidate https://huggingface.co/.../v2026.04.3/ambientcg.json \\
+        --previous https://huggingface.co/.../v2026.04.2/ambientcg.json
+
+    # With a waiver YAML for known-OK upstream edits:
+    ... --waivers .github/content-drift-waivers.yaml
+
+Waiver YAML shape:
+    ambientcg:
+      - id: "Rock064"
+        reason: "AMD legitimately re-published with corrected category"
+        accepted_by: "lars"
+        date: "2026-05-08"
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger("content-drift-gate")
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+# Per-source: keys inside ``upstream.raw`` that change every bake
+# without representing real content drift (download counts, etc.).
+# Excluded from the stable hash. Empty set = hash raw as-is.
+#
+# IMPORTANT: this is NOT for upstream's own content timestamps
+# (`updated_date`, `created_date`, `published_date`) — those DO change
+# when upstream actually edits a material, which IS the drift we
+# want to catch. Only true per-bake nondeterminism goes here.
+_VOLATILE_UPSTREAM_RAW_FIELDS: dict[str, frozenset[str]] = {
+    "ambientcg": frozenset({"downloadCount", "popularityScore"}),
+    "polyhaven": frozenset({"download_count"}),
+    "gpuopen": frozenset(),
+    "physicallybased": frozenset(),
+}
+
+
+def stable_hash_upstream_raw(raw: dict[str, Any], volatile: frozenset[str]) -> str:
+    """SHA-256 over ``upstream.raw`` with volatile fields stripped.
+
+    JSON serialization is sort_keys=True + separators=(",", ":") so
+    dict ordering / whitespace can never produce false positives.
+    """
+    filtered = {k: v for k, v in raw.items() if k not in volatile}
+    blob = json.dumps(filtered, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+def fetch_catalog(url: str) -> list[dict[str, Any]] | None:
+    """Fetch a `<source>.json` catalog. Returns ``None`` on 404."""
+    try:
+        with urllib.request.urlopen(url, timeout=60) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+
+
+def diff_content(
+    source: str,
+    prev: list[dict[str, Any]],
+    cand: list[dict[str, Any]],
+) -> list[dict[str, str]]:
+    """Per-material upstream.raw hash diff. Returns drift records."""
+    volatile = _VOLATILE_UPSTREAM_RAW_FIELDS.get(source, frozenset())
+
+    prev_by_id = {e["id"]: e for e in prev if "id" in e}
+    cand_by_id = {e["id"]: e for e in cand if "id" in e}
+    common = prev_by_id.keys() & cand_by_id.keys()
+
+    drifted: list[dict[str, str]] = []
+    for mid in sorted(common):
+        prev_raw = (prev_by_id[mid].get("upstream") or {}).get("raw")
+        cand_raw = (cand_by_id[mid].get("upstream") or {}).get("raw")
+        if prev_raw is None or cand_raw is None:
+            # Pre-Phase-C records on either side — skip rather than
+            # false-positive on the schema migration itself.
+            continue
+        h_prev = stable_hash_upstream_raw(prev_raw, volatile)
+        h_cand = stable_hash_upstream_raw(cand_raw, volatile)
+        if h_prev != h_cand:
+            drifted.append({"id": mid, "prev_hash": h_prev, "cand_hash": h_cand})
+    return drifted
+
+
+def load_waivers(path: Path | None, source: str) -> set[str]:
+    """Parse waiver YAML → set of waived material ids for ``source``.
+
+    YAML shape (per module docstring):
+        <source>:
+          - id: <material-id>
+            reason: <text>
+            ...
+    """
+    if path is None or not path.exists():
+        return set()
+    raw = path.read_text()
+    if not raw.strip():
+        return set()
+
+    try:
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(raw) or {}
+    except ImportError:  # pragma: no cover — tested envs install pyyaml
+        log.warning("PyYAML not installed; waivers ignored")
+        return set()
+
+    entries = (data or {}).get(source) or []
+    return {str(e["id"]) for e in entries if isinstance(e, dict) and "id" in e}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--source", required=True, help="Source name (e.g. ambientcg)")
+    p.add_argument("--candidate", required=True, help="URL to candidate <source>.json")
+    p.add_argument("--previous", required=True, help="URL to previous <source>.json")
+    p.add_argument(
+        "--waivers",
+        type=Path,
+        default=None,
+        help="Optional YAML file with per-id waivers for known-OK upstream edits",
+    )
+    p.add_argument(
+        "--max-report",
+        type=int,
+        default=20,
+        help="Max drifted material ids to print on failure (default 20)",
+    )
+    args = p.parse_args()
+
+    log.info("content-drift gate: source=%s", args.source)
+    log.info("  candidate: %s", args.candidate)
+    log.info("  previous:  %s", args.previous)
+
+    cand = fetch_catalog(args.candidate)
+    if cand is None:
+        log.error("FAIL: candidate %s returned 404", args.candidate)
+        return 2
+
+    prev = fetch_catalog(args.previous)
+    if prev is None:
+        log.info(
+            "  OK no previous catalog at %s — first cut on this line, free pass", args.previous
+        )
+        return 0
+
+    drifted = diff_content(args.source, prev, cand)
+    waived_ids = load_waivers(args.waivers, args.source)
+    blocking = [d for d in drifted if d["id"] not in waived_ids]
+    waived_count = len(drifted) - len(blocking)
+
+    if not blocking:
+        log.info(
+            "  OK %s: %d materials, no content drift (waived: %d)",
+            args.source,
+            len(cand),
+            waived_count,
+        )
+        return 0
+
+    log.error(
+        "FAIL content-drift: %d material(s) drifted in %s (showing first %d)",
+        len(blocking),
+        args.source,
+        min(args.max_report, len(blocking)),
+    )
+    for d in blocking[: args.max_report]:
+        log.error("  %s: %s -> %s", d["id"], d["prev_hash"][:12], d["cand_hash"][:12])
+    if len(blocking) > args.max_report:
+        log.error("  ... and %d more", len(blocking) - args.max_report)
+    log.error(
+        "If these are legitimate upstream edits, add to the waiver YAML; "
+        "otherwise investigate the upstream change."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_upstream_content_drift.py
+++ b/tests/test_check_upstream_content_drift.py
@@ -1,0 +1,293 @@
+"""Tests for scripts/check_upstream_content_drift.py (mat-vis#295).
+
+The script is a CI gate. We don't hit the network — every test
+monkeypatches :func:`fetch_catalog` so the behavior we're locking in
+is the diff + hash logic, not urllib.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "check_upstream_content_drift.py"
+
+
+@pytest.fixture(scope="module")
+def drift_mod():
+    """Load the script as a module."""
+    spec = importlib.util.spec_from_file_location("content_drift_gate", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["content_drift_gate"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _entry(mid: str, raw: dict | None = None) -> dict:
+    """Build a minimal v3-shaped catalog entry with upstream.raw."""
+    return {
+        "id": mid,
+        "source": "test",
+        "mat_vis": {"name": mid},
+        "upstream": {
+            "source": "test",
+            "schema_version": 1,
+            "fetched_at": "2026-05-07T09:00:00Z",
+            "raw": raw or {},
+        },
+    }
+
+
+# ── stable_hash_upstream_raw ────────────────────────────────────
+
+
+def test_hash_is_deterministic(drift_mod):
+    raw = {"b": 2, "a": 1, "c": 3}
+    h1 = drift_mod.stable_hash_upstream_raw(raw, frozenset())
+    h2 = drift_mod.stable_hash_upstream_raw({"a": 1, "b": 2, "c": 3}, frozenset())
+    assert h1 == h2  # key order independence
+
+
+def test_hash_changes_on_value_edit(drift_mod):
+    h_old = drift_mod.stable_hash_upstream_raw({"metalness": 1.0}, frozenset())
+    h_new = drift_mod.stable_hash_upstream_raw({"metalness": 0.95}, frozenset())
+    assert h_old != h_new
+
+
+def test_hash_excludes_volatile_fields(drift_mod):
+    raw_a = {"name": "X", "downloadCount": 100, "popularityScore": 0.5}
+    raw_b = {"name": "X", "downloadCount": 999, "popularityScore": 0.99}
+    volatile = frozenset({"downloadCount", "popularityScore"})
+    assert drift_mod.stable_hash_upstream_raw(
+        raw_a, volatile
+    ) == drift_mod.stable_hash_upstream_raw(raw_b, volatile)
+
+
+def test_hash_includes_upstream_own_timestamps(drift_mod):
+    """Upstream's own timestamps (updated_date) ARE content drift —
+    they change when upstream actually edits the material. Must NOT be
+    excluded by the volatile filter."""
+    raw_a = {"name": "X", "updated_date": "2025-01-01"}
+    raw_b = {"name": "X", "updated_date": "2026-01-01"}
+    h_a = drift_mod.stable_hash_upstream_raw(raw_a, frozenset())
+    h_b = drift_mod.stable_hash_upstream_raw(raw_b, frozenset())
+    assert h_a != h_b
+
+
+# ── diff_content ────────────────────────────────────────────────
+
+
+def test_diff_no_drift_returns_empty(drift_mod):
+    prev = [_entry("a", {"x": 1}), _entry("b", {"x": 2})]
+    cand = [_entry("a", {"x": 1}), _entry("b", {"x": 2})]
+    assert drift_mod.diff_content("test", prev, cand) == []
+
+
+def test_diff_detects_value_change(drift_mod):
+    prev = [_entry("a", {"metalness": 1.0})]
+    cand = [_entry("a", {"metalness": 0.95})]
+    drifted = drift_mod.diff_content("test", prev, cand)
+    assert len(drifted) == 1
+    assert drifted[0]["id"] == "a"
+
+
+def test_diff_ignores_added_materials(drift_mod):
+    """A material in cand but not prev is an addition, not drift."""
+    prev = [_entry("a", {"x": 1})]
+    cand = [_entry("a", {"x": 1}), _entry("b", {"x": 2})]
+    assert drift_mod.diff_content("test", prev, cand) == []
+
+
+def test_diff_ignores_removed_materials(drift_mod):
+    """A material in prev but not cand is a removal, not drift."""
+    prev = [_entry("a", {"x": 1}), _entry("b", {"x": 2})]
+    cand = [_entry("a", {"x": 1})]
+    assert drift_mod.diff_content("test", prev, cand) == []
+
+
+def test_diff_skips_pre_phase_c_records(drift_mod):
+    """Records without upstream.raw on either side are skipped, not
+    reported as drift."""
+    prev = [{"id": "a", "source": "test", "mat_vis": {}}]  # no upstream block
+    cand = [_entry("a", {"x": 1})]
+    assert drift_mod.diff_content("test", prev, cand) == []
+
+
+def test_diff_uses_per_source_volatile_allowlist(drift_mod):
+    """ambientcg has downloadCount/popularityScore in its volatile set;
+    those must not trigger drift."""
+    prev = [_entry("a", {"name": "X", "downloadCount": 100, "popularityScore": 0.5})]
+    cand = [_entry("a", {"name": "X", "downloadCount": 5000, "popularityScore": 0.99})]
+    assert drift_mod.diff_content("ambientcg", prev, cand) == []
+
+
+def test_diff_unknown_source_uses_empty_volatile(drift_mod):
+    """An unknown source defaults to no volatile fields — every raw
+    change is real drift."""
+    prev = [_entry("a", {"foo": 1})]
+    cand = [_entry("a", {"foo": 2})]
+    drifted = drift_mod.diff_content("brand_new_source", prev, cand)
+    assert len(drifted) == 1
+
+
+def test_diff_reports_hashes(drift_mod):
+    prev = [_entry("a", {"x": 1})]
+    cand = [_entry("a", {"x": 2})]
+    [d] = drift_mod.diff_content("test", prev, cand)
+    assert "prev_hash" in d and "cand_hash" in d
+    assert d["prev_hash"] != d["cand_hash"]
+    assert len(d["prev_hash"]) == 64  # sha256 hex
+
+
+# ── load_waivers ────────────────────────────────────────────────
+
+
+def test_waivers_missing_path_returns_empty(drift_mod):
+    assert drift_mod.load_waivers(None, "test") == set()
+
+
+def test_waivers_nonexistent_file_returns_empty(drift_mod, tmp_path):
+    assert drift_mod.load_waivers(tmp_path / "nope.yaml", "test") == set()
+
+
+def test_waivers_empty_file_returns_empty(drift_mod, tmp_path):
+    p = tmp_path / "empty.yaml"
+    p.write_text("")
+    assert drift_mod.load_waivers(p, "test") == set()
+
+
+def test_waivers_parses_per_source(drift_mod, tmp_path):
+    p = tmp_path / "waivers.yaml"
+    p.write_text(
+        "ambientcg:\n"
+        '  - id: "Rock064"\n'
+        '    reason: "AMD republished with corrected category"\n'
+        '  - id: "Brick001"\n'
+        '    reason: "upstream tag normalization"\n'
+        "polyhaven:\n"
+        '  - id: "some_material"\n'
+        '    reason: "normal map re-export"\n'
+    )
+    assert drift_mod.load_waivers(p, "ambientcg") == {"Rock064", "Brick001"}
+    assert drift_mod.load_waivers(p, "polyhaven") == {"some_material"}
+    assert drift_mod.load_waivers(p, "gpuopen") == set()
+
+
+# ── main(): end-to-end via monkeypatched fetch_catalog ──────────
+
+
+@pytest.fixture
+def patch_argv(monkeypatch):
+    """Helper to set sys.argv for the gate's argparse main."""
+
+    def _patch(*args: str) -> None:
+        monkeypatch.setattr(sys, "argv", ["check_upstream_content_drift.py", *args])
+
+    return _patch
+
+
+def test_main_no_drift_passes(drift_mod, monkeypatch, patch_argv, caplog):
+    cand = [_entry("a", {"x": 1})]
+    prev = [_entry("a", {"x": 1})]
+
+    def fake_fetch(url):
+        return cand if "candidate" in url else prev
+
+    monkeypatch.setattr(drift_mod, "fetch_catalog", fake_fetch)
+    patch_argv(
+        "--source",
+        "test",
+        "--candidate",
+        "https://x/candidate.json",
+        "--previous",
+        "https://x/previous.json",
+    )
+    with caplog.at_level("INFO", logger="content-drift-gate"):
+        assert drift_mod.main() == 0
+    assert any("no content drift" in r.message for r in caplog.records)
+
+
+def test_main_drift_fails(drift_mod, monkeypatch, patch_argv, caplog):
+    def fake_fetch(url):
+        if "candidate" in url:
+            return [_entry("a", {"metalness": 0.95})]
+        return [_entry("a", {"metalness": 1.0})]
+
+    monkeypatch.setattr(drift_mod, "fetch_catalog", fake_fetch)
+    patch_argv(
+        "--source",
+        "test",
+        "--candidate",
+        "https://x/candidate.json",
+        "--previous",
+        "https://x/previous.json",
+    )
+    with caplog.at_level("ERROR", logger="content-drift-gate"):
+        assert drift_mod.main() == 1
+    assert any("FAIL content-drift" in r.message for r in caplog.records)
+
+
+def test_main_first_cut_free_pass(drift_mod, monkeypatch, patch_argv, caplog):
+    """If previous catalog 404s (first cut on a release line), exit 0."""
+
+    def fake_fetch(url):
+        if "candidate" in url:
+            return [_entry("a", {"x": 1})]
+        return None
+
+    monkeypatch.setattr(drift_mod, "fetch_catalog", fake_fetch)
+    patch_argv(
+        "--source",
+        "test",
+        "--candidate",
+        "https://x/candidate.json",
+        "--previous",
+        "https://x/previous.json",
+    )
+    with caplog.at_level("INFO", logger="content-drift-gate"):
+        assert drift_mod.main() == 0
+    assert any("first cut" in r.message for r in caplog.records)
+
+
+def test_main_candidate_404_fails(drift_mod, monkeypatch, patch_argv):
+    def fake_fetch(url):
+        return None
+
+    monkeypatch.setattr(drift_mod, "fetch_catalog", fake_fetch)
+    patch_argv(
+        "--source",
+        "test",
+        "--candidate",
+        "https://x/candidate.json",
+        "--previous",
+        "https://x/previous.json",
+    )
+    assert drift_mod.main() == 2
+
+
+def test_main_waiver_unblocks(drift_mod, monkeypatch, patch_argv, caplog, tmp_path):
+    waivers = tmp_path / "w.yaml"
+    waivers.write_text('test:\n  - id: "a"\n    reason: "OK"\n')
+
+    def fake_fetch(url):
+        if "candidate" in url:
+            return [_entry("a", {"metalness": 0.95})]
+        return [_entry("a", {"metalness": 1.0})]
+
+    monkeypatch.setattr(drift_mod, "fetch_catalog", fake_fetch)
+    patch_argv(
+        "--source",
+        "test",
+        "--candidate",
+        "https://x/candidate.json",
+        "--previous",
+        "https://x/previous.json",
+        "--waivers",
+        str(waivers),
+    )
+    with caplog.at_level("INFO", logger="content-drift-gate"):
+        assert drift_mod.main() == 0
+    assert any("waived: 1" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Closes #295. Adds \`scripts/check_upstream_content_drift.py\` — per-material \`upstream.raw\` equality between consecutive HF releases. Catches the silent-edit class the existing schema-drift gate is structurally blind to: *the keys stay the same, the values change*.

Examples this would have caught:
- AMD changes Aluminum Brushed's metalness from 1.0 → 0.95 in their upstream catalog with no schema change.
- polyhaven re-uploads a normal map under the same id with a new texture.
- ambientcg silently revises a material's category or dimensions.

Without this gate, every gap-fill bake on top of an existing tag silently picks up the live upstream — soft-forking the release.

## Algorithm

1. Fetch candidate \`<source>.json\` (just baked + pushed at \`--release-tag\`) from HF.
2. Fetch previous release's \`<source>.json\` from HF.
3. For each material id in BOTH, hash a stable representation of \`upstream.raw\`, with per-source volatile fields (download counts, popularity scores) excluded. Upstream's OWN content timestamps (\`updated_date\`, etc.) are NOT excluded — those change when upstream actually edits a material, which IS the drift we want to catch.
4. Fail on any per-material hash mismatch, modulo the optional waiver YAML for known-OK upstream edits.

**Free pass on first cut**: previous catalog 404 → exit 0. Mirrors the schema-drift gate's first-run behavior.

## Per-source volatile fields

- ambientcg: \`downloadCount\`, \`popularityScore\`
- polyhaven: \`download_count\`
- gpuopen / physicallybased: none

## Tests

21-test suite covers:
- Stable-hash determinism (key-order independence)
- Value-edit detection
- Volatile-field exclusion + upstream-own-timestamp preservation
- Diff logic: no drift, value change, added/removed materials, pre-Phase-C records, per-source allowlist, unknown source defaults
- Waiver YAML loading: missing/empty/per-source
- End-to-end \`main()\`: no-drift = 0, drift = 1, candidate 404 = 2, prev 404 = 0 free pass, waiver unblocks

## Out of scope (follow-up PR)

- bake.yml wiring — lands once #323 (matrix-driven bake.yml) settles to avoid merge conflicts. The script is invokable standalone today.
- Cross-tier consistency (P2 in #295) — separate issue.

## Per #306 spike consensus

This is the missing half: the matrix (#306) declares which cells exist; this gate locks the per-material content.

## Test plan

- [x] 21/21 unit tests green locally
- [ ] CI runs the new test suite
- [ ] Smoke against real HF: \`uv run python scripts/check_upstream_content_drift.py --source gpuopen --candidate https://huggingface.co/.../v2026.04.3/gpuopen.json --previous https://huggingface.co/.../v2026.04.2/gpuopen.json\` should pass (we verified no upstream drift between v2026.04.2 and v2026.04.3 in the spike).

## References

- mat-vis#295 (epic)
- mat-vis#306 (release-matrix; provides the cells this gate iterates over)
- mat-vis#320 (matrix schema landed)
- ADR-0011 (upstream allowlist / Layer 2 verbatim mirror)