### PR TITLE
test: pin Bernhard's open mat-vis bugs as strict xfails (#330/#331/#332/#333)

### DIFF
--- a/clients/python/tests/test_download_progress.py
+++ b/clients/python/tests/test_download_progress.py
@@ -107,3 +107,40 @@ def test_fetch_texture_silent_on_cache_hit(tmp_cache, caplog):
     assert data == TINY_PNG
     download_msgs = [r.getMessage() for r in caplog.records if "Downloading" in r.getMessage()]
     assert not download_msgs, f"cache hit must be silent, got 'Downloading' logs: {download_msgs}"
+
+
+# ── mat-vis#333: log.info from #287 is silent in default loggers ──
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="mat-vis#333: on_download callback hook not implemented",
+)
+def test_client_accepts_on_download_callback() -> None:
+    """``MatVisClient`` should accept an ``on_download=`` callback that
+    fires on each cache-miss download. Replaces the silent ``log.info``
+    from #287 (whose close was premature — see bernhard's #312).
+
+    The callback is the proper user-facing surface: zero default behavior,
+    consumers wire their UI (tqdm, rich, custom). See mat-vis#333 for the
+    full design (callback + TTY default).
+
+    This test is the forcing function — checks the API surface exists.
+    Full behavioural test (callback fires per cache-miss with correct
+    args) belongs in the fix PR.
+
+    bernhard's repro at https://github.com/MorePET/mat-vis/issues/312 —
+    5 calls to ``Vis(...).to_threejs()`` over fresh cache produces zero
+    output today.
+    """
+    import inspect
+
+    from mat_vis_client import MatVisClient
+
+    sig = inspect.signature(MatVisClient.__init__)
+    assert "on_download" in sig.parameters, (
+        "MatVisClient.__init__ should accept an on_download= callback "
+        "kwarg (mat-vis#333). Today only log.info fires — silent in "
+        "default loggers (consumers' apps default to WARNING). "
+        "bernhard's #312 cascade: '5 downloads, zero feedback'."
+    )

--- a/clients/python/tests/test_errors.py
+++ b/clients/python/tests/test_errors.py
@@ -523,3 +523,40 @@ def test_ambiguous_material_error_lists_names():
         client.fetch_all_textures("gpuopen", "Brick Wall", tier="1k")
     # Candidates should be names, not UUIDs.
     assert any("Brick" in c for c in exc.value.candidates)
+
+
+# ── mat-vis#332: MaterialNotStagedError should list available tiers ──
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="mat-vis#332: error message does not include 'Available tiers'",
+)
+def test_material_not_staged_error_lists_available_tiers() -> None:
+    """``MaterialNotStagedError`` should include an ``Available tiers: [...]``
+    line so the user knows which tiers ARE staged.
+
+    bernhard mat-vis#311 sub-bullet "Unclear error messages":
+
+        Expectation: ... is not staged for tier '3k'. Available tiers: ['1k', '2k', ...]
+
+    Today the message says ``Needs a re-bake`` (actionable only for
+    maintainers) without listing the staged tiers.
+
+    See https://github.com/MorePET/mat-vis/issues/332 for the
+    forward-verify acceptance.
+    """
+    from mat_vis_client import MaterialNotStagedError
+
+    err = MaterialNotStagedError(
+        source="gpuopen",
+        material_id="c12edfda-a5bd-4469-8147-4a6540a0a213",
+        tier="3k",
+        original_name="Aluminum Brushed",
+    )
+    msg = str(err)
+    assert "Available tiers:" in msg, (
+        f"MaterialNotStagedError message {msg!r} should list available tiers "
+        "(mat-vis#332). bernhard's #311 expectation: '... not staged for "
+        'tier 3k. Available tiers: ["1k", "2k", ...]\'.'
+    )

