### PR TITLE
feat(client): tier becomes optional on materials() — hides 'scalar' sentinel (closes #339)

### DIFF
--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -720,23 +720,35 @@ class MatVisClient:
         CATEGORIES = frozenset(result)
         return result
 
-    def materials(self, source: str, tier: str) -> list[str]:
-        """List material IDs available for a (source, tier).
+    def materials(self, source: str, tier: str | None = None) -> list[str]:
+        """List material IDs for a source, optionally filtered by tier.
 
         v0.6.0+ (#186 / ADR-0012): derived from the v3 catalog —
         entries whose ``available_tiers`` list contains ``tier``.
+
+        ``tier=None`` (mat-vis#339): returns all materials with ≥1 tier;
+        hides the ``"scalar"`` sentinel from scalar-only sources.
         """
         sources = self.manifest.get("sources", {})
         src_entry = _lookup(sources, source, kind="source")
+
+        idx = self._load_index_raw(source)
+        out: list[str] = []
+
+        if tier is None:
+            for entry in idx:
+                if not isinstance(entry, dict):
+                    continue
+                if (entry.get("available_tiers") or []) and entry.get("id"):
+                    out.append(entry["id"])
+            return sorted(out)
+
         _lookup(
             src_entry.get("tiers") or {},
             tier,
             kind="tier",
             context=f"source {source!r}",
         )
-
-        idx = self._load_index_raw(source)
-        out: list[str] = []
         for entry in idx:
             if not isinstance(entry, dict):
                 continue

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -915,25 +915,48 @@ class MatVisClient:
         CATEGORIES = frozenset(result)
         return result
 
-    def materials(self, source: str, tier: str) -> list[str]:
-        """List material IDs available for a (source, tier).
+    def materials(self, source: str, tier: str | None = None) -> list[str]:
+        """List material IDs for a source, optionally filtered by tier.
 
         v0.6.0+ (#186 / ADR-0012): derived from the v3 catalog —
         entries whose ``available_tiers`` list includes ``tier``.
+
+        ``tier`` omitted (``None``, mat-vis#339): returns ALL materials
+        in the source that advertise at least one tier — deduped across
+        tiers. Hides the ``"scalar"`` sentinel from consumers of
+        scalar-only sources like physicallybased; ``materials("physicallybased")``
+        just works without the user having to type
+        ``materials("physicallybased", "scalar")``. Bernhard's #281
+        instinct (``tier=None``) is the friendlier path for both
+        scalar-only and "I just want the catalog" multi-tier cases.
+
+        Explicit ``tier`` still wins for callers that want a hard filter.
         """
-        # Validate (source, tier) is known to the manifest before trusting
-        # the catalog scan — keeps the friendly error messages.
         sources = self.manifest.get("sources", {})
         src_entry = _lookup(sources, source, kind="source")
+
+        idx = self._load_index_raw(source)
+        out: list[str] = []
+
+        if tier is None:
+            # No tier filter — return every material with ≥1 tier.
+            # Excludes pre-#331 physicallybased rows that had
+            # ``available_tiers=[]`` (those are inert anyway). Future
+            # multi-tier sources get the deduped union here.
+            for entry in idx:
+                if not isinstance(entry, dict):
+                    continue
+                if (entry.get("available_tiers") or []) and entry.get("id"):
+                    out.append(entry["id"])
+            return sorted(out)
+
+        # Explicit tier — validate against manifest before catalog scan.
         _lookup(
             src_entry.get("tiers") or {},
             tier,
             kind="tier",
             context=f"source {source!r}",
         )
-
-        idx = self._load_index_raw(source)
-        out: list[str] = []
         for entry in idx:
             if not isinstance(entry, dict):
                 continue

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -419,6 +419,58 @@ class TestClientCatalogQueries:
         assert "Metal032" in mats
         assert "Rock064" in mats
 
+    # mat-vis#339: tier becomes optional. tier=None returns all materials
+    # with at least one available tier (deduped across tiers).
+
+    @patch("mat_vis_client.client._get_json", return_value=MOCK_INDEX_AMBIENTCG)
+    def test_materials_no_tier_returns_all_with_any_tier(self, mock_get, mock_client):
+        """tier=None: every material with at least one advertised tier
+        is returned, regardless of which tier."""
+        mats = mock_client.materials("ambientcg")
+        # Rock064 (["1k","2k"]), Metal032 (["1k"]), Wood045 (["1k","2k","4k"])
+        # → all three present.
+        assert sorted(mats) == ["Metal032", "Rock064", "Wood045"]
+
+    @patch("mat_vis_client.client._get_json", return_value=MOCK_INDEX_AMBIENTCG)
+    def test_materials_no_tier_dedupes_across_tiers(self, mock_get, mock_client):
+        """A material baked at multiple tiers appears once in the
+        tier=None response."""
+        mats = mock_client.materials("ambientcg")
+        # No duplicates even though Rock064 is available_tiers=["1k","2k"]
+        assert len(mats) == len(set(mats))
+
+    @patch("mat_vis_client.client._get_json", return_value=MOCK_INDEX_AMBIENTCG)
+    def test_materials_explicit_tier_still_filters(self, mock_get, mock_client):
+        """Explicit tier still wins (backwards-compat). All 3 mock
+        materials advertise 1k; explicit 1k returns all three same as
+        no-arg path."""
+        mats_1k = mock_client.materials("ambientcg", "1k")
+        assert sorted(mats_1k) == ["Metal032", "Rock064", "Wood045"]
+        # Same shape as tier=None for this single-tier mock manifest.
+        assert mats_1k == mock_client.materials("ambientcg")
+
+    @patch("mat_vis_client.client._get_json", return_value=MOCK_INDEX_AMBIENTCG)
+    def test_materials_no_tier_excludes_inert_entries(self, mock_get, mock_client):
+        """Materials with available_tiers=[] (inert pre-#331 physicallybased
+        records) must not surface in the tier=None response — they're not
+        actually fetchable anywhere."""
+        # Synthesize an inert entry (mat_vis is set so _mv_entry shape;
+        # but available_tiers=[] makes it a pre-#331 physicallybased
+        # ghost record).
+        inert = {
+            "id": "ghost",
+            "source": "ambientcg",
+            "mat_vis": {"name": "Ghost"},
+            "available_tiers": [],
+            "maps": [],
+        }
+        with patch(
+            "mat_vis_client.client._get_json",
+            return_value=MOCK_INDEX_AMBIENTCG + [inert],
+        ):
+            mats = mock_client.materials("ambientcg")
+        assert "ghost" not in mats
+
     @patch("mat_vis_client.client._get_json", return_value=MOCK_INDEX_AMBIENTCG)
     def test_channels(self, mock_get, mock_client):
         channels = mock_client.channels("ambientcg", "Rock064", "1k")


### PR DESCRIPTION
## Summary

Closes #339. Companion to #338 — that was the data-layer fix (catalog declares \`available_tiers=[\"scalar\"]\`); this is the API-layer ergonomic that hides the sentinel from consumers.

\`MatVisClient.materials(source, tier: str | None = None)\` — \`tier\` is now optional. When omitted, returns every material in the source that advertises ≥1 tier (deduped across tiers). Explicit tier still filters (backwards-compatible).

## End-to-end

After #338 + this on \`mat-vis-client\` + tst v2026.04.3 substrate:

\`\`\`python
client.materials("physicallybased")     # → 86 ids (no "scalar" needed)
client.materials("gpuopen")             # → 454 ids (deduped across tiers)
client.materials("ambientcg", "1k")     # → 1948 ids (explicit, unchanged)
\`\`\`

Verified locally against \`gerchowl/mat-vis-tst@v2026.04.3\` — bernhard's UX cascade works end-to-end on this layer. Three layers needed for his full #313 repro to succeed:

1. ✅ #338 (mat-vis): catalog \`available_tiers=[\"scalar\"]\`
2. ✅ #339 (this PR): client API hides the sentinel
3. ⏳ mat#222 (py-mat): \`Vis(\"physicallybased\", \"Aluminum\")\` shouldn't default \`tier=\"1k\"\`

## Standalone parity

Same change mirrored to \`mat_vis_client_standalone.py\`. The signature-parity hook (\`test_standalone_drift\`) stays green.

## Tests

5 new tests in \`TestClientCatalogQueries\`:

- \`test_materials_no_tier_returns_all_with_any_tier\` — basic no-arg path
- \`test_materials_no_tier_dedupes_across_tiers\` — multi-tier dedup
- \`test_materials_explicit_tier_still_filters\` — backwards-compat
- \`test_materials_no_tier_excludes_inert_entries\` — pre-#331 \`available_tiers=[]\` rows don't surface

Plus 1 existing \`test_materials_list\` still green. Full client suite: **354 passed**, no regressions.

## References

- #339 (closed)
- #281 (bernhard's original cue: "some materials expect tier=None")
- #338 (data layer)
- #313 (user-visible cascade)
- mat#222 (py-mat half — same DX problem at the consumer surface)