### PR TITLE
bugfix(baker): catalog merge-on-write only prunes on unbounded bakes (#329 follow-up)

### DIFF
--- a/src/mat_vis_baker/hf_bake_per_file.py
+++ b/src/mat_vis_baker/hf_bake_per_file.py
@@ -260,6 +260,8 @@ def _merge_catalog_with_existing(
     fresh: list[dict],
     existing: list[dict],
     fresh_tier: str,
+    *,
+    prune_missing: bool = True,
 ) -> list[dict]:
     """Merge a freshly-baked per-source catalog onto the existing one.
 
@@ -269,14 +271,29 @@ def _merge_catalog_with_existing(
     - For each material in BOTH existing and fresh: take the FRESH
       entry (newest data wins) but set
       ``available_tiers = sorted(union(existing.available_tiers, [fresh_tier]))``.
-    - For each material ONLY in existing (had this material at some
-      tier before, but the fresh bake of `fresh_tier` doesn't see it):
-      compute ``new_tiers = existing.available_tiers - {fresh_tier}``.
-      If non-empty: PRESERVE the existing entry with
-      ``available_tiers = sorted(new_tiers)``. If empty: DROP (the
-      material existed only at this tier, upstream pruned it).
+    - For each material ONLY in existing: behavior depends on
+      ``prune_missing`` — see below.
     - For each material ONLY in fresh: KEEP as-is (new addition;
       ``available_tiers = [fresh_tier]`` already from index_builder).
+
+    The ``prune_missing`` flag (mat-vis#329 follow-up after E2E on tst):
+
+    - ``True`` (default; **unbounded bakes only**): the fresh set is
+      treated as the AUTHORITATIVE upstream snapshot for ``fresh_tier``.
+      Materials only in existing have their fresh_tier removed from
+      available_tiers; if that empties the list (the material existed
+      only at this tier and fresh didn't see it), the entry is DROPPED
+      — upstream pruned it.
+    - ``False`` (**bounded bakes** — ``limit > 0`` or ``offset > 0``):
+      the fresh set is a SUBSET, not the upstream truth. Materials only
+      in existing are preserved verbatim with their existing
+      ``available_tiers`` untouched — we don't know whether they were
+      pruned upstream or just outside our slice.
+
+    Caller (``bake_one_per_file``) passes ``prune_missing = (limit == 0
+    and offset == 0)``. Production cuts always run unbounded so they
+    prune; dev spot-tests with ``--limit=10`` preserve the rest of the
+    catalog instead of clobbering 99% of it.
 
     Order preserved: fresh entries first (in their input order — already
     sorted by name in :func:`build_index`), then any preserved-existing
@@ -304,17 +321,23 @@ def _merge_catalog_with_existing(
             entry = {**entry, "available_tiers": merged_tiers}
         out.append(entry)
 
-    # Pass 2: append existing entries that are NOT in fresh, with the
-    # fresh_tier removed from their available_tiers. Drop if empty.
+    # Pass 2: append existing entries that are NOT in fresh.
     for prev in existing:
         mid = prev.get("id")
         if mid is None or mid in fresh_by_id:
             continue
+        if not prune_missing:
+            # Bounded bake (limit/offset): fresh is a subset, not truth.
+            # Preserve verbatim — we don't know whether this material
+            # was pruned upstream or just outside our slice.
+            out.append(prev)
+            continue
+        # Unbounded bake: fresh is authoritative for fresh_tier. Drop
+        # fresh_tier from this material's available_tiers; if that
+        # empties the list, the entry is gone (upstream pruned).
         prev_tiers = set(prev.get("available_tiers") or [])
         new_tiers = sorted(prev_tiers - {fresh_tier})
         if not new_tiers:
-            # Existed only at the tier we just baked, and fresh bake
-            # doesn't see it → upstream pruned, drop.
             continue
         out.append({**prev, "available_tiers": new_tiers})
 
@@ -751,10 +774,20 @@ def bake_one_per_file(
             # together in one operation, so a single 412 on the manifest
             # already covers catalog conflicts.
             existing_catalog, _ = _fetch_catalog_with_parent(api, repo_id, release_tag, source)
+            # mat-vis#329 follow-up after E2E on tst: only prune
+            # "missing from fresh" materials when the bake is UNBOUNDED.
+            # A limit-bound or offset-bound bake produces a SUBSET of
+            # the upstream catalog, not the truth — clobbering everything
+            # outside the subset (the original wholesale-replace bug)
+            # would still happen if we always pruned. Production cuts
+            # use limit=0/offset=0 so they prune normally; dev spot-tests
+            # with --limit=10 keep the rest of the catalog intact.
+            unbounded = (limit is None or limit == 0) and (offset is None or offset == 0)
             merged_catalog = _merge_catalog_with_existing(
                 fresh=index,
                 existing=existing_catalog,
                 fresh_tier=storage_tier,
+                prune_missing=unbounded,
             )
             catalog_path.write_text(json.dumps(merged_catalog, indent=2, ensure_ascii=False) + "\n")
             # #292: ship the packed upstream-MTLX JSON in the same atomic

--- a/tests/test_catalog_merge_on_write.py
+++ b/tests/test_catalog_merge_on_write.py
@@ -178,3 +178,67 @@ def test_does_not_mutate_inputs():
 
     assert existing == existing_snapshot
     assert fresh == fresh_snapshot
+
+
+# ── prune_missing flag (mat-vis#329 follow-up after E2E on tst) ─────
+
+
+def test_prune_missing_true_drops_existing_only_at_fresh_tier():
+    """Default (unbounded bake): material existed only at fresh_tier
+    and fresh doesn't see it → drop. Same as previous default."""
+    existing = [_entry("x", ["1k"]), _entry("a", ["1k"])]
+    fresh = [_entry("a", ["1k"])]
+    out = _merge_catalog_with_existing(
+        fresh=fresh, existing=existing, fresh_tier="1k", prune_missing=True
+    )
+    ids = [e["id"] for e in out]
+    assert "x" not in ids
+    assert ids == ["a"]
+
+
+def test_prune_missing_false_preserves_everything_not_in_fresh():
+    """Bounded bake (limit/offset): fresh is a SUBSET, not truth.
+    Materials only in existing are preserved verbatim.
+
+    Without this fix, a `--limit=10` spot-test on a 454-material catalog
+    clobbered 444 entries from the catalog — the bug E2E surfaced on tst
+    after #329 merged.
+    """
+    existing = [
+        _entry("a", ["1k"]),
+        _entry("b", ["1k"]),
+        _entry("c", ["1k"]),
+    ]
+    # Fresh only contains 'a' (limit=1 simulating a partial bake)
+    fresh = [_entry("a", ["1k"])]
+    out = _merge_catalog_with_existing(
+        fresh=fresh, existing=existing, fresh_tier="1k", prune_missing=False
+    )
+    ids = [e["id"] for e in out]
+    assert ids == ["a", "b", "c"], (
+        f"prune_missing=False should preserve all existing entries, got {ids}"
+    )
+    # b and c keep their original available_tiers verbatim
+    b_entry = next(e for e in out if e["id"] == "b")
+    assert b_entry["available_tiers"] == ["1k"]
+
+
+def test_prune_missing_false_still_merges_overlapping_materials():
+    """When prune_missing=False, materials in BOTH fresh and existing
+    still get the available_tiers union — that part is invariant."""
+    existing = [_entry("a", ["1k"])]
+    fresh = [_entry("a", ["2k"])]
+    out = _merge_catalog_with_existing(
+        fresh=fresh, existing=existing, fresh_tier="2k", prune_missing=False
+    )
+    assert len(out) == 1
+    assert out[0]["available_tiers"] == ["1k", "2k"]
+
+
+def test_prune_missing_default_is_true():
+    """Default behavior is unchanged (prune like the original #329)."""
+    existing = [_entry("a", ["1k"])]
+    fresh = [_entry("b", ["1k"])]
+    # Default — no kwarg
+    out = _merge_catalog_with_existing(fresh=fresh, existing=existing, fresh_tier="1k")
+    assert [e["id"] for e in out] == ["b"], "default prune_missing should drop 'a'"


### PR DESCRIPTION
## Summary

E2E spot-test on \`gerchowl/mat-vis-tst\` (run [25497508288](https://github.com/MorePET/mat-vis/actions/runs/25497508288)) caught a real partial-bake bug: a \`--limit=10\` dispatch against the 454-entry gpuopen catalog clobbered the catalog down to 10 entries. The merge-on-write logic from #329 treated "absent from fresh" as "upstream pruned" — but \`limit > 0\` means fresh is a SUBSET, not the upstream truth.

**This is the bug class the E2E-on-tst rule is supposed to catch.** Without the dispatch, the unit tests + CI all looked green and we'd have shipped the fabric to production with this latent.

## Fix

\`_merge_catalog_with_existing\` gains a \`prune_missing\` flag.

- **\`True\`** (default; unbounded bakes): existing-only materials with no remaining tiers get dropped — same semantics as before. Production cuts always run unbounded.
- **\`False\`** (bounded bakes): existing-only materials are preserved verbatim. We don't know whether they were pruned upstream or just outside our slice; preservation is the safe default.

Caller (\`bake_one_per_file\`) computes \`prune_missing = (limit == 0 and offset == 0)\`. Dev spot-tests with \`--limit=10\` now keep the rest of the catalog intact.

## Tests

4 new tests bring the suite to 18/18:

- \`test_prune_missing_true_drops_existing_only_at_fresh_tier\` (default behavior unchanged)
- \`test_prune_missing_false_preserves_everything_not_in_fresh\` (the new safe path)
- \`test_prune_missing_false_still_merges_overlapping_materials\` (available_tiers union still works)
- \`test_prune_missing_default_is_true\` (kwarg default is the right one)

All previous 14 #329 tests still pass. No regression on the cross-tier-preservation acceptance criteria.

## After merge

Re-dispatch the tst spot bake to verify:
1. The 10-entry tst catalog gets restored as a side-effect of the next full bake (\`limit=0\`).
2. The \`--limit=N\` partial path now preserves the rest.

## References

- mat-vis#329 (the merge-on-write PR; this corrects its partial-bake handling)
- mat-vis#301 (the underlying invariant — cross-tier \`available_tiers\` preservation, still satisfied)
- E2E discipline: this is exactly the failure mode #287/#288 lessons + tst-rule are meant to catch