--- a/clients/python/tests/test_materials_named.py
+++ b/clients/python/tests/test_materials_named.py
@@ -1,0 +1,45 @@
+"""Red test for mat-vis#330: materials_named() output ergonomics.
+
+bernhard-42's mat-vis#311 sub-bullet "Consistently support material names":
+``client.materials("ambientcg", "1k")`` returns IDs (UUIDs for gpuopen,
+slugs for ambientcg/polyhaven). The catalog already carries human-readable
+names in ``entry.mat_vis.name``; ``materials()`` just doesn't surface them.
+
+This test fails red because the proposed ``materials_named()`` accessor
+doesn't exist on ``MatVisClient``. xfail-strict forces removing the
+marker as a mechanical step in the fix PR — guards against the
+symptom-vs-spec failure mode that bit #287/#288.
+
+See https://github.com/MorePET/mat-vis/issues/330 for the proposed shape:
+``MatVisClient.materials_named(source, tier) -> dict[str, str]`` mapping
+id → display name pulled from ``entry["mat_vis"]["name"]``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="mat-vis#330: materials_named() accessor not implemented",
+)
+def test_materials_named_method_exists() -> None:
+    """``MatVisClient`` must expose a ``materials_named()`` method that
+    returns ``{id: display_name}`` for the given (source, tier).
+
+    The full behavioural test lives in the fix PR (it needs a stubbed
+    HF tree to assert returned values). This test is the forcing
+    function: the API surface must exist before the fix can claim closed.
+
+    bernhard's repro at https://github.com/MorePET/mat-vis/issues/311 —
+    "Consistently support material names" section.
+    """
+    from mat_vis_client import MatVisClient
+
+    assert hasattr(MatVisClient, "materials_named"), (
+        "MatVisClient.materials_named is missing — see mat-vis#330. "
+        "Bernhard wants {id: display_name} dict alongside the existing "
+        "materials() method so consumers can render material names in UI "
+        "without a second round-trip through the catalog."
+    )

--- a/tests/test_physicallybased_available_tiers.py
+++ b/tests/test_physicallybased_available_tiers.py
@@ -1,0 +1,72 @@
+"""Red test for mat-vis#331: physicallybased catalog ships available_tiers=[].
+
+bernhard-42's mat-vis#311 + #313: ``client.materials("physicallybased", "scalar")``
+returns empty even though 86 materials exist in the catalog. Root cause is in
+the fetcher (``sources/physicallybased.py:197``) which hardcodes
+``available_tiers=[]`` instead of ``available_tiers=["scalar"]``.
+
+This test fails red on the current fetcher; the fix is a one-line change
+that flips the literal. xfail-strict forces removing the marker as a
+mechanical step in the fix PR — guards against the symptom-vs-spec failure
+mode that bit #287/#288 (closing on a different layer than the bug).
+
+See https://github.com/MorePET/mat-vis/issues/331 for the proper-fix
+acceptance, and #313 for bernhard's user-visible repro that this unblocks
+in combination with mat#222.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mat_vis_baker.sources.physicallybased import fetch
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="mat-vis#331: physicallybased fetcher hardcodes available_tiers=[]",
+)
+def test_fetch_populates_available_tiers_with_scalar_sentinel() -> None:
+    """Every record from the physicallybased fetcher must declare
+    ``available_tiers=["scalar"]`` so ``client.materials()`` filters
+    correctly.
+
+    The catalog uses the ``scalar`` sentinel for textureless sources
+    (manifest already declares ``tiers.scalar.complete=True`` for
+    physicallybased — the fetcher is the only place still emitting
+    ``[]``).
+    """
+    fake_api = [
+        {
+            "name": "Aluminum",
+            "category": "metal",
+            "color": [0.9, 0.9, 0.9],
+            "ior": 1.39,
+            "metalness": 1.0,
+            "roughness": 0.0,
+            "tags": ["mirror"],
+        },
+        {
+            "name": "Banana",
+            "category": "organic",
+            "color": [1.0, 0.8, 0.2],
+            "ior": 1.45,
+            "tags": [],
+        },
+    ]
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = fake_api
+
+    with patch("mat_vis_baker.sources.physicallybased.retry_request", return_value=mock_resp):
+        records = fetch()
+
+    assert records, "physicallybased fetcher returned no records"
+    for rec in records:
+        assert rec.available_tiers == ["scalar"], (
+            f"physicallybased record {rec.mat_vis.name!r} has "
+            f"available_tiers={rec.available_tiers}; expected ['scalar'] "
+            '(mat-vis#331 — required so client.materials("physicallybased", '
+            '"scalar") returns the entries; cascades to mat-vis#313)'
+        )


### PR DESCRIPTION
## Summary

Locks 4 currently-failing-on-dev behaviors into the test suite as \`pytest.mark.xfail(strict=True)\` baselines. \`strict\` means: when the fix lands and the test passes, the xfail itself fails — forcing the developer to remove the marker as a mechanical step in the fix PR.

## Discipline

Addresses the symptom-vs-spec failure mode that bit #287/#288: closed against unit tests inside the package while the user-visible bug persisted at the consumer's surface. Each test here carries bernhard's literal repro snippet and a cross-link to the proper-fix issue.

| Test | File | Issue |
|---|---|---|
| \`test_fetch_populates_available_tiers_with_scalar_sentinel\` | \`tests/test_physicallybased_available_tiers.py\` (new) | #331 — fetcher hardcodes \`available_tiers=[]\`; cascades to #313 |
| \`test_materials_named_method_exists\` | \`clients/python/tests/test_materials_named.py\` (new) | #330 — display-name accessor |
| \`test_material_not_staged_error_lists_available_tiers\` | \`clients/python/tests/test_errors.py\` (append) | #332 — error message should include \`Available tiers: [...]\` |
| \`test_client_accepts_on_download_callback\` | \`clients/python/tests/test_download_progress.py\` (append) | #333 — proper user-facing surface to replace #287's silent \`log.info\` |

## Test suite stays green

- baker: **506 passed + 1 xfailed**
- client: **350 passed + 3 xfailed**

The 4 new xfails are the only new "failures" and are expected per \`strict=True\`.

## Shape

Forcing-function only: each test asserts the API surface or behavior contract, not the full spec. Full behavioural tests land in the fix PR alongside the implementation.

## References

- Bug-fix issues: #330, #331, #332, #333
- bernhard's user-surface umbrellas: #311, #312, #313
- Failure-mode it guards against: lessons from #287, #288