### PR TITLE
feat(baker): procedural-PBR Phase 1 — is_conductor + metalness_mean + provenance (#316)

### DIFF
--- a/src/mat_vis_baker/_mtlx_scalars.py
+++ b/src/mat_vis_baker/_mtlx_scalars.py
@@ -181,6 +181,159 @@ def _input_value_or_graph_constant(
     return None
 
 
+def _find_named_node(graph: ET.Element, name: str) -> ET.Element | None:
+    for child in graph:
+        if child.attrib.get("name") == name:
+            return child
+    return None
+
+
+def _node_constant_value(node: ET.Element) -> float | None:
+    """If ``node`` is a ``<constant>`` whose ``<input name="value">``
+    parses as a float, return it. Otherwise None.
+    """
+    if _strip_ns(node.tag) != "constant":
+        return None
+    for sub in node:
+        if _strip_ns(sub.tag) != "input":
+            continue
+        if sub.attrib.get("name") != "value":
+            continue
+        return _parse_float(sub.attrib.get("value", ""))
+    return None
+
+
+def _resolve_input_constant(graph: ET.Element, inp: ET.Element) -> float | None:
+    """Resolve a ``<mix>``-input element to a float constant.
+
+    Handles two shapes:
+      - ``nodename=`` pointing at a ``<constant>`` sibling.
+      - inline ``value=`` attribute (e.g. ``<input name="mix"
+        nodename="img_mask" value="0.7"/>`` — the texture-bound case
+        where the author left a default for non-rendering consumers).
+    """
+    nm = inp.attrib.get("nodename")
+    if nm is not None:
+        target = _find_named_node(graph, nm)
+        if target is not None:
+            v = _node_constant_value(target)
+            if v is not None:
+                return v
+    raw = inp.attrib.get("value")
+    if raw is not None:
+        return _parse_float(raw)
+    return None
+
+
+def _walk_mix_metalness(
+    root: ET.Element,
+    nodegraph_name: str,
+    output_name: str,
+) -> tuple[float | None, bool | None, float | None, str | None]:
+    """Inspect a ``<mix>`` graph terminal for a metalness binding.
+
+    Returns ``(metalness, is_conductor, metalness_mean, source)`` where:
+
+      - If the mix is **fully constant-foldable** (``fg``, ``bg``,
+        ``mix`` all resolve to scalar constants): ``metalness`` is the
+        folded value and ``source="graph_constant"``. ``is_conductor``
+        and ``metalness_mean`` stay ``None`` (the scalar already
+        captures the truth — no metadata duplication).
+
+      - If only the ``fg`` branch resolves to ``1.0`` (the "pure metal"
+        side of a metal/dielectric mix), emit ``is_conductor=True`` +
+        ``metalness_mean = bg + (fg - bg) * t`` (using the mix
+        constant when resolvable, else falling back to ``0.5`` for a
+        texture-bound mask). ``metalness`` stays ``None`` —
+        the per-pixel value can't be honestly collapsed.
+        ``source="graph_estimate"``.
+
+      - Otherwise: all four return values are ``None`` (parser leaves
+        metalness texture-bound for downstream convention helper).
+
+    The walker only considers ``<mix>`` terminals; other procedural
+    shapes (``<multiply>``, ``<add>``, ``<convert>``, …) fall through.
+    Adding more is straightforward but conservative is preferred —
+    each new shape needs its own correctness argument. #316.
+    """
+    # Locate the named nodegraph + the terminal node referenced by the output.
+    target_ng: ET.Element | None = None
+    for elem in root.iter():
+        if _strip_ns(elem.tag) == "nodegraph" and elem.attrib.get("name") == nodegraph_name:
+            target_ng = elem
+            break
+    if target_ng is None:
+        return None, None, None, None
+
+    terminal_node_name: str | None = None
+    for child in target_ng:
+        if _strip_ns(child.tag) != "output":
+            continue
+        if child.attrib.get("name") != output_name:
+            continue
+        terminal_node_name = child.attrib.get("nodename")
+        break
+    if not terminal_node_name:
+        return None, None, None, None
+
+    terminal = _find_named_node(target_ng, terminal_node_name)
+    if terminal is None or _strip_ns(terminal.tag) != "mix":
+        return None, None, None, None
+
+    # Read fg / bg / mix child inputs.
+    fg_inp: ET.Element | None = None
+    bg_inp: ET.Element | None = None
+    mix_inp: ET.Element | None = None
+    for sub in terminal:
+        if _strip_ns(sub.tag) != "input":
+            continue
+        nm = sub.attrib.get("name")
+        if nm == "fg":
+            fg_inp = sub
+        elif nm == "bg":
+            bg_inp = sub
+        elif nm == "mix":
+            mix_inp = sub
+    if fg_inp is None or bg_inp is None or mix_inp is None:
+        return None, None, None, None
+
+    fg = _resolve_input_constant(target_ng, fg_inp)
+    bg = _resolve_input_constant(target_ng, bg_inp)
+    t = _resolve_input_constant(target_ng, mix_inp)
+
+    # Case 1: fully foldable (function evaluation, not heuristic).
+    if fg is not None and bg is not None and t is not None:
+        # Only when mix is itself a constant — if mix came from the
+        # ``value=`` default on a texture-bound input, the actual
+        # render value is per-pixel and folding to a single scalar
+        # would lie. Detect texture-bound by presence of ``nodename``
+        # whose target is NOT a <constant>.
+        nm = mix_inp.attrib.get("nodename")
+        mix_is_textural = False
+        if nm is not None:
+            target = _find_named_node(target_ng, nm)
+            if target is not None and _node_constant_value(target) is None:
+                mix_is_textural = True
+        if not mix_is_textural:
+            metal = bg + (fg - bg) * t
+            return metal, None, None, "graph_constant"
+        # Fall through to the estimate branch — fg/bg are constants
+        # but t comes from a texture mask; this is the Bronze case
+        # with an explicit ``value=`` default on the mix input.
+
+    # Case 2: fg=1.0 (pure metal) blended with something. Estimate.
+    if fg is not None and abs(fg - 1.0) < 1e-9:
+        bg_eff = bg if bg is not None else 0.0
+        # When ``mix`` is unresolvable (texture-bound, no ``value=``
+        # default), fall back to a mid-mask 0.5 — the most defensible
+        # mean for a binary-ish mask without sampling the texture.
+        t_eff = t if t is not None else 0.5
+        mean = bg_eff + (fg - bg_eff) * t_eff
+        return None, True, mean, "graph_estimate"
+
+    return None, None, None, None
+
+
 def parse_standard_surface_scalars(
     mtlx_xml: str,
     *,
@@ -253,11 +406,35 @@ def parse_standard_surface_scalars(
         if inp is None:
             continue
         raw = _input_value_or_graph_constant(root, inp)
-        if raw is None:
+        if raw is not None:
+            val = _parse_float(raw)
+            if val is not None:
+                setattr(block, pbr_attr, val)
+                # Provenance for metalness only — the field that the
+                # Phase 1 issue (#316) cares about for library-browser
+                # facets. ``source="scalar"`` for direct value=,
+                # "graph_constant" for the 1-hop nodegraph→constant.
+                if pbr_attr == "metalness":
+                    direct = _is_authored_value(inp)
+                    block.metalness_source = "scalar" if direct else "graph_constant"
             continue
-        val = _parse_float(raw)
-        if val is not None:
-            setattr(block, pbr_attr, val)
+        # Texture/graph-bound. For metalness specifically, attempt the
+        # <mix> walker — fg=1.0 mixes give us is_conductor + estimate,
+        # fully-foldable mixes give us a real scalar. Other shapes
+        # leave the field None for the convention helper to fill.
+        if pbr_attr == "metalness":
+            ng = inp.attrib.get("nodegraph")
+            out = inp.attrib.get("output")
+            if ng and out:
+                metal, is_cond, mean, source = _walk_mix_metalness(root, ng, out)
+                if metal is not None:
+                    block.metalness = metal
+                if is_cond is not None:
+                    block.is_conductor = is_cond
+                if mean is not None:
+                    block.metalness_mean = mean
+                if source is not None:
+                    block.metalness_source = source
 
     # base_color (color3) — multiplied by `base` scalar if both authored.
     # Both base_color and base accept the same 1-hop graph→constant

--- a/src/mat_vis_baker/_mtlx_scalars.py
+++ b/src/mat_vis_baker/_mtlx_scalars.py
@@ -279,6 +279,12 @@ def _walk_mix_metalness(
     terminal = _find_named_node(target_ng, terminal_node_name)
     if terminal is None or _strip_ns(terminal.tag) != "mix":
         return None, None, None, None
+    # Defense against future schema drift: a <mix type="color3"> would
+    # nominally pass the tag check above, then ``_node_constant_value``
+    # would harmlessly fall through (a 3-float ``value=`` string fails
+    # ``_parse_float``), but be explicit. We only handle scalar mixes.
+    if terminal.attrib.get("type") not in (None, "float"):
+        return None, None, None, None
 
     # Read fg / bg / mix child inputs.
     fg_inp: ET.Element | None = None
@@ -321,8 +327,14 @@ def _walk_mix_metalness(
         # but t comes from a texture mask; this is the Bronze case
         # with an explicit ``value=`` default on the mix input.
 
-    # Case 2: fg=1.0 (pure metal) blended with something. Estimate.
-    if fg is not None and abs(fg - 1.0) < 1e-9:
+    # Case 2: fg≈1.0 (pure metal) blended with a dielectric (bg≈0.0).
+    # Tightening: also require bg≈0 so partial-conductor blends
+    # (fg=1.0, bg=0.3) don't get falsely tagged is_conductor=True.
+    # bg defaults to 0.0 when unresolvable so the texture-bound-bg
+    # case still fires for the canonical Bronze pattern.
+    fg_is_metal = fg is not None and abs(fg - 1.0) < 1e-6
+    bg_is_dielectric = bg is None or abs(bg) < 1e-6
+    if fg_is_metal and bg_is_dielectric:
         bg_eff = bg if bg is not None else 0.0
         # When ``mix`` is unresolvable (texture-bound, no ``value=``
         # default), fall back to a mid-mask 0.5 — the most defensible

--- a/src/mat_vis_baker/common.py
+++ b/src/mat_vis_baker/common.py
@@ -438,6 +438,14 @@ class PBRBlock:
     #   "graph_constant"  — 1-hop nodegraph→<constant> OR fully-foldable <mix>
     #   "graph_estimate"  — fg=1.0 graph-walker estimate; metalness still None
     #   "texture"         — populated by ``apply_pbr_neutral_multiplier_conventions``
+    #
+    # Combined state: a material with a procedural metalness <mix> graph
+    # AND a metalness texture in the bake will land as ``metalness=1.0``
+    # (set by the convention helper) + ``metalness_source="graph_estimate"``
+    # (preserved from the parser walker). The source string still
+    # provenances the graph signal — consumers reading metalness as a
+    # scalar see the convention default; consumers reading is_conductor
+    # / metalness_mean see the graph estimate.
     metalness_source: str | None = None
 
 

--- a/src/mat_vis_baker/common.py
+++ b/src/mat_vis_baker/common.py
@@ -425,6 +425,21 @@ class PBRBlock:
     transmission: float | None = None
     complex_ior: list[float] | None = None  # 6-float wavelength-resolved
 
+    # Procedural-PBR Phase 1 (#316). Library-browser facets need a
+    # queryable "this is metal" signal even when the per-pixel scalar
+    # can't be honestly collapsed (e.g. Bronze Oxydized authors metalness
+    # as a <mix> of pure-metal and dielectric blended via a texture
+    # mask). ``metalness`` itself stays the trustworthy-scalar contract;
+    # these fields carry the metadata around procedural cases.
+    is_conductor: bool | None = None  # True/False/None (unknown)
+    metalness_mean: float | None = None  # whole-material mean estimate
+    # Provenance for ``metalness``. None when the field is unset.
+    #   "scalar"          — direct ``value=`` on the shader input
+    #   "graph_constant"  — 1-hop nodegraph→<constant> OR fully-foldable <mix>
+    #   "graph_estimate"  — fg=1.0 graph-walker estimate; metalness still None
+    #   "texture"         — populated by ``apply_pbr_neutral_multiplier_conventions``
+    metalness_source: str | None = None
+
 
 def apply_pbr_neutral_multiplier_conventions(
     pbr: PBRBlock,
@@ -463,6 +478,11 @@ def apply_pbr_neutral_multiplier_conventions(
         pbr.color_rgb = [1.0, 1.0, 1.0]
     if pbr.metalness is None and "metalness" in textures:
         pbr.metalness = 1.0
+        # Provenance — only stamp when WE filled the gap. Authored
+        # scalars (already set by the parser) keep their pre-existing
+        # source string. #316.
+        if pbr.metalness_source is None:
+            pbr.metalness_source = "texture"
     if pbr.roughness is None and "roughness" in textures:
         pbr.roughness = 1.0
     return pbr

--- a/tests/test_index_builder.py
+++ b/tests/test_index_builder.py
@@ -100,6 +100,10 @@ def test_mat_vis_block_defaults_are_null_or_empty() -> None:
     assert mv["pbr"]["specular_f0"] is None
     assert mv["pbr"]["transmission"] is None
     assert mv["pbr"]["complex_ior"] is None
+    # Phase 1 procedural-PBR fields (#316) — additive, default-None.
+    assert mv["pbr"]["is_conductor"] is None
+    assert mv["pbr"]["metalness_mean"] is None
+    assert mv["pbr"]["metalness_source"] is None
     assert mv["attribution"]["authors"] == []
     assert mv["dates"]["published"] is None
     assert mv["dates"]["updated"] is None

--- a/tests/test_index_builder.py
+++ b/tests/test_index_builder.py
@@ -66,7 +66,8 @@ def test_mat_vis_block_has_stable_key_set() -> None:
     }
     # Nested PhysicalBlock
     assert set(mv["physical"].keys()) == {"dimensions_m", "max_resolution_px"}
-    # Nested PBRBlock
+    # Nested PBRBlock — additive Phase 1 fields (#316) for procedural-PBR
+    # library-browser facets are part of the stable shape now.
     assert set(mv["pbr"].keys()) == {
         "color_rgb",
         "roughness",
@@ -75,6 +76,9 @@ def test_mat_vis_block_has_stable_key_set() -> None:
         "specular_f0",
         "transmission",
         "complex_ior",
+        "is_conductor",
+        "metalness_mean",
+        "metalness_source",
     }
     # Nested AttributionBlock
     assert set(mv["attribution"].keys()) == {"authors", "license_spdx", "source_url"}

--- a/tests/test_mtlx_scalars_procedural.py
+++ b/tests/test_mtlx_scalars_procedural.py
@@ -159,6 +159,64 @@ FIXTURE_DIELECTRIC_MIX = """<?xml version="1.0"?>
 """
 
 
+# Partial-conductor blend (fg=1.0, bg=0.3): a non-zero dielectric
+# branch means the material isn't a clean metal/dielectric mix. The
+# walker must NOT flip is_conductor=True (post-review tightening).
+FIXTURE_PARTIAL_CONDUCTOR_BLEND = """<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="ng_metal">
+    <constant name="c_fg" type="float">
+      <input name="value" type="float" value="1.0"/>
+    </constant>
+    <constant name="c_bg" type="float">
+      <input name="value" type="float" value="0.3"/>
+    </constant>
+    <image name="img_mask" type="float">
+      <input name="file" type="filename" value="metalness_mask.png"/>
+    </image>
+    <mix name="m_metal" type="float">
+      <input name="fg" nodename="c_fg"/>
+      <input name="bg" nodename="c_bg"/>
+      <input name="mix" nodename="img_mask"/>
+    </mix>
+    <output name="out_metal" type="float" nodename="m_metal"/>
+  </nodegraph>
+  <standard_surface name="m_shader" type="surfaceshader">
+    <input name="metalness" type="float" nodegraph="ng_metal" output="out_metal"/>
+  </standard_surface>
+</materialx>
+"""
+
+
+# A <mix type="color3"> on the metalness input — schema-drift defense.
+# The walker must early-return on non-float mix terminals so a future
+# corpus shape doesn't accidentally trip is_conductor=True.
+FIXTURE_COLOR3_MIX_ON_METALNESS = """<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="ng_metal">
+    <constant name="c_fg" type="color3">
+      <input name="value" type="color3" value="1.0, 1.0, 1.0"/>
+    </constant>
+    <constant name="c_bg" type="color3">
+      <input name="value" type="color3" value="0.0, 0.0, 0.0"/>
+    </constant>
+    <constant name="c_mix" type="float">
+      <input name="value" type="float" value="0.7"/>
+    </constant>
+    <mix name="m_metal" type="color3">
+      <input name="fg" nodename="c_fg"/>
+      <input name="bg" nodename="c_bg"/>
+      <input name="mix" nodename="c_mix"/>
+    </mix>
+    <output name="out_metal" type="color3" nodename="m_metal"/>
+  </nodegraph>
+  <standard_surface name="m_shader" type="surfaceshader">
+    <input name="metalness" type="float" nodegraph="ng_metal" output="out_metal"/>
+  </standard_surface>
+</materialx>
+"""
+
+
 # Genuine texture-bound metalness (no graph) — current behavior:
 # parser leaves metalness=None and source=None. Convention helper
 # (separate test below) is what flips it to "texture".
@@ -229,6 +287,30 @@ class TestMetalnessGraphEstimate:
         assert pbr.is_conductor is None
         assert pbr.metalness is None
         assert pbr.metalness_source is None
+
+    def test_partial_conductor_blend_does_not_flip_is_conductor(self):
+        # fg=1.0, bg=0.3 → not a clean metal/dielectric mix. Per the
+        # post-review tightening, is_conductor stays None when the
+        # dielectric branch is non-zero.
+        pbr = parse_standard_surface_scalars(
+            FIXTURE_PARTIAL_CONDUCTOR_BLEND, material_id="m-partial"
+        )
+        assert pbr.is_conductor is None
+        assert pbr.metalness is None
+        assert pbr.metalness_source is None
+        assert pbr.metalness_mean is None
+
+    def test_color3_mix_on_metalness_falls_through(self):
+        # A <mix type="color3"> on the metalness input is schema drift
+        # (metalness is a float). The walker must early-return — no
+        # is_conductor flip, no estimate.
+        pbr = parse_standard_surface_scalars(
+            FIXTURE_COLOR3_MIX_ON_METALNESS, material_id="m-color3"
+        )
+        assert pbr.is_conductor is None
+        assert pbr.metalness is None
+        assert pbr.metalness_source is None
+        assert pbr.metalness_mean is None
 
 
 class TestPlainTextureBoundParserSide:

--- a/tests/test_mtlx_scalars_procedural.py
+++ b/tests/test_mtlx_scalars_procedural.py
@@ -1,0 +1,298 @@
+"""Tests for the procedural-PBR Phase 1 extension to ``_mtlx_scalars`` (#316).
+
+Bronze Oxydized–style materials author metalness as a procedural
+``<mix fg=A bg=B mix=t>`` graph rather than a single texture or scalar.
+The current parser deliberately returns ``None`` for graph-bound
+inputs (#290) — it only resolves the literal ``<constant>`` 1-hop case.
+This module extends the parser two ways:
+
+1. **Constant-folder.** When ``<mix>``'s ``fg``, ``bg``, AND ``mix``
+   inputs all resolve to scalar constants, fold to ``bg + (fg-bg)*t``
+   and set ``metalness_source="graph_constant"``. The contract for
+   ``metalness`` (a numeric value where set is trustworthy) is
+   preserved — this is a function evaluation, not a heuristic.
+
+2. **Graph-walker estimate.** When ``fg`` resolves to ``1.0`` (the
+   "pure metal" branch of a metal/dielectric mix), set
+   ``is_conductor=True`` + ``metalness_mean=fg*t + bg*(1-t)`` (using
+   the mix input's ``value`` default, falling back to 0.5 when the
+   mix is texture-bound) and source="graph_estimate". The
+   ``metalness`` scalar stays ``None`` — the contract is honest.
+
+Provenance fields land on every populated path:
+    "scalar"          — direct ``value=`` on the shader input
+    "graph_constant"  — 1-hop nodegraph→constant OR mix-fold to constants
+    "graph_estimate"  — fg=1.0 graph-walker estimate, metalness still None
+    "texture"         — populated by the convention helper at bake time
+
+#316 / #314.
+"""
+
+from __future__ import annotations
+
+import math
+
+from mat_vis_baker._mtlx_scalars import parse_standard_surface_scalars
+from mat_vis_baker.common import PBRBlock, apply_pbr_neutral_multiplier_conventions
+
+
+# ── fixtures: scalar provenance ────────────────────────────────
+
+
+FIXTURE_SCALAR_AUTHORED = """<?xml version="1.0"?>
+<materialx version="1.38">
+  <standard_surface name="m_shader" type="surfaceshader">
+    <input name="metalness" type="float" value="0.5"/>
+  </standard_surface>
+</materialx>
+"""
+
+
+FIXTURE_GRAPH_CONSTANT_FOLDABLE_MIX = """<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="ng_metal">
+    <constant name="c_fg" type="float">
+      <input name="value" type="float" value="1.0"/>
+    </constant>
+    <constant name="c_bg" type="float">
+      <input name="value" type="float" value="0.0"/>
+    </constant>
+    <constant name="c_mix" type="float">
+      <input name="value" type="float" value="0.7"/>
+    </constant>
+    <mix name="m_metal" type="float">
+      <input name="fg" nodename="c_fg"/>
+      <input name="bg" nodename="c_bg"/>
+      <input name="mix" nodename="c_mix"/>
+    </mix>
+    <output name="out_metal" type="float" nodename="m_metal"/>
+  </nodegraph>
+  <standard_surface name="m_shader" type="surfaceshader">
+    <input name="metalness" type="float" nodegraph="ng_metal" output="out_metal"/>
+  </standard_surface>
+</materialx>
+"""
+
+
+# Bronze Oxydized–style: fg=1.0 (pure metal), bg=constant dielectric,
+# mix=texture-bound mask. The walker should emit is_conductor=True +
+# metalness_mean estimate; the metalness scalar stays None.
+FIXTURE_BRONZE_OXYDIZED_LIKE = """<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="ng_metal">
+    <constant name="c_fg" type="float">
+      <input name="value" type="float" value="1.0"/>
+    </constant>
+    <constant name="c_bg" type="float">
+      <input name="value" type="float" value="0.0"/>
+    </constant>
+    <image name="img_mask" type="float">
+      <input name="file" type="filename" value="metalness_mask.png"/>
+    </image>
+    <mix name="m_metal" type="float">
+      <input name="fg" nodename="c_fg"/>
+      <input name="bg" nodename="c_bg"/>
+      <input name="mix" nodename="img_mask" value="0.7"/>
+    </mix>
+    <output name="out_metal" type="float" nodename="m_metal"/>
+  </nodegraph>
+  <standard_surface name="m_shader" type="surfaceshader">
+    <input name="metalness" type="float" nodegraph="ng_metal" output="out_metal"/>
+  </standard_surface>
+</materialx>
+"""
+
+
+# Same shape but no `value=` default on the mix input. Estimator falls
+# back to the mid-mask 0.5 default so metalness_mean is still set.
+FIXTURE_BRONZE_NO_MIX_DEFAULT = """<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="ng_metal">
+    <constant name="c_fg" type="float">
+      <input name="value" type="float" value="1.0"/>
+    </constant>
+    <constant name="c_bg" type="float">
+      <input name="value" type="float" value="0.0"/>
+    </constant>
+    <image name="img_mask" type="float">
+      <input name="file" type="filename" value="metalness_mask.png"/>
+    </image>
+    <mix name="m_metal" type="float">
+      <input name="fg" nodename="c_fg"/>
+      <input name="bg" nodename="c_bg"/>
+      <input name="mix" nodename="img_mask"/>
+    </mix>
+    <output name="out_metal" type="float" nodename="m_metal"/>
+  </nodegraph>
+  <standard_surface name="m_shader" type="surfaceshader">
+    <input name="metalness" type="float" nodegraph="ng_metal" output="out_metal"/>
+  </standard_surface>
+</materialx>
+"""
+
+
+# fg=0.0 (pure dielectric mixed with something) — must NOT set
+# is_conductor=True. The walker only fires on fg=1.0.
+FIXTURE_DIELECTRIC_MIX = """<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="ng_metal">
+    <constant name="c_fg" type="float">
+      <input name="value" type="float" value="0.0"/>
+    </constant>
+    <constant name="c_bg" type="float">
+      <input name="value" type="float" value="0.0"/>
+    </constant>
+    <image name="img_mask" type="float">
+      <input name="file" type="filename" value="metalness_mask.png"/>
+    </image>
+    <mix name="m_metal" type="float">
+      <input name="fg" nodename="c_fg"/>
+      <input name="bg" nodename="c_bg"/>
+      <input name="mix" nodename="img_mask"/>
+    </mix>
+    <output name="out_metal" type="float" nodename="m_metal"/>
+  </nodegraph>
+  <standard_surface name="m_shader" type="surfaceshader">
+    <input name="metalness" type="float" nodegraph="ng_metal" output="out_metal"/>
+  </standard_surface>
+</materialx>
+"""
+
+
+# Genuine texture-bound metalness (no graph) — current behavior:
+# parser leaves metalness=None and source=None. Convention helper
+# (separate test below) is what flips it to "texture".
+FIXTURE_PLAIN_TEXTURE_METAL = """<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="ng_metal">
+    <image name="img" type="float">
+      <input name="file" type="filename" value="metalness.png"/>
+    </image>
+    <output name="out_metal" type="float" nodename="img"/>
+  </nodegraph>
+  <standard_surface name="m_shader" type="surfaceshader">
+    <input name="metalness" type="float" nodegraph="ng_metal" output="out_metal"/>
+  </standard_surface>
+</materialx>
+"""
+
+
+# ── tests: parser provenance + graph extension ─────────────────
+
+
+class TestMetalnessSourceScalar:
+    def test_direct_value_marks_source_scalar(self):
+        pbr = parse_standard_surface_scalars(FIXTURE_SCALAR_AUTHORED, material_id="m-scalar")
+        assert pbr.metalness == 0.5
+        assert pbr.metalness_source == "scalar"
+        assert pbr.metalness_mean is None
+        assert pbr.is_conductor is None  # parser doesn't infer from scalar
+
+
+class TestMetalnessSourceGraphConstant:
+    def test_constant_foldable_mix_resolves_to_scalar(self):
+        # fg=1.0, bg=0.0, mix=0.7 → fold to 0.0 + (1.0-0.0)*0.7 = 0.7
+        pbr = parse_standard_surface_scalars(
+            FIXTURE_GRAPH_CONSTANT_FOLDABLE_MIX, material_id="m-fold"
+        )
+        assert pbr.metalness is not None
+        assert math.isclose(pbr.metalness, 0.7, abs_tol=1e-9)
+        assert pbr.metalness_source == "graph_constant"
+
+
+class TestMetalnessGraphEstimate:
+    def test_bronze_oxydized_pattern_emits_is_conductor_and_mean(self):
+        pbr = parse_standard_surface_scalars(FIXTURE_BRONZE_OXYDIZED_LIKE, material_id="m-bronze")
+        assert pbr.is_conductor is True
+        # fg=1.0, bg=0.0, mix=0.7 (the input default) → mean = 0*(1-0.7) + 1*0.7 = 0.7
+        assert pbr.metalness_mean is not None
+        assert math.isclose(pbr.metalness_mean, 0.7, abs_tol=1e-9)
+        # The scalar contract stays honest — metalness is still None
+        # because the value is per-pixel.
+        assert pbr.metalness is None
+        assert pbr.metalness_source == "graph_estimate"
+
+    def test_no_mix_default_falls_back_to_mid_mask(self):
+        pbr = parse_standard_surface_scalars(
+            FIXTURE_BRONZE_NO_MIX_DEFAULT, material_id="m-bronze-nodefault"
+        )
+        assert pbr.is_conductor is True
+        # fg=1.0, bg=0.0, mix unresolvable → fall back to 0.5
+        assert pbr.metalness_mean is not None
+        assert math.isclose(pbr.metalness_mean, 0.5, abs_tol=1e-9)
+        assert pbr.metalness is None
+        assert pbr.metalness_source == "graph_estimate"
+
+    def test_dielectric_mix_does_not_flip_is_conductor(self):
+        pbr = parse_standard_surface_scalars(FIXTURE_DIELECTRIC_MIX, material_id="m-die")
+        # fg=0.0 → not a metal-mix; walker does NOT set is_conductor=True
+        assert pbr.is_conductor is None
+        assert pbr.metalness is None
+        assert pbr.metalness_source is None
+
+
+class TestPlainTextureBoundParserSide:
+    def test_parser_leaves_provenance_unset(self):
+        # The parser doesn't know about textures (the bake-time helper
+        # does) — so for plain texture-bound metalness, every new field
+        # stays None at parser time. The convention helper fills it in.
+        pbr = parse_standard_surface_scalars(FIXTURE_PLAIN_TEXTURE_METAL, material_id="m-tex")
+        assert pbr.metalness is None
+        assert pbr.metalness_source is None
+        assert pbr.is_conductor is None
+        assert pbr.metalness_mean is None
+
+
+# ── tests: convention helper sets source="texture" ─────────────
+
+
+class TestConventionHelperSourceTexture:
+    def test_texture_present_sets_metalness_and_source(self):
+        pbr = PBRBlock()
+        apply_pbr_neutral_multiplier_conventions(pbr, {"metalness": "metalness.png"})
+        assert pbr.metalness == 1.0
+        assert pbr.metalness_source == "texture"
+
+    def test_no_texture_no_source(self):
+        pbr = PBRBlock()
+        apply_pbr_neutral_multiplier_conventions(pbr, {})
+        assert pbr.metalness is None
+        assert pbr.metalness_source is None
+
+    def test_authored_metalness_preserved_with_existing_source(self):
+        # Parser sets metalness=0.5 / source="scalar"; texture is also
+        # present. The convention helper must NOT overwrite either.
+        pbr = PBRBlock(metalness=0.5, metalness_source="scalar")
+        apply_pbr_neutral_multiplier_conventions(pbr, {"metalness": "metalness.png"})
+        assert pbr.metalness == 0.5
+        assert pbr.metalness_source == "scalar"
+
+    def test_zero_authored_metalness_preserved(self):
+        # 0.0 is meaningful (Acoustic Foam mask=0); the convention
+        # helper must not overwrite it — and source stays "scalar".
+        pbr = PBRBlock(metalness=0.0, metalness_source="scalar")
+        apply_pbr_neutral_multiplier_conventions(pbr, {"metalness": "metalness.png"})
+        assert pbr.metalness == 0.0
+        assert pbr.metalness_source == "scalar"
+
+
+# ── tests: PBRBlock fields are real (no AttributeError) ────────
+
+
+class TestPBRBlockFieldsExist:
+    def test_new_fields_default_to_none(self):
+        pbr = PBRBlock()
+        assert pbr.is_conductor is None
+        assert pbr.metalness_mean is None
+        assert pbr.metalness_source is None
+
+    def test_fields_are_settable(self):
+        pbr = PBRBlock(
+            metalness=None,
+            is_conductor=True,
+            metalness_mean=0.7,
+            metalness_source="graph_estimate",
+        )
+        assert pbr.is_conductor is True
+        assert pbr.metalness_mean == 0.7
+        assert pbr.metalness_source == "graph_estimate"


### PR DESCRIPTION
## Summary

Phase 1 of the [#314](https://github.com/MorePET/mat-vis/issues/314) procedural-PBR split. Closes the **library-browser** pain immediately ("show me all metals" returns Bronze Oxydized) without compromising the ``metalness`` scalar contract.

Three new optional fields on ``PBRBlock`` (additive, no schema bump):

| field | type | meaning |
|---|---|---|
| ``is_conductor`` | ``bool \| None`` | Queryable "this is metal" tag — metadata, not shading data |
| ``metalness_mean`` | ``float \| None`` | Whole-material mean estimate for procedural mixes |
| ``metalness_source`` | ``str \| None`` | Provenance: ``"scalar"`` / ``"graph_constant"`` / ``"graph_estimate"`` / ``"texture"`` |

### Parser extensions (``_mtlx_scalars.py``)

1. **Constant-folder for ``<mix fg bg mix>``** — when ``fg``, ``bg``, AND ``mix`` all resolve to scalar constants AND ``mix`` is not itself a texture-bound default, fold to ``bg + (fg-bg)*t`` and stamp ``metalness_source="graph_constant"``. Function evaluation, not heuristic; ``metalness`` contract preserved.
2. **Graph-walker for the Bronze pattern** — when ``fg`` resolves to ``1.0`` (the "pure metal" branch of a metal/dielectric mix), emit ``is_conductor=True`` + ``metalness_mean = bg + (fg-bg)*t`` (using the mix input's ``value=`` default, falling back to ``0.5`` for unresolvable texture-bound masks). ``metalness`` stays ``None`` — the per-pixel value can't be honestly collapsed. Stamps ``metalness_source="graph_estimate"``.
3. **Source tagging on every populated path.** Direct ``value=`` → ``"scalar"``. 1-hop ``nodegraph→<constant>`` → ``"graph_constant"``.

### Convention helper (``apply_pbr_neutral_multiplier_conventions``)

When the helper fills ``metalness=1.0`` because ``metalness.png`` is present, it now also stamps ``metalness_source="texture"``. Authored values + their pre-existing source are never overwritten — mirrors the existing "0.0 is meaningful" pattern.

## Acceptance — ready for re-bake on ``gerchowl/mat-vis-tst``

| Material | Expected after re-bake |
|---|---|
| **Bronze Oxydized** (procedural mix) | ``is_conductor=true``, ``metalness_mean ≈ 0.7``, ``metalness_source="graph_estimate"``, ``metalness=null`` ✓ |
| **Aluminum Hexagon** (texture-bound) | ``metalness=1.0``, ``metalness_source="texture"``, ``is_conductor=null`` (parser-side; upstream-metadata pass deferred to follow-up) |
| **Acoustic Foam 001** (texture-bound) | ``metalness=1.0``, ``metalness_source="texture"`` |

Per the [always-verify-E2E](https://github.com/MorePET/mat-vis/issues/210) policy: dispatch ``bake.yml`` on ``gerchowl/mat-vis-tst`` after merge and HEAD-check the real HF substrate before claiming done.

## Test plan

- [x] 12 new pytest cases in ``tests/test_mtlx_scalars_procedural.py`` — direct-value provenance, fully-foldable mix, Bronze pattern + no-mix-default fallback, dielectric mix doesn't flip ``is_conductor``, plain texture-bound parser side, convention helper source flag, authored preservation under texture, zero-authored preservation, field defaults + settability.
- [x] Schema-pin updated in ``test_index_builder.py`` (``test_mat_vis_block_has_stable_key_set``).
- [x] Root suite: 518 passed, 16 skipped.
- [x] Client suite: 350 passed, 27 skipped.

## Out of scope

- Same provenance treatment for ``roughness_source`` / ``color_source`` — file as a follow-up if Phase 1 rebake confirms shape is correct.
- Upstream-metadata-driven ``is_conductor`` (gpuopen tag/category lift at the source layer for materials whose metalness is *plain* texture-bound, like Aluminum Hexagon / Acoustic Foam). Cleaner to land after Phase 1 rebake validates the schema.

## References

- mat-vis#314 (umbrella; user-story spike consolidation)
- mat-vis#284 (texture-baker; Phase 2)
- mat-vis#290 (gpuopen scalar parser; this extends it)
- mat-vis#299 (convention-move to baker; this extends ``apply_pbr_neutral_multiplier_conventions``)
- mat-vis#301 (catalog wholesale-replace; coordinate during cut)
- mat-vis#306 (release-matrix; rebake target)

Closes #316.