### PR TITLE
bugfix(baker): physicallybased fetcher emits available_tiers=['scalar'] (closes #331)

### DIFF
--- a/src/mat_vis_baker/sources/physicallybased.py
+++ b/src/mat_vis_baker/sources/physicallybased.py
@@ -194,7 +194,13 @@ def fetch(*, session: requests.Session | None = None) -> list[MaterialRecord]:
                 fetched_at=fetched_at,
                 raw=_filter_upstream(mat, UPSTREAM_ALLOWLIST),
             ),
-            available_tiers=[],
+            # mat-vis#331: scalar-only sources advertise the "scalar"
+            # sentinel tier (the manifest already declares
+            # tiers.scalar.complete=True for physicallybased). Was [];
+            # client.materials("physicallybased", "scalar") returned
+            # empty for every dispatcher because `tier in []` matches
+            # nothing — see Bernhard's #313 cascade.
+            available_tiers=["scalar"],
             maps=[],
         )
         records.append(rec)

--- a/tests/test_physicallybased_available_tiers.py
+++ b/tests/test_physicallybased_available_tiers.py
@@ -1,33 +1,25 @@
-"""Red test for mat-vis#331: physicallybased catalog ships available_tiers=[].
+"""Test for mat-vis#331: physicallybased catalog ships available_tiers=["scalar"].
 
 bernhard-42's mat-vis#311 + #313: ``client.materials("physicallybased", "scalar")``
-returns empty even though 86 materials exist in the catalog. Root cause is in
-the fetcher (``sources/physicallybased.py:197``) which hardcodes
+returned empty even though 86 materials exist in the catalog. Root cause was in
+the fetcher (``sources/physicallybased.py:197``) which hardcoded
 ``available_tiers=[]`` instead of ``available_tiers=["scalar"]``.
 
-This test fails red on the current fetcher; the fix is a one-line change
-that flips the literal. xfail-strict forces removing the marker as a
-mechanical step in the fix PR — guards against the symptom-vs-spec failure
-mode that bit #287/#288 (closing on a different layer than the bug).
+Was a strict-xfail forcing function until the fix landed; now a regular
+green test pinning the contract for the future.
 
-See https://github.com/MorePET/mat-vis/issues/331 for the proper-fix
-acceptance, and #313 for bernhard's user-visible repro that this unblocks
-in combination with mat#222.
+See https://github.com/MorePET/mat-vis/issues/331 (closed by this fix) and
+#313 for bernhard's user-visible repro that this unblocks in combination
+with mat#222.
 """
 
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from mat_vis_baker.sources.physicallybased import fetch
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="mat-vis#331: physicallybased fetcher hardcodes available_tiers=[]",
-)
 def test_fetch_populates_available_tiers_with_scalar_sentinel() -> None:
     """Every record from the physicallybased fetcher must declare
     ``available_tiers=["scalar"]`` so ``client.materials()`` filters


### PR DESCRIPTION
## Summary

Closes #331 (data-layer half of bernhard's #313 cascade). One-line fetcher fix at \`sources/physicallybased.py:197\`:

\`\`\`diff
-            available_tiers=[],
+            available_tiers=["scalar"],
\`\`\`

The catalog's 86 entries were all advertising \`available_tiers=[]\`, so \`client.materials("physicallybased", "scalar")\` filtered them all out (\`tier in []\` matches nothing). The manifest already declared \`tiers.scalar.complete=True\` for physicallybased — the fetcher was just emitting an empty literal that contradicted it.

## Tests

Removes the strict-xfail marker on \`test_fetch_populates_available_tiers_with_scalar_sentinel\` (committed in #334 as a forcing function); it's now a regular green regression test.

## Out of scope

The API-layer DX concern — \`tier=\"scalar\"\` is a leaky sentinel and the user shouldn't have to know it (Bernhard's #281 quote: *"some materials expect \`tier=None\`. Need to find out how to work with this"*) — is filed separately as a new issue. This PR is data-layer only; the new issue tracks making \`tier\` optional for scalar-only sources at the client API.

The pymat-side default-tier mismatch (mat#222) is the other half of the cascade.

## Forward-verify after merge

1. Re-dispatch physicallybased bake on tst (current v2026.04.3 has \`available_tiers=[]\` from the pre-fix bake earlier today).
2. Confirm \`client.materials("physicallybased", "scalar")\` returns 86 ids.
3. With mat#222 landing on py-mat: \`Vis("physicallybased", "Aluminum").to_threejs()\` succeeds end-to-end. That closes Bernhard's #313 repro.

## References

- mat-vis#331 (closed by this)
- mat-vis#313 (cascade — needs both this + mat#222 + the new UX issue)
- mat#222 (pymat side — \`Vis\` defaults \`tier=\"1k\"\`)
- mat-vis#334 (the xfail this PR removes)