### PR TITLE
feat(client): to_threejs color_format kwarg with phased default flip (#298)

### DIFF
--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -34,6 +34,7 @@ import sys
 import time
 import urllib.request
 from pathlib import Path
+from typing import Literal
 
 REPO = "MorePET/mat-vis"
 GITHUB_API = f"https://api.github.com/repos/{REPO}"  # update-check only
@@ -1773,11 +1774,15 @@ class VisAsset:
                 return not tiers
         return False
 
-    def to_threejs(self) -> dict:
-        """Return a Three.js ``MeshPhysicalMaterial`` parameter dict."""
+    def to_threejs(self, *, color_format: Literal["hex", "int"] | None = None) -> dict:
+        """Return a Three.js ``MeshPhysicalMaterial`` parameter dict.
+
+        ``color_format`` forwards to the underlying adapter — see
+        ADR-0013 / #298 for the 0.6.x → 0.7.0 migration story.
+        """
         from mat_vis_client.adapters import to_threejs
 
-        return to_threejs(self.scalars, self.textures)
+        return to_threejs(self.scalars, self.textures, color_format=color_format)
 
     def to_gltf(self) -> dict:
         """Return a glTF 2.0 material dict."""

--- a/clients/python/src/mat_vis_client/adapters.py
+++ b/clients/python/src/mat_vis_client/adapters.py
@@ -16,9 +16,11 @@ from __future__ import annotations
 import base64
 import math
 import re
+import warnings
 import xml.etree.ElementTree as ET
 from io import BytesIO
 from pathlib import Path
+from typing import Literal
 
 from mat_vis_client.schema import (
     GLTF_MAP as _GLTF_TEX_MAP,
@@ -134,6 +136,8 @@ def _sanitize_material_name(name: str) -> str:
 def to_threejs(
     scalars: dict,
     textures: dict[str, bytes] | None = None,
+    *,
+    color_format: Literal["hex", "int"] | None = None,
 ) -> dict:
     """Convert to a Three.js MeshPhysicalMaterial parameter dict.
 
@@ -149,6 +153,15 @@ def to_threejs(
         textures: Channel name -> PNG bytes. Keys are mat-vis channel
             names: color, normal, roughness, metalness, ao,
             displacement, emission.
+        color_format: Output shape for ``result["color"]`` when
+            ``color_hex`` is present. ``"int"`` emits a hex int (e.g.
+            ``12566468``); ``"hex"`` emits the ``"#RRGGBB"`` string
+            verbatim. Both forms round-trip lossless through Three.js
+            ``MeshPhysicalMaterial`` (its ``Color.set`` dispatches on
+            type — ``setHex`` for int, ``setStyle`` for string).
+            Default is unset for 0.6.x and emits a DeprecationWarning;
+            in 0.7.0 it flips to ``"hex"`` (Pythonic, JSON-friendly,
+            REPL-readable). py-mat #99 / ADR-0013.
 
     Returns:
         Dict suitable for `new THREE.MeshPhysicalMaterial(result)`.
@@ -173,7 +186,24 @@ def to_threejs(
     if "roughness" in scalars and scalars["roughness"] is not None:
         result["roughness"] = scalars["roughness"]
     if "color_hex" in scalars and scalars["color_hex"] is not None:
-        result["color"] = _color_hex_to_int(scalars["color_hex"])
+        if color_format is None:
+            warnings.warn(
+                "to_threejs(color_format=) default will flip from 'int' to "
+                "'hex' in mat-vis-client 0.7.0. Pass color_format='int' to "
+                "keep the current hex-int output, or color_format='hex' to "
+                "opt into the new '#RRGGBB' string default. See ADR-0013.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            effective = "int"
+        elif color_format in ("hex", "int"):
+            effective = color_format
+        else:
+            raise ValueError(f"color_format must be 'hex' or 'int', got {color_format!r}")
+        if effective == "int":
+            result["color"] = _color_hex_to_int(scalars["color_hex"])
+        else:  # "hex"
+            result["color"] = scalars["color_hex"]
     if "ior" in scalars and scalars["ior"] is not None:
         result["ior"] = scalars["ior"]
     if "transmission" in scalars and scalars["transmission"] is not None:

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -36,6 +36,7 @@ import urllib.request
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
+from typing import Literal
 
 REPO = "MorePET/mat-vis"
 GITHUB_API = f"https://api.github.com/repos/{REPO}"  # update-check only
@@ -2098,15 +2099,16 @@ class VisAsset:
                 return not tiers
         return False
 
-    def to_threejs(self) -> dict:
+    def to_threejs(self, *, color_format: Literal["hex", "int"] | None = None) -> dict:
         """Return a Three.js ``MeshPhysicalMaterial`` parameter dict.
 
         Wraps :func:`mat_vis_client.adapters.to_threejs` with this asset's
-        identity-bound scalars and textures.
+        identity-bound scalars and textures. ``color_format`` is forwarded —
+        see ADR-0013 / #298 for the 0.6.x → 0.7.0 migration story.
         """
         from mat_vis_client.adapters import to_threejs
 
-        return to_threejs(self.scalars, self.textures)
+        return to_threejs(self.scalars, self.textures, color_format=color_format)
 
     def to_gltf(self) -> dict:
         """Return a glTF 2.0 material dict.

--- a/clients/python/tests/test_adapters_color_format.py
+++ b/clients/python/tests/test_adapters_color_format.py
@@ -1,0 +1,108 @@
+"""Tests for to_threejs ``color_format`` kwarg (ADR-0013 §Decision-2 / #298).
+
+py-mat #99 (Bernhard, build123d): emitting ``result["color"]`` as a
+hex int (``12566468``) is opaque in the REPL, doesn't round-trip
+through JSON for non-Three.js consumers, and is un-Pythonic. The
+substrate gains a ``color_format: Literal["hex", "int"]`` kwarg; the
+default flips from ``"int"`` (current) to ``"hex"`` in 0.7.0.
+
+0.6.5 phasing:
+    color_format=None (unset) → DeprecationWarning + "int" (preserves
+                                current behavior; gives downstream
+                                callers a minor cycle to migrate).
+    color_format="int"        → silent; result["color"] is hex int.
+    color_format="hex"        → silent; result["color"] is "#RRGGBB"
+                                string (Three.js MeshPhysicalMaterial
+                                accepts both lossless).
+
+0.7.0 will drop the sentinel: default flips to ``"hex"``, no warning.
+
+#298.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from mat_vis_client.adapters import to_threejs
+
+
+class TestColorFormatDefault:
+    """Default (unset) behavior — emits DeprecationWarning, returns int."""
+
+    def test_default_emits_deprecation_warning(self):
+        with pytest.warns(DeprecationWarning, match="color_format"):
+            to_threejs({"color_hex": "#bfbfc4"})
+
+    def test_default_preserves_int_behavior(self):
+        with pytest.warns(DeprecationWarning):
+            result = to_threejs({"color_hex": "#bfbfc4"})
+        assert result["color"] == 0xBFBFC4
+        assert isinstance(result["color"], int)
+
+    def test_no_warning_when_color_hex_absent(self):
+        # color_format only governs the color emit; no color_hex → no warning.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            to_threejs({"metalness": 1.0, "roughness": 0.3})
+
+    def test_no_warning_when_color_hex_is_none(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            to_threejs({"color_hex": None})
+
+
+class TestColorFormatExplicit:
+    """Explicit kwarg — no warning, behavior pinned."""
+
+    def test_int_format_explicit(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            result = to_threejs({"color_hex": "#bfbfc4"}, color_format="int")
+        assert result["color"] == 0xBFBFC4
+        assert isinstance(result["color"], int)
+
+    def test_hex_format_explicit(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            result = to_threejs({"color_hex": "#bfbfc4"}, color_format="hex")
+        assert result["color"] == "#bfbfc4"
+        assert isinstance(result["color"], str)
+
+    def test_hex_format_uppercase_preserved(self):
+        # The adapter passes the hex string through verbatim; no normalization.
+        result = to_threejs({"color_hex": "#FF0000"}, color_format="hex")
+        assert result["color"] == "#FF0000"
+
+    def test_int_format_pure_red(self):
+        result = to_threejs({"color_hex": "#FF0000"}, color_format="int")
+        assert result["color"] == 0xFF0000
+
+    def test_int_format_pure_white(self):
+        result = to_threejs({"color_hex": "#FFFFFF"}, color_format="int")
+        assert result["color"] == 0xFFFFFF
+
+
+class TestColorFormatInvalid:
+    """Invalid values raise ValueError on first use."""
+
+    def test_invalid_format_raises(self):
+        with pytest.raises(ValueError, match="color_format"):
+            to_threejs({"color_hex": "#bfbfc4"}, color_format="rgb")  # type: ignore[arg-type]
+
+    def test_invalid_format_only_raises_when_color_hex_present(self):
+        # Without color_hex, color_format is unused — no validation needed.
+        result = to_threejs({}, color_format="rgb")  # type: ignore[arg-type]
+        assert "color" not in result
+
+
+class TestColorFormatKwargOnly:
+    """color_format is keyword-only — positional pass should fail."""
+
+    def test_positional_third_arg_rejected(self):
+        with pytest.raises(TypeError):
+            # Third positional arg should TypeError because color_format
+            # is behind a `*` separator.
+            to_threejs({}, None, "hex")  # type: ignore[misc]

--- a/clients/python/tests/test_adapters_metalcolormap.py
+++ b/clients/python/tests/test_adapters_metalcolormap.py
@@ -106,6 +106,7 @@ def test_substrate_neutralized_color_flows_through():
     result = to_threejs(
         {"metalness": 1.0, "color_hex": "#FFFFFF"},
         {"color": _png_bytes()},
+        color_format="int",
     )
     assert result["color"] == 0xFFFFFF
 
@@ -121,5 +122,6 @@ def test_authored_color_preserved():
     result = to_threejs(
         {"metalness": 1.0, "color_hex": "#E3E3E3"},
         {"color": _png_bytes()},
+        color_format="int",
     )
     assert result["color"] == 0xE3E3E3

--- a/clients/python/tests/test_asset.py
+++ b/clients/python/tests/test_asset.py
@@ -132,8 +132,8 @@ def test_to_threejs_matches_free_function():
         patch.object(c, "_scalars_for", return_value=scalars),
         patch.object(c, "fetch_all_textures", return_value=textures),
     ):
-        got = a.to_threejs()
-    assert got == to_threejs(scalars, textures)
+        got = a.to_threejs(color_format="int")
+    assert got == to_threejs(scalars, textures, color_format="int")
 
 
 def test_to_gltf_matches_free_function():
@@ -257,7 +257,7 @@ def test_to_threejs_scalar_only_source_returns_scalars_no_textures():
     a = VisAsset(c, "physicallybased", "Aluminum", "1k")
     entries = [_scalar_only_index_entry("Aluminum")]
     with patch.object(c, "index", return_value=entries):
-        result = a.to_threejs()
+        result = a.to_threejs(color_format="int")
     # Scalars come through.
     assert result["type"] == "MeshPhysicalMaterial"
     assert result.get("metalness") == 1.0

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -547,7 +547,10 @@ class TestAdapterHelpers:
 
 class TestToThreejs:
     def test_scalars_only(self):
-        result = to_threejs({"metalness": 1.0, "roughness": 0.3, "color_hex": "#C0C0C0"})
+        result = to_threejs(
+            {"metalness": 1.0, "roughness": 0.3, "color_hex": "#C0C0C0"},
+            color_format="int",
+        )
         assert result["type"] == "MeshPhysicalMaterial"
         assert result["metalness"] == 1.0
         assert result["roughness"] == 0.3

--- a/clients/python/tests/test_client_legacy.py
+++ b/clients/python/tests/test_client_legacy.py
@@ -930,7 +930,10 @@ class TestAdapterHelpers:
 
 class TestToThreejs:
     def test_scalars_only(self):
-        result = to_threejs({"metalness": 1.0, "roughness": 0.3, "color_hex": "#C0C0C0"})
+        result = to_threejs(
+            {"metalness": 1.0, "roughness": 0.3, "color_hex": "#C0C0C0"},
+            color_format="int",
+        )
         assert result["type"] == "MeshPhysicalMaterial"
         assert result["metalness"] == 1.0
         assert result["roughness"] == 0.3


### PR DESCRIPTION
## Summary

Adds keyword-only ``color_format: Literal["hex", "int"] | None`` to ``to_threejs``. Threaded through ``VisAsset.to_threejs`` (both the package and the standalone mirror).

| color_format | Behavior | Output shape |
|---|---|---|
| ``None`` (unset) | ``DeprecationWarning`` + emits int (preserves current behavior) | ``12566468`` |
| ``"int"`` | silent, current behavior | ``12566468`` |
| ``"hex"`` | silent, new opt-in | ``"#bfbfc4"`` |
| anything else | ``ValueError`` | — |

The validation only fires when ``color_hex`` is present in scalars — callers without color flow through silently.

## Why phased

Both forms round-trip lossless through ``THREE.MeshPhysicalMaterial`` (its ``Color.set`` dispatches by type — ``setHex`` for int, ``setStyle`` for string). But:

- mat-vis-client is treated as a real downstream contract (py-mat already pins ``>=0.6.3``; in-repo tests assert ``result["color"] == 0xC0C0C0``).
- A ``>=0.6.3`` consumer doing ``new THREE.MeshPhysicalMaterial(result)`` keeps working under either default. But anyone who ever did ``hex(result["color"])``, persisted to JSON, or compared against an int silently breaks.

Sentinel-default + ``DeprecationWarning`` gives downstream callers a minor cycle to migrate. The 0.7.0 cut flips the default to ``"hex"`` and drops the sentinel. py-mat #99 closes on the 0.7.0 bump.

## Test pin updates

The four existing int-pinned tests are now explicit (``color_format="int"``) so they document the legacy behavior they assert and don't trigger the warning during regression runs:

- ``test_client.py::TestToThreejs::test_scalars_only``
- ``test_client_legacy.py::TestToThreejs::test_scalars_only``
- ``test_adapters_metalcolormap.py::test_substrate_neutralized_color_flows_through``
- ``test_adapters_metalcolormap.py::test_authored_color_preserved``
- ``test_asset.py::test_to_threejs_matches_free_function``
- ``test_asset.py::test_to_threejs_scalar_only_source_returns_scalars_no_textures``

## Test plan

- [x] 12 new pytest cases in ``test_adapters_color_format.py`` covering: default DeprecationWarning + int output, no-warning when color_hex absent / None, ``"int"`` and ``"hex"`` explicit forms, invalid format ValueError, kwarg-only enforcement.
- [x] Standalone-drift test ``test_standalone_drift.py`` green — ``mat_vis_client_standalone.py::VisAsset.to_threejs`` mirrors the new kwarg signature.
- [x] ``just test-fast`` (root + client): 468 passed, 16 skipped, **zero warnings**.

## Out of scope

- Default flip + sentinel removal — held for the 0.7.0 cut.
- ``"rgb_float"`` / ``"rgb_byte"`` enum expansion — held for #304 (RGBA input → unambiguous tuple output).

Closes #298. Refs ADR-0013, py-mat #99.