### PR TITLE
feat(client)!: 0.7.0 phase — linear-color foundation + #304 canonical input + colorspace fix

### DIFF
--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -1774,11 +1774,11 @@ class VisAsset:
                 return not tiers
         return False
 
-    def to_threejs(self, *, color_format: Literal["hex", "int"] | None = None) -> dict:
+    def to_threejs(self, *, color_format: Literal["hex", "int"] = "hex") -> dict:
         """Return a Three.js ``MeshPhysicalMaterial`` parameter dict.
 
-        ``color_format`` forwards to the underlying adapter — see
-        ADR-0013 / #298 for the 0.6.x → 0.7.0 migration story.
+        ``color_format`` forwards to the underlying adapter; default is
+        ``"hex"`` (``"#RRGGBB"`` string) since 0.7.0.
         """
         from mat_vis_client.adapters import to_threejs
 

--- a/clients/python/src/mat_vis_client/adapters.py
+++ b/clients/python/src/mat_vis_client/adapters.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import base64
 import math
 import re
-import warnings
 import xml.etree.ElementTree as ET
 from io import BytesIO
 from pathlib import Path
@@ -87,11 +86,102 @@ def _color_hex_to_int(hex_str: str) -> int:
     return int(hex_str.lstrip("#"), 16)
 
 
-def _color_hex_to_rgba(hex_str: str) -> list[float]:
-    """Convert '#RRGGBB' to glTF [R, G, B, A] floats in [0, 1]."""
+def _color_hex_to_srgb_rgba(hex_str: str) -> tuple[float, float, float, float]:
+    """Convert '#RRGGBB' to sRGB-encoded float-4 in [0, 1]. Alpha=1.0.
+
+    NOT linear — see :func:`_srgb_to_linear` for the boundary conversion
+    that ``_resolve_base_color`` applies before linear-space outputs.
+    """
     h = hex_str.lstrip("#")
     r, g, b = int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
-    return [r / 255.0, g / 255.0, b / 255.0, 1.0]
+    return (r / 255.0, g / 255.0, b / 255.0, 1.0)
+
+
+def _srgb_to_linear(c: float) -> float:
+    """sRGB → linear per IEC 61966-2-1 (piecewise transfer function).
+
+    Below 0.04045 the curve is the linear segment ``c / 12.92``;
+    above, the gamma segment ``((c + 0.055) / 1.055) ** 2.4``.
+    Used at every adapter color boundary so sRGB inputs land in
+    linear-aware fields (glTF ``baseColorFactor``, MTLX
+    ``diffuseColor``) without the silent over-bright bug that
+    shipped through 0.6.x. ADR-0013 §Decision-1 / #304.
+    """
+    if c <= 0.04045:
+        return c / 12.92
+    return ((c + 0.055) / 1.055) ** 2.4
+
+
+def _linear_to_srgb(c: float) -> float:
+    """linear → sRGB, inverse of :func:`_srgb_to_linear`."""
+    if c <= 0.0031308:
+        return c * 12.92
+    return 1.055 * (c ** (1.0 / 2.4)) - 0.055
+
+
+def _resolve_base_color(
+    scalars: dict,
+) -> tuple[float, float, float, float] | None:
+    """Resolve the canonical base color as **linear RGBA** in [0, 1].
+
+    Priority order (first non-None wins):
+        1. ``base_color_linear`` (NEW canonical, 4-tuple linear, no transform)
+        2. ``color_rgba`` (4-tuple sRGB-RGB + linear alpha, RGB de-gammas)
+        3. ``color_hex`` (string sRGB ``#RRGGBB``, de-gammas, alpha=1.0)
+
+    Multiple non-equal non-None values raise ``ValueError``. Equal
+    canonical-form values pass.
+
+    Returns ``None`` when no color key is present or all are None.
+
+    ADR-0013 §Decision-1 / #304.
+    """
+    bcl = scalars.get("base_color_linear")
+    rgba_in = scalars.get("color_rgba")
+    hexv = scalars.get("color_hex")
+
+    bcl_t: tuple[float, float, float, float] | None = (
+        tuple(bcl) if bcl is not None else None  # type: ignore[assignment]
+    )
+    rgba_linear: tuple[float, float, float, float] | None = None
+    if rgba_in is not None:
+        r, g, b, a = rgba_in
+        rgba_linear = (
+            _srgb_to_linear(r),
+            _srgb_to_linear(g),
+            _srgb_to_linear(b),
+            a,
+        )
+    hex_linear: tuple[float, float, float, float] | None = None
+    if hexv is not None:
+        sr, sg, sb, sa = _color_hex_to_srgb_rgba(hexv)
+        hex_linear = (
+            _srgb_to_linear(sr),
+            _srgb_to_linear(sg),
+            _srgb_to_linear(sb),
+            sa,
+        )
+
+    candidates = [c for c in (bcl_t, rgba_linear, hex_linear) if c is not None]
+    if not candidates:
+        return None
+    first = candidates[0]
+    for cand in candidates[1:]:
+        if not all(math.isclose(x, y, rel_tol=1e-6, abs_tol=1e-9) for x, y in zip(first, cand)):
+            raise ValueError(
+                "scalars contains multiple base-color keys with non-equal "
+                "values; pick one of base_color_linear / color_rgba / color_hex"
+            )
+    return first
+
+
+def _color_hex_to_rgba(hex_str: str) -> list[float]:
+    """Deprecated 0.6.x helper retained for backward import compat. Kept
+    as a thin wrapper around :func:`_color_hex_to_srgb_rgba` returning a
+    list (the legacy signature). New code paths must use
+    :func:`_resolve_base_color` to get the *linear* form.
+    """
+    return list(_color_hex_to_srgb_rgba(hex_str))
 
 
 def _resolve_metalness(scalars: dict) -> float | None:
@@ -137,7 +227,7 @@ def to_threejs(
     scalars: dict,
     textures: dict[str, bytes] | None = None,
     *,
-    color_format: Literal["hex", "int"] | None = None,
+    color_format: Literal["hex", "int"] = "hex",
 ) -> dict:
     """Convert to a Three.js MeshPhysicalMaterial parameter dict.
 
@@ -147,21 +237,24 @@ def to_threejs(
               (glTF-spec alias). Setting both with non-equal values
               raises ValueError.
             - roughness (float 0-1)
-            - color_hex (str '#RRGGBB')
+            - base_color_linear (tuple[float,float,float,float] —
+              canonical linear RGBA), or
+            - color_rgba (tuple[float,float,float,float] — sRGB RGB
+              + linear alpha; legacy alias), or
+            - color_hex (str ``#RRGGBB`` — sRGB; legacy alias).
+              ``ValueError`` on non-equal multiple base-color keys.
             - ior (float)
             - transmission (float 0-1)
+            - emissive (tuple[float,float,float] linear RGB)
+            - clearcoat (float 0-1)
         textures: Channel name -> PNG bytes. Keys are mat-vis channel
             names: color, normal, roughness, metalness, ao,
             displacement, emission.
-        color_format: Output shape for ``result["color"]`` when
-            ``color_hex`` is present. ``"int"`` emits a hex int (e.g.
-            ``12566468``); ``"hex"`` emits the ``"#RRGGBB"`` string
-            verbatim. Both forms round-trip lossless through Three.js
-            ``MeshPhysicalMaterial`` (its ``Color.set`` dispatches on
-            type — ``setHex`` for int, ``setStyle`` for string).
-            Default is unset for 0.6.x and emits a DeprecationWarning;
-            in 0.7.0 it flips to ``"hex"`` (Pythonic, JSON-friendly,
-            REPL-readable). py-mat #99 / ADR-0013.
+        color_format: Output shape for ``result["color"]``. ``"hex"``
+            (default since 0.7.0) emits ``"#RRGGBB"`` sRGB string;
+            ``"int"`` emits a hex int (legacy form). Both round-trip
+            lossless through ``THREE.MeshPhysicalMaterial`` (its
+            ``Color.set`` dispatches by type). py-mat #99 / ADR-0013.
 
     Returns:
         Dict suitable for `new THREE.MeshPhysicalMaterial(result)`.
@@ -185,25 +278,27 @@ def to_threejs(
         result["metalness"] = metalness
     if "roughness" in scalars and scalars["roughness"] is not None:
         result["roughness"] = scalars["roughness"]
-    if "color_hex" in scalars and scalars["color_hex"] is not None:
-        if color_format is None:
-            warnings.warn(
-                "to_threejs(color_format=) default will flip from 'int' to "
-                "'hex' in mat-vis-client 0.7.0. Pass color_format='int' to "
-                "keep the current hex-int output, or color_format='hex' to "
-                "opt into the new '#RRGGBB' string default. See ADR-0013.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            effective = "int"
-        elif color_format in ("hex", "int"):
-            effective = color_format
-        else:
-            raise ValueError(f"color_format must be 'hex' or 'int', got {color_format!r}")
-        if effective == "int":
-            result["color"] = _color_hex_to_int(scalars["color_hex"])
-        else:  # "hex"
-            result["color"] = scalars["color_hex"]
+    if color_format not in ("hex", "int"):
+        raise ValueError(f"color_format must be 'hex' or 'int', got {color_format!r}")
+    base_color = _resolve_base_color(scalars)
+    if base_color is not None:
+        # Three.js MeshPhysicalMaterial.color is sRGB by default
+        # (ColorManagement r152+). Re-encode linear → sRGB regardless
+        # of which input form the caller used.
+        srgb = tuple(_linear_to_srgb(c) for c in base_color[:3])
+        hex_str = "#{:02x}{:02x}{:02x}".format(
+            int(round(max(0.0, min(1.0, srgb[0])) * 255)),
+            int(round(max(0.0, min(1.0, srgb[1])) * 255)),
+            int(round(max(0.0, min(1.0, srgb[2])) * 255)),
+        )
+        if color_format == "hex":
+            # Preserve the input hex literal verbatim when the caller
+            # passed color_hex — avoids surprise float-round byte
+            # changes. Synthesized form covers tuple inputs.
+            literal = scalars.get("color_hex")
+            result["color"] = literal if literal is not None else hex_str
+        else:  # "int"
+            result["color"] = int(hex_str.lstrip("#"), 16)
     if "ior" in scalars and scalars["ior"] is not None:
         result["ior"] = scalars["ior"]
     if "transmission" in scalars and scalars["transmission"] is not None:
@@ -264,8 +359,12 @@ def to_gltf(
         pbr["metallicFactor"] = metalness
     if "roughness" in scalars and scalars["roughness"] is not None:
         pbr["roughnessFactor"] = scalars["roughness"]
-    if "color_hex" in scalars and scalars["color_hex"] is not None:
-        pbr["baseColorFactor"] = _color_hex_to_rgba(scalars["color_hex"])
+    base_color = _resolve_base_color(scalars)
+    if base_color is not None:
+        # glTF 2.0 §3.9.2 requires baseColorFactor in linear space.
+        # _resolve_base_color de-gammas at the boundary regardless of
+        # which input form the caller used. ADR-0013 §Decision-2.
+        pbr["baseColorFactor"] = list(base_color)
 
     # IOR extension — omit when the value matches the spec default 1.5
     # (a no-op extension entry only bloats glTF output). mat-vis#290.
@@ -440,13 +539,14 @@ def _build_mtlx_tree(
     # the nodegraph path above provides diffuseColor via the <image>
     # node (with srgb_texture colorspace). The scalar fallback is for
     # PBR-scalar-only materials (most metals/plastics) so MTLX renderers
-    # don't fall back to white. ADR-0013 §Decision-2 / #317.
-    # NOTE: 0.6.5 emits sRGB-byte/255 (matches naive _color_hex_to_rgba);
-    # 0.7.0 will switch to linear via _srgb_to_linear under #304.
-    if scalars.get("color_hex") is not None and "color" not in tex_filenames:
-        rgba = _color_hex_to_rgba(scalars["color_hex"])
-        rgb = ",".join(f"{c:g}" for c in rgba[:3])
-        ET.SubElement(shader, "input", name="diffuseColor", type="color3", value=rgb)
+    # don't fall back to white. UsdPreviewSurface diffuseColor is linear
+    # by convention — _resolve_base_color de-gammas at the boundary
+    # regardless of input form. ADR-0013 §Decision-2 / #317 / #304.
+    if "color" not in tex_filenames:
+        base_color = _resolve_base_color(scalars)
+        if base_color is not None:
+            rgb = ",".join(f"{c:g}" for c in base_color[:3])
+            ET.SubElement(shader, "input", name="diffuseColor", type="color3", value=rgb)
 
     # Emissive RGB on the shader scalar path. Texture-bound emission is
     # already routed through the nodegraph above (channel "emission").

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -2099,12 +2099,12 @@ class VisAsset:
                 return not tiers
         return False
 
-    def to_threejs(self, *, color_format: Literal["hex", "int"] | None = None) -> dict:
+    def to_threejs(self, *, color_format: Literal["hex", "int"] = "hex") -> dict:
         """Return a Three.js ``MeshPhysicalMaterial`` parameter dict.
 
         Wraps :func:`mat_vis_client.adapters.to_threejs` with this asset's
-        identity-bound scalars and textures. ``color_format`` is forwarded —
-        see ADR-0013 / #298 for the 0.6.x → 0.7.0 migration story.
+        identity-bound scalars and textures. ``color_format`` is forwarded;
+        default is ``"hex"`` (Pythonic ``"#RRGGBB"`` string) since 0.7.0.
         """
         from mat_vis_client.adapters import to_threejs
 

--- a/clients/python/tests/test_adapters_color_format.py
+++ b/clients/python/tests/test_adapters_color_format.py
@@ -1,21 +1,13 @@
 """Tests for to_threejs ``color_format`` kwarg (ADR-0013 §Decision-2 / #298).
 
 py-mat #99 (Bernhard, build123d): emitting ``result["color"]`` as a
-hex int (``12566468``) is opaque in the REPL, doesn't round-trip
-through JSON for non-Three.js consumers, and is un-Pythonic. The
-substrate gains a ``color_format: Literal["hex", "int"]`` kwarg; the
-default flips from ``"int"`` (current) to ``"hex"`` in 0.7.0.
+hex int is opaque in the REPL, doesn't round-trip through JSON for
+non-Three.js consumers, and is un-Pythonic. ``color_format: Literal[
+"hex", "int"]`` exposes the choice; default is ``"hex"`` since 0.7.0.
 
-0.6.5 phasing:
-    color_format=None (unset) → DeprecationWarning + "int" (preserves
-                                current behavior; gives downstream
-                                callers a minor cycle to migrate).
-    color_format="int"        → silent; result["color"] is hex int.
-    color_format="hex"        → silent; result["color"] is "#RRGGBB"
-                                string (Three.js MeshPhysicalMaterial
-                                accepts both lossless).
-
-0.7.0 will drop the sentinel: default flips to ``"hex"``, no warning.
+  color_format="hex" (default) → result["color"] is "#RRGGBB" string.
+  color_format="int"           → result["color"] is hex int (legacy).
+  color_format=anything else   → ValueError (eager validation).
 
 #298.
 """
@@ -30,27 +22,21 @@ from mat_vis_client.adapters import to_threejs
 
 
 class TestColorFormatDefault:
-    """Default (unset) behavior — emits DeprecationWarning, returns int."""
+    """Default behavior (0.7.0): emits ``"#RRGGBB"`` string, no warning."""
 
-    def test_default_emits_deprecation_warning(self):
-        with pytest.warns(DeprecationWarning, match="color_format"):
-            to_threejs({"color_hex": "#bfbfc4"})
-
-    def test_default_preserves_int_behavior(self):
-        with pytest.warns(DeprecationWarning):
+    def test_default_emits_hex_string(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
             result = to_threejs({"color_hex": "#bfbfc4"})
-        assert result["color"] == 0xBFBFC4
-        assert isinstance(result["color"], int)
+        assert result["color"] == "#bfbfc4"
+        assert isinstance(result["color"], str)
 
-    def test_no_warning_when_color_hex_absent(self):
-        # color_format only governs the color emit; no color_hex → no warning.
+    def test_no_warning_for_any_call(self):
+        # The 0.6.x DeprecationWarning is gone in 0.7.0.
         with warnings.catch_warnings():
             warnings.simplefilter("error", DeprecationWarning)
+            to_threejs({"color_hex": "#FF0000"})
             to_threejs({"metalness": 1.0, "roughness": 0.3})
-
-    def test_no_warning_when_color_hex_is_none(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", DeprecationWarning)
             to_threejs({"color_hex": None})
 
 
@@ -92,10 +78,11 @@ class TestColorFormatInvalid:
         with pytest.raises(ValueError, match="color_format"):
             to_threejs({"color_hex": "#bfbfc4"}, color_format="rgb")  # type: ignore[arg-type]
 
-    def test_invalid_format_only_raises_when_color_hex_present(self):
-        # Without color_hex, color_format is unused — no validation needed.
-        result = to_threejs({}, color_format="rgb")  # type: ignore[arg-type]
-        assert "color" not in result
+    def test_invalid_format_raises_eagerly_even_without_color(self):
+        # 0.7.0: validation fires up front regardless of whether scalars
+        # actually contain a color key. Fail fast for typos.
+        with pytest.raises(ValueError, match="color_format"):
+            to_threejs({}, color_format="rgb")  # type: ignore[arg-type]
 
 
 class TestColorFormatKwargOnly:

--- a/clients/python/tests/test_adapters_linear_color.py
+++ b/clients/python/tests/test_adapters_linear_color.py
@@ -1,0 +1,263 @@
+"""Tests for the linear-color foundation + #304 canonical input + 0.7.0 default flip.
+
+ADR-0013 §Decision-1 / 2 / 5 — phase 0.7.0:
+
+1. ``_srgb_to_linear`` / ``_linear_to_srgb`` — IEC 61966-2-1 piecewise
+   conversions used at every adapter color boundary so sRGB inputs
+   land in linear-aware fields (glTF ``baseColorFactor``, MTLX
+   ``diffuseColor``) without the silent sRGB-as-linear rendering bug
+   that shipped through 0.6.x.
+
+2. ``_resolve_base_color`` — canonical input resolver. Returns linear
+   RGBA in [0, 1] from any of:
+       - ``base_color_linear`` (NEW canonical, no transform)
+       - ``color_rgba`` (sRGB legacy alias, de-gammas RGB; alpha
+         passes through linear)
+       - ``color_hex`` (sRGB legacy alias, de-gammas)
+   ValueError on conflicting non-equal values.
+
+3. #304 alpha preservation — ``color_rgba`` 4-tuple input flows
+   through ``to_gltf`` ``baseColorFactor`` as linear RGBA without
+   collapsing alpha.
+
+4. ``to_gltf`` ``baseColorFactor`` is now LINEAR per glTF 2.0 §3.9.2
+   — fixes the latent over-bright rendering bug. Numeric output
+   changes for any ``color_hex``-only caller (extremes #000000 /
+   #FFFFFF / #FF0000 round-trip identically; mid-tones differ).
+
+5. ``to_threejs`` default ``color_format`` flips from int to
+   ``"hex"``. The DeprecationWarning is gone. The sentinel is
+   removed.
+
+#304 + ADR-0013.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+
+import pytest
+
+from mat_vis_client.adapters import (
+    _linear_to_srgb,
+    _resolve_base_color,
+    _srgb_to_linear,
+    to_gltf,
+    to_threejs,
+)
+
+
+# ── sRGB ↔ linear helpers ──────────────────────────────────────
+
+
+class TestSrgbLinearHelpers:
+    """IEC 61966-2-1 piecewise transfer function. Verified against
+    the spec's reference points and round-trip preservation.
+    """
+
+    def test_pure_extremes_unchanged(self):
+        # 0 and 1 are mathematical fixed points; allow float-math tolerance.
+        assert _srgb_to_linear(0.0) == 0.0
+        assert math.isclose(_srgb_to_linear(1.0), 1.0, abs_tol=1e-9)
+        assert _linear_to_srgb(0.0) == 0.0
+        assert math.isclose(_linear_to_srgb(1.0), 1.0, abs_tol=1e-9)
+
+    def test_linear_breakpoint(self):
+        # The piecewise breakpoint at sRGB = 0.04045 → linear = 0.0031308.
+        # Below the breakpoint, sRGB to linear is the linear segment c/12.92.
+        assert math.isclose(_srgb_to_linear(0.04045), 0.0031308, abs_tol=1e-6)
+
+    def test_mid_tone_de_gamma(self):
+        # sRGB 0.5 → linear ~0.2140 (well-known reference point).
+        assert math.isclose(_srgb_to_linear(0.5), 0.21404, abs_tol=1e-4)
+
+    def test_round_trip_integrity(self):
+        # Round-trip preserves value to within 1e-9 across the [0, 1]
+        # range (modulo float precision).
+        for v in (0.1, 0.25, 0.5, 0.749, 0.8, 0.95):
+            assert math.isclose(_linear_to_srgb(_srgb_to_linear(v)), v, abs_tol=1e-6)
+
+    def test_known_byte_values(self):
+        # 0xbf = 191/255 ≈ 0.7490196 sRGB → linear ≈ 0.520996.
+        # Used as a substrate-realistic check.
+        srgb = 0xBF / 255.0
+        assert math.isclose(_srgb_to_linear(srgb), 0.520996, abs_tol=1e-5)
+        # 0xc4 = 196/255 ≈ 0.7686275 sRGB → linear ≈ 0.552011.
+        srgb_c4 = 0xC4 / 255.0
+        assert math.isclose(_srgb_to_linear(srgb_c4), 0.552011, abs_tol=1e-5)
+
+
+# ── _resolve_base_color ────────────────────────────────────────
+
+
+class TestResolveBaseColor:
+    def test_no_color_returns_none(self):
+        assert _resolve_base_color({}) is None
+
+    def test_color_hex_de_gammas(self):
+        # #bfbfc4 sRGB → linear (~0.521, ~0.521, ~0.552, 1.0).
+        rgba = _resolve_base_color({"color_hex": "#bfbfc4"})
+        assert rgba is not None
+        assert math.isclose(rgba[0], 0.520996, abs_tol=1e-5)
+        assert math.isclose(rgba[2], 0.552011, abs_tol=1e-5)
+        assert rgba[3] == 1.0
+
+    def test_color_hex_pure_extremes_round_trip(self):
+        # #FFFFFF and #000000 are fixed points in sRGB→linear.
+        assert _resolve_base_color({"color_hex": "#FFFFFF"}) == (1.0, 1.0, 1.0, 1.0)
+        assert _resolve_base_color({"color_hex": "#000000"}) == (0.0, 0.0, 0.0, 1.0)
+        assert _resolve_base_color({"color_hex": "#FF0000"}) == (1.0, 0.0, 0.0, 1.0)
+
+    def test_base_color_linear_passes_through(self):
+        # Canonical linear input — no de-gamma, no transform.
+        rgba = _resolve_base_color({"base_color_linear": (0.5, 0.5, 0.5, 0.7)})
+        assert rgba == (0.5, 0.5, 0.5, 0.7)
+
+    def test_color_rgba_de_gammas_rgb_preserves_alpha(self):
+        # color_rgba is sRGB-encoded RGB + linear alpha.
+        rgba = _resolve_base_color({"color_rgba": (0.5, 0.5, 0.5, 0.7)})
+        assert rgba is not None
+        # Linear value of sRGB 0.5
+        assert math.isclose(rgba[0], 0.21404, abs_tol=1e-4)
+        # Alpha passes through linearly
+        assert rgba[3] == 0.7
+
+    def test_priority_canonical_wins(self):
+        # When both base_color_linear and color_hex are set, the
+        # canonical key takes precedence; conflict only fires when
+        # values are non-equal.
+        rgba = _resolve_base_color(
+            {
+                "base_color_linear": (0.1, 0.2, 0.3, 0.5),
+            }
+        )
+        assert rgba == (0.1, 0.2, 0.3, 0.5)
+
+    def test_conflict_color_rgba_vs_color_hex_raises(self):
+        with pytest.raises(ValueError, match="color"):
+            _resolve_base_color({"color_rgba": (1.0, 0.0, 0.0, 1.0), "color_hex": "#00FF00"})
+
+    def test_conflict_base_color_linear_vs_color_hex_raises(self):
+        with pytest.raises(ValueError, match="color"):
+            _resolve_base_color(
+                {
+                    "base_color_linear": (0.0, 1.0, 0.0, 1.0),
+                    "color_hex": "#FF0000",
+                }
+            )
+
+    def test_none_keys_defer(self):
+        # Setting a key to None should defer to the next priority key.
+        rgba = _resolve_base_color({"base_color_linear": None, "color_hex": "#FF0000"})
+        assert rgba == (1.0, 0.0, 0.0, 1.0)
+
+
+# ── to_gltf — linear baseColorFactor ────────────────────────────
+
+
+class TestToGltfLinearBaseColor:
+    """ADR-0013 §Decision-2: glTF 2.0 §3.9.2 requires baseColorFactor
+    in linear space. 0.6.x emitted sRGB-byte/255 — fixed in 0.7.0.
+    """
+
+    def test_white_round_trips_identical(self):
+        result = to_gltf({"color_hex": "#FFFFFF"})
+        assert result["pbrMetallicRoughness"]["baseColorFactor"] == [1.0, 1.0, 1.0, 1.0]
+
+    def test_black_round_trips_identical(self):
+        result = to_gltf({"color_hex": "#000000"})
+        assert result["pbrMetallicRoughness"]["baseColorFactor"] == [0.0, 0.0, 0.0, 1.0]
+
+    def test_pure_red_round_trips_identical(self):
+        result = to_gltf({"color_hex": "#FF0000"})
+        assert result["pbrMetallicRoughness"]["baseColorFactor"] == [1.0, 0.0, 0.0, 1.0]
+
+    def test_mid_tone_de_gammas(self):
+        # #bfbfc4 sRGB → linear ~(0.521, 0.521, 0.552). Was (0.749…, …)
+        # pre-0.7.0 — this is the breaking-change correctness fix.
+        result = to_gltf({"color_hex": "#bfbfc4"})
+        bcf = result["pbrMetallicRoughness"]["baseColorFactor"]
+        assert math.isclose(bcf[0], 0.520996, abs_tol=1e-5)
+        assert math.isclose(bcf[2], 0.552011, abs_tol=1e-5)
+        assert bcf[3] == 1.0
+
+    def test_color_rgba_alpha_preserved_through_to_gltf(self):
+        # #304 alpha-loss fix. RGBA with alpha=0.7 must reach
+        # baseColorFactor[3] verbatim; RGB de-gamma applies separately.
+        result = to_gltf({"color_rgba": (0.5, 0.5, 0.5, 0.7)})
+        bcf = result["pbrMetallicRoughness"]["baseColorFactor"]
+        assert math.isclose(bcf[0], 0.21404, abs_tol=1e-4)  # sRGB 0.5 → linear
+        assert bcf[3] == 0.7
+
+    def test_base_color_linear_passes_through(self):
+        # Canonical linear input — no transform, alpha intact.
+        result = to_gltf({"base_color_linear": (0.5, 0.5, 0.5, 0.7)})
+        assert result["pbrMetallicRoughness"]["baseColorFactor"] == [0.5, 0.5, 0.5, 0.7]
+
+
+# ── to_threejs — default flip ──────────────────────────────────
+
+
+class TestToThreejsDefaultIsHex:
+    """0.7.0: default color_format flips from int (with
+    DeprecationWarning) to "hex" (silent, Pythonic, JSON-friendly).
+    """
+
+    def test_default_emits_hex_string(self):
+        result = to_threejs({"color_hex": "#bfbfc4"})
+        assert result["color"] == "#bfbfc4"
+        assert isinstance(result["color"], str)
+
+    def test_no_deprecation_warning_at_default(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            to_threejs({"color_hex": "#FF0000"})
+
+    def test_int_format_still_works(self):
+        result = to_threejs({"color_hex": "#bfbfc4"}, color_format="int")
+        assert result["color"] == 0xBFBFC4
+
+    def test_hex_format_explicit_unchanged(self):
+        result = to_threejs({"color_hex": "#bfbfc4"}, color_format="hex")
+        assert result["color"] == "#bfbfc4"
+
+
+# ── color_rgba on to_threejs ───────────────────────────────────
+
+
+class TestToThreejsColorRgba:
+    """to_threejs accepts color_rgba and base_color_linear too.
+    Three.js consumes sRGB hex; we re-encode from linear so the
+    string output is correct regardless of input form.
+    """
+
+    def test_color_rgba_emits_correct_hex(self):
+        # color_rgba sRGB (1.0, 0.0, 0.0, 1.0) → "#ff0000"
+        result = to_threejs({"color_rgba": (1.0, 0.0, 0.0, 1.0)})
+        assert result["color"].lower() == "#ff0000"
+
+    def test_base_color_linear_re_gammas_for_hex(self):
+        # base_color_linear (1.0, 1.0, 1.0, 1.0) → "#ffffff" (sRGB)
+        result = to_threejs({"base_color_linear": (1.0, 1.0, 1.0, 1.0)})
+        assert result["color"].lower() == "#ffffff"
+
+
+# ── MTLX diffuseColor / emissiveColor — linear values ───────────
+
+
+class TestMtlxLinearValues:
+    """ADR-0013 §Decision-2: UsdPreviewSurface diffuseColor /
+    emissiveColor are linear by convention. 0.6.x emitted
+    sRGB-byte/255 — fixed in 0.7.0.
+    """
+
+    def test_diffuse_color_is_linear(self, tmp_path):
+        from mat_vis_client.adapters import export_mtlx
+
+        out = export_mtlx({"color_hex": "#bfbfc4"}, output_dir=tmp_path)
+        xml = out.read_text()
+        # 0xbf/255 = 0.74902 sRGB → ~0.520996 linear
+        assert "0.520996" in xml
+        # The pre-0.7.0 sRGB-byte value (0.74902) must not appear.
+        assert "0.74902" not in xml

--- a/clients/python/tests/test_adapters_mtlx_scalar_color.py
+++ b/clients/python/tests/test_adapters_mtlx_scalar_color.py
@@ -11,10 +11,8 @@ to_gltf on the scalar path. Texture-bound color still routes through
 the existing nodegraph (with the established ``srgb_texture``
 colorspace tag); only the scalar fallback is new.
 
-The 0.6.5 cut emits sRGB-byte/255 (matches the existing naive
-``_color_hex_to_rgba`` helper). The 0.7.0 cut will switch to linear
-via ``_srgb_to_linear`` since UsdPreviewSurface ``diffuseColor`` is
-linear by convention.
+UsdPreviewSurface ``diffuseColor`` is **linear** by convention. Since
+0.7.0 (#304) the scalar emit de-gammas via ``_resolve_base_color``.
 
 #317.
 """
@@ -50,9 +48,9 @@ class TestMtlxScalarColor:
         xml = out.read_text()
         assert 'name="diffuseColor"' in xml
         assert 'type="color3"' in xml
-        # 0xbf/255 = 0.7490196..., 0xc4/255 = 0.7686274...
-        # Default ``{:g}`` (6 sig figs) → "0.74902" / "0.768627".
-        assert 'value="0.74902,0.74902,0.768627"' in xml
+        # sRGB de-gammaed: 0xbf → ~0.520996, 0xc4 → ~0.552011 linear.
+        # Default ``{:g}`` (6 sig figs) → "0.520996" / "0.552011".
+        assert 'value="0.520996,0.520996,0.552011"' in xml
 
     def test_pure_red_renders_cleanly(self, tmp_path: Path):
         out = export_mtlx({"color_hex": "#FF0000"}, output_dir=tmp_path)
@@ -78,7 +76,7 @@ class TestMtlxScalarColor:
         # texture-path diffuseColor input is `<... nodegraph="..."
         # output="..."/>` (no value attr). Confirm the scalar form is
         # absent — only the nodegraph form should bind diffuseColor.
-        assert "0.74902" not in xml
+        assert "0.520996" not in xml
         assert 'colorspace="srgb_texture"' in xml
 
     def test_no_color_input_when_neither_scalar_nor_texture(self, tmp_path: Path):


### PR DESCRIPTION
## Summary — coordinated 0.7.0 cut

ADR-0013 phases the breaking-change correctness fixes into a single 0.7.0 PR so consumers see one numeric jump rather than a sequence of partial breaks.

### What changes

| Layer | Before (0.6.x) | After (0.7.0) |
|---|---|---|
| Canonical color input | ``color_hex`` only (lossy) | ``base_color_linear`` (canonical) + ``color_rgba`` (sRGB) + ``color_hex`` (sRGB), priority order |
| ``to_gltf`` ``baseColorFactor`` | sRGB-as-linear (wrong-space, over-bright) | **linear** per glTF 2.0 §3.9.2 ✓ |
| ``to_threejs`` default | int + ``DeprecationWarning`` | ``"#RRGGBB"`` sRGB string, no warning |
| MTLX ``diffuseColor`` value | sRGB-byte/255 | **linear** (UsdPreviewSurface convention) |
| MTLX ``emissiveColor`` value | linear-as-input (no transform) | unchanged — already linear by convention |
| Alpha through ``to_gltf`` | dropped via ``_rgba_to_hex`` boundary | preserved through ``color_rgba`` / ``base_color_linear`` |
| ``color_format`` default | sentinel-with-warning | ``"hex"``; eager validation |

### Foundation helpers (new)

```python
def _srgb_to_linear(c: float) -> float: ...      # IEC 61966-2-1 piecewise
def _linear_to_srgb(c: float) -> float: ...
def _resolve_base_color(scalars) -> tuple[float, float, float, float] | None: ...
```

``_resolve_base_color`` is the boundary: returns linear RGBA from any input form, raises ``ValueError`` on conflicting non-equal values.

### Numeric impact (the breaking part)

For ``to_gltf({"color_hex": "#bfbfc4"})``:
- 0.6.x: ``baseColorFactor == [0.74902, 0.74902, 0.76863, 1.0]`` (sRGB-as-linear — **wrong**)
- 0.7.0: ``baseColorFactor == [0.520996, 0.520996, 0.552011, 1.0]`` (linear — **correct**)

Extremes (``#000000`` / ``#FFFFFF`` / ``#FF0000``) are fixed points and round-trip identically. Mid-tones differ. Renderers that were "compensating" via gamma settings will need adjustment — flagged explicitly in the commit message and CHANGELOG-worthy.

### Test plan

- [x] 27 new pytest cases in ``test_adapters_linear_color.py`` covering: sRGB ↔ linear helper round-trip + extremes + breakpoint + mid-tone + substrate-realistic byte values; ``_resolve_base_color`` priority + alpha preservation + ValueError on conflict; ``to_gltf`` linear ``baseColorFactor`` (extremes identical, mid-tones de-gammaed); ``to_threejs`` default-flip + no-warning + ``color_rgba`` / ``base_color_linear`` re-encode; MTLX linear values.
- [x] Three phase-0.6.5 tests updated to align (``test_adapters_color_format.py``, ``test_adapters_mtlx_scalar_color.py``).
- [x] Standalone-mirror signature drift caught by ``test_standalone_drift.py``; updated.
- [x] ``just test-fast`` (root + client): 489 + 350 = 839 passed, 27+16 skipped, **zero warnings**.

### Cross-repo

- py-mat 0.7.0+: adopt ``base_color_linear`` as canonical (replace ``_rgba_to_hex`` boundary call); pin ``mat-vis-client>=0.7.0``.
- Closes py-mat #99 on the bump.

Closes #304. Refs ADR-0013, milestone #3.