### PR TITLE
feat(baker): per-source catalog merge-on-write (closes #301)

### DIFF
--- a/src/mat_vis_baker/hf_bake_per_file.py
+++ b/src/mat_vis_baker/hf_bake_per_file.py
@@ -220,6 +220,107 @@ def _merge_manifest_for_source(
     return manifest
 
 
+def _fetch_catalog_with_parent(
+    api: HfApi, repo_id: str, revision: str, source: str
+) -> tuple[list[dict], str | None]:
+    """Return ``(existing_catalog, parent_sha)`` for the per-source catalog.
+
+    Mirrors :func:`_fetch_manifest_with_parent` for the per-source
+    ``<source>.json``. ``parent_sha`` is unused for the catalog write
+    (the manifest write is the CAS anchor — both files commit together
+    in one operation), but returned for symmetry / future use.
+
+    Returns ``([], None)`` when the catalog doesn't exist yet
+    (first cut on a release tag).
+    """
+    parent_sha: str | None = None
+    try:
+        info = api.repo_info(repo_id=repo_id, repo_type="dataset", revision=revision)
+        parent_sha = getattr(info, "sha", None)
+    except Exception:  # noqa: BLE001 — branch may not exist yet
+        pass
+
+    existing: list[dict] = []
+    try:
+        path = api.hf_hub_download(
+            repo_id=repo_id,
+            repo_type="dataset",
+            revision=revision,
+            filename=f"{source}.json",
+        )
+        loaded = json.loads(Path(path).read_text())
+        if isinstance(loaded, list):
+            existing = loaded
+    except Exception:  # noqa: BLE001 — 404 / not yet uploaded → []
+        existing = []
+    return existing, parent_sha
+
+
+def _merge_catalog_with_existing(
+    fresh: list[dict],
+    existing: list[dict],
+    fresh_tier: str,
+) -> list[dict]:
+    """Merge a freshly-baked per-source catalog onto the existing one.
+
+    Implements the cross-tier ``available_tiers`` preservation that
+    mat-vis#301 needs:
+
+    - For each material in BOTH existing and fresh: take the FRESH
+      entry (newest data wins) but set
+      ``available_tiers = sorted(union(existing.available_tiers, [fresh_tier]))``.
+    - For each material ONLY in existing (had this material at some
+      tier before, but the fresh bake of `fresh_tier` doesn't see it):
+      compute ``new_tiers = existing.available_tiers - {fresh_tier}``.
+      If non-empty: PRESERVE the existing entry with
+      ``available_tiers = sorted(new_tiers)``. If empty: DROP (the
+      material existed only at this tier, upstream pruned it).
+    - For each material ONLY in fresh: KEEP as-is (new addition;
+      ``available_tiers = [fresh_tier]`` already from index_builder).
+
+    Order preserved: fresh entries first (in their input order — already
+    sorted by name in :func:`build_index`), then any preserved-existing
+    entries in their original order.
+
+    First-cut case (no existing): returns ``fresh`` unchanged.
+    """
+    if not existing:
+        return fresh
+
+    fresh_by_id: dict[str, dict] = {e["id"]: e for e in fresh if "id" in e}
+    out: list[dict] = []
+
+    # Pass 1: walk fresh in order, merging available_tiers from existing.
+    existing_by_id: dict[str, dict] = {e["id"]: e for e in existing if "id" in e}
+    for entry in fresh:
+        mid = entry.get("id")
+        if mid is None:
+            continue
+        prev = existing_by_id.get(mid)
+        if prev is not None:
+            prev_tiers = set(prev.get("available_tiers") or [])
+            cur_tiers = set(entry.get("available_tiers") or [])
+            merged_tiers = sorted(prev_tiers | cur_tiers)
+            entry = {**entry, "available_tiers": merged_tiers}
+        out.append(entry)
+
+    # Pass 2: append existing entries that are NOT in fresh, with the
+    # fresh_tier removed from their available_tiers. Drop if empty.
+    for prev in existing:
+        mid = prev.get("id")
+        if mid is None or mid in fresh_by_id:
+            continue
+        prev_tiers = set(prev.get("available_tiers") or [])
+        new_tiers = sorted(prev_tiers - {fresh_tier})
+        if not new_tiers:
+            # Existed only at the tier we just baked, and fresh bake
+            # doesn't see it → upstream pruned, drop.
+            continue
+        out.append({**prev, "available_tiers": new_tiers})
+
+    return out
+
+
 def _channel_ext(data: bytes) -> str:
     """Inspect magic bytes; mirror TarWriter's detection so URLs stay
     predictable for clients."""
@@ -634,6 +735,28 @@ def bake_one_per_file(
                 mtlx_filename=mtlx_filename,
             )
             manifest_path.write_text(json.dumps(merged, indent=2, ensure_ascii=False) + "\n")
+
+            # mat-vis#301: per-source catalog merge-on-write.
+            # Fetch existing `<source>.json` from HF and merge with the
+            # freshly-baked records (preserving cross-tier
+            # `available_tiers` for materials baked at OTHER tiers in
+            # earlier dispatches). Without this, baking 1k then 2k
+            # without a derive in between would clobber the 1k tier
+            # off every material's `available_tiers` even though the 1k
+            # files are still committed under `<source>/1k/`.
+            #
+            # Fetched inside the CAS loop so a concurrent writer's
+            # update is observed on retry — same shape as the manifest
+            # merge above. The `<source>.json` and manifest commit
+            # together in one operation, so a single 412 on the manifest
+            # already covers catalog conflicts.
+            existing_catalog, _ = _fetch_catalog_with_parent(api, repo_id, release_tag, source)
+            merged_catalog = _merge_catalog_with_existing(
+                fresh=index,
+                existing=existing_catalog,
+                fresh_tier=storage_tier,
+            )
+            catalog_path.write_text(json.dumps(merged_catalog, indent=2, ensure_ascii=False) + "\n")
             # #292: ship the packed upstream-MTLX JSON in the same atomic
             # commit as catalog + manifest. The manifest entry that points
             # at it lands in the same commit, so a client that sees the

--- a/tests/test_catalog_merge_on_write.py
+++ b/tests/test_catalog_merge_on_write.py
@@ -1,0 +1,180 @@
+"""Tests for the per-source catalog merge-on-write (mat-vis#301).
+
+The merge function preserves cross-tier `available_tiers` so that
+baking 1k then 2k (or any cross-tier sequence) doesn't clobber the
+earlier tier off every material's catalog entry.
+
+Pure-function tests against `_merge_catalog_with_existing`. The
+HF-fetch wiring + CAS retry loop is tested live in
+`tests/e2e/test_per_file_roundtrip.py` (gated on MAT_VIS_E2E=1) and
+not duplicated here.
+"""
+
+from __future__ import annotations
+
+
+from mat_vis_baker.hf_bake_per_file import _merge_catalog_with_existing
+
+
+def _entry(mid: str, tiers: list[str], **extra) -> dict:
+    """Build a minimal catalog entry with the given available_tiers."""
+    return {
+        "id": mid,
+        "source": "test",
+        "available_tiers": list(tiers),
+        "mat_vis": {"name": mid, **(extra.get("mat_vis") or {})},
+    }
+
+
+# ── first-cut case ──────────────────────────────────────────────
+
+
+def test_first_cut_no_existing_returns_fresh_unchanged():
+    fresh = [_entry("a", ["1k"]), _entry("b", ["1k"])]
+    out = _merge_catalog_with_existing(fresh=fresh, existing=[], fresh_tier="1k")
+    assert out == fresh
+
+
+def test_first_cut_with_falsy_existing_treats_as_empty():
+    fresh = [_entry("a", ["2k"])]
+    out = _merge_catalog_with_existing(fresh=fresh, existing=[], fresh_tier="2k")
+    assert out == fresh
+
+
+# ── core merge behavior ─────────────────────────────────────────
+
+
+def test_material_in_both_unions_available_tiers():
+    """Material present at 1k previously, now baked at 2k → both tiers."""
+    existing = [_entry("a", ["1k"])]
+    fresh = [_entry("a", ["2k"])]
+    out = _merge_catalog_with_existing(fresh=fresh, existing=existing, fresh_tier="2k")
+    assert len(out) == 1
+    assert out[0]["id"] == "a"
+    assert out[0]["available_tiers"] == ["1k", "2k"]
+
+
+def test_material_in_both_takes_fresh_data_for_other_fields():
+    """Newest data wins for everything except available_tiers."""
+    existing = [_entry("a", ["1k"], mat_vis={"category": "stale"})]
+    fresh = [_entry("a", ["2k"], mat_vis={"category": "current"})]
+    out = _merge_catalog_with_existing(fresh=fresh, existing=existing, fresh_tier="2k")
+    assert out[0]["mat_vis"]["category"] == "current"
+
+
+def test_re_bake_same_tier_no_op_on_available_tiers():
+    """Bake 1k twice — available_tiers stays ["1k"]."""
+    existing = [_entry("a", ["1k"])]
+    fresh = [_entry("a", ["1k"])]
+    out = _merge_catalog_with_existing(fresh=fresh, existing=existing, fresh_tier="1k")
+    assert out[0]["available_tiers"] == ["1k"]
+
+
+def test_material_only_in_fresh_added_as_new():
+    """A new material upstream — added as-is."""
+    existing = [_entry("a", ["1k"])]
+    fresh = [_entry("a", ["2k"]), _entry("b", ["2k"])]
+    out = _merge_catalog_with_existing(fresh=fresh, existing=existing, fresh_tier="2k")
+    ids = [e["id"] for e in out]
+    assert ids == ["a", "b"]
+
+
+def test_material_only_in_existing_with_other_tier_preserved():
+    """Bake 1k after upstream prunes material X from a previous 2k bake.
+    X had available_tiers=["1k", "2k"] before this 1k re-bake; fresh
+    doesn't see X. Drop fresh_tier from X → ["2k"], preserve."""
+    existing = [_entry("x", ["1k", "2k"])]
+    fresh = [_entry("a", ["1k"])]
+    out = _merge_catalog_with_existing(fresh=fresh, existing=existing, fresh_tier="1k")
+    ids = [e["id"] for e in out]
+    assert "x" in ids
+    x_entry = next(e for e in out if e["id"] == "x")
+    assert x_entry["available_tiers"] == ["2k"]
+
+
+def test_material_only_in_existing_with_only_fresh_tier_dropped():
+    """Material had only the fresh_tier; fresh bake doesn't see it
+    (upstream pruned). Drop the entry."""
+    existing = [_entry("x", ["1k"])]
+    fresh = [_entry("a", ["1k"])]
+    out = _merge_catalog_with_existing(fresh=fresh, existing=existing, fresh_tier="1k")
+    ids = [e["id"] for e in out]
+    assert "x" not in ids
+    assert ids == ["a"]
+
+
+# ── cross-tier scenarios from the issue's acceptance criteria ───
+
+
+def test_acceptance_bake_1k_then_2k_preserves_both_tiers():
+    """Issue mat-vis#301 acceptance: bake (gpuopen, 1k), bake
+    (gpuopen, 2k), assert catalog has available_tiers=["1k", "2k"]
+    for the same material."""
+    # Step 1: fresh 1k bake (no existing)
+    cat_after_1k = _merge_catalog_with_existing(
+        fresh=[_entry("aluminum", ["1k"])],
+        existing=[],
+        fresh_tier="1k",
+    )
+    assert cat_after_1k[0]["available_tiers"] == ["1k"]
+
+    # Step 2: 2k bake on top
+    cat_after_2k = _merge_catalog_with_existing(
+        fresh=[_entry("aluminum", ["2k"])],
+        existing=cat_after_1k,
+        fresh_tier="2k",
+    )
+    assert cat_after_2k[0]["available_tiers"] == ["1k", "2k"]
+
+
+def test_three_tier_chain():
+    """1k → 2k → 4k cumulative."""
+    cat = _merge_catalog_with_existing(fresh=[_entry("m", ["1k"])], existing=[], fresh_tier="1k")
+    cat = _merge_catalog_with_existing(fresh=[_entry("m", ["2k"])], existing=cat, fresh_tier="2k")
+    cat = _merge_catalog_with_existing(fresh=[_entry("m", ["4k"])], existing=cat, fresh_tier="4k")
+    assert cat[0]["available_tiers"] == ["1k", "2k", "4k"]
+
+
+# ── ordering ────────────────────────────────────────────────────
+
+
+def test_fresh_entries_come_before_preserved_existing():
+    """Output order: fresh entries (in input order), then preserved
+    existing entries (in their original order)."""
+    existing = [_entry("z", ["2k"]), _entry("y", ["2k"])]
+    fresh = [_entry("a", ["1k"]), _entry("b", ["1k"])]
+    out = _merge_catalog_with_existing(fresh=fresh, existing=existing, fresh_tier="1k")
+    ids = [e["id"] for e in out]
+    assert ids == ["a", "b", "z", "y"]
+
+
+# ── edge cases ──────────────────────────────────────────────────
+
+
+def test_entries_without_id_skipped():
+    existing = [{"available_tiers": ["1k"]}, _entry("a", ["1k"])]
+    fresh = [{"available_tiers": ["2k"]}, _entry("a", ["2k"])]
+    out = _merge_catalog_with_existing(fresh=fresh, existing=existing, fresh_tier="2k")
+    # Only the entries with an id survive the merge
+    assert len(out) == 1
+    assert out[0]["id"] == "a"
+    assert out[0]["available_tiers"] == ["1k", "2k"]
+
+
+def test_missing_available_tiers_treated_as_empty():
+    existing = [{"id": "a", "source": "test", "mat_vis": {}}]  # no available_tiers
+    fresh = [_entry("a", ["1k"])]
+    out = _merge_catalog_with_existing(fresh=fresh, existing=existing, fresh_tier="1k")
+    assert out[0]["available_tiers"] == ["1k"]
+
+
+def test_does_not_mutate_inputs():
+    existing = [_entry("a", ["1k"])]
+    fresh = [_entry("a", ["2k"])]
+    existing_snapshot = [dict(e) for e in existing]
+    fresh_snapshot = [dict(e) for e in fresh]
+
+    _merge_catalog_with_existing(fresh=fresh, existing=existing, fresh_tier="2k")
+
+    assert existing == existing_snapshot
+    assert fresh == fresh_snapshot


### PR DESCRIPTION
## Summary

Closes #301. Replaces wholesale-replace catalog write in \`hf_bake_per_file.py\` with merge-on-write so cross-tier \`available_tiers\` survives sequential bakes.

**Bug:** Bake 1k then bake 2k (without an intervening derive) → catalog claims \`available_tiers=["2k"]\` only, even though the 1k texture files are still committed under \`<source>/1k/\`. Only the derive path's \`_extend_available_tiers\` was patching this; bake itself was lying.

**Fix:** \`_merge_catalog_with_existing(fresh, existing, fresh_tier)\` pure function:
- Material in BOTH: take fresh entry, set \`available_tiers = sorted(union(existing, [fresh_tier]))\`
- Material ONLY in existing with other tiers: preserve with \`available_tiers = sorted(existing - {fresh_tier})\`
- Material ONLY in existing at fresh_tier only: drop (upstream pruned)
- Material ONLY in fresh: add as-is

Wired inside the existing CAS retry loop alongside the manifest merge — single 412 on the manifest already covers catalog conflicts (they commit together).

## Tests

14 unit tests covering first-cut case, the issue's acceptance test (1k → 2k → both tiers), 3-tier chain, re-bake same tier, only-in-fresh / only-in-existing variants, ordering, edge cases, input immutability. 503/503 host tests still pass.

## Defensive layering

The derive-side \`_extend_available_tiers\` (\`hf_derive_per_file.py:147\`) remains as defensive layering — same invariant, two layers. Could be simplified later but not in this PR (scope discipline).

## References

- mat-vis#301 (epic)
- mat-vis#99 (related, derive-side patch this fix makes redundant on the bake path)