### PR TITLE
bugfix(ci): plan job needs --with '.[baker]' for mat-vis-baker matrix list (#323 follow-up)

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -8,7 +8,7 @@
 # one matrix sibling per cell.
 #
 # Reproduce locally:
-#   uv run --with . mat-vis-baker matrix list v2026.04
+#   uv run --with '.[baker]' mat-vis-baker matrix list v2026.04
 #   dagger call bake --source=ambientcg --tier=1k --release-tag=v2026.04.3 ...
 # Or in one shot:
 #   dagger call bake-matrix --line=v2026.04 --release-tag=v2026.04.3 ...
@@ -132,7 +132,14 @@ jobs:
           extra=()
           if [ -n "${FILTER_SOURCE:-}" ]; then extra+=(--filter-source "$FILTER_SOURCE"); fi
           if [ -n "${FILTER_TIER:-}" ]; then extra+=(--filter-tier "$FILTER_TIER"); fi
-          payload=$(uv run --with . mat-vis-baker matrix list "$LINE" "${extra[@]}")
+          # The `matrix` subcommand only touches release_matrix + sources
+          # + common, but common.py imports `requests` at module top for
+          # retry_request — so the CLI entrypoint can't import without the
+          # baker extras installed. Use '.[baker]' to pull requests +
+          # pyarrow into the lightweight `setup-uv` env. The bake step
+          # itself runs inside `_baker_container` (which does `uv sync
+          # --all-extras`); only this plan job invokes the CLI directly.
+          payload=$(uv run --with '.[baker]' mat-vis-baker matrix list "$LINE" "${extra[@]}")
           echo "matrix payload: $payload"
           cells=$(printf '%s' "$payload" | python3 -c 'import json,sys; print(json.dumps(json.load(sys.stdin)["cells"]))')
           if [ "$cells" = "[]" ]; then


### PR DESCRIPTION
## Summary

E2E verification on \`gerchowl/mat-vis-tst\` of the just-landed CI/CD fabric (#323/#326/#327/#329) caught: the plan job in \`bake.yml\` fails immediately with \`ModuleNotFoundError: No module named 'requests'\`. Run [25497168037](https://github.com/MorePET/mat-vis/actions/runs/25497168037).

## Root cause

\`\`\`yaml
- run: |
    payload=\$(uv run --with . mat-vis-baker matrix list "\$LINE" ...)
\`\`\`

The \`matrix\` subcommand only touches \`release_matrix\` + \`sources\` + \`common\`, but \`common.py\` imports \`requests\` at module top (for \`retry_request\`). The CLI entrypoint can't import without the baker extras installed.

The bake step itself runs inside \`_baker_container\` which does \`uv sync --all-extras\` — the issue only fires for the lightweight plan job that invokes \`mat-vis-baker\` directly.

## Fix

Use \`--with '.[baker]'\` to pull \`requests\` + \`pyarrow\` into the setup-uv env:

\`\`\`yaml
- run: |
    payload=\$(uv run --with '.[baker]' mat-vis-baker matrix list ...)
\`\`\`

Updates the header comment too so local repros match the workflow.

## Why this matters beyond the fix

Caught precisely the failure mode the E2E-on-tst discipline guards against: unit tests pass + CI green tells you nothing about whether a real workflow dispatch can run end-to-end. Without the tst dispatch this would have silently shipped to a production substrate cut and broken bakes there instead.

## Test plan

- [x] Local repro: \`uv run --with '.[baker]' mat-vis-baker matrix list v2026.04 --filter-source gpuopen\` returns the expected JSON
- [ ] CI on this PR runs the unit tests
- [ ] After merge: re-dispatch the tst spot bake and confirm the plan job goes green, then validates the rest of the fabric end-to-end (#326 content-drift, #329 merge-on-write, #327 Dagger validate-release)