### PR TITLE
bugfix(ci): validate_release iterates union of (source,tier) keys (closes #344)

### DIFF
--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -138,6 +138,13 @@ def find_regressions(
     Previous release = the newest ``release_tag`` strictly less than
     ``current_tag`` (lexicographic — fine for CalVer ``vYYYY.MM.N``).
     No previous row → no regression possible (first-ever release).
+
+    mat-vis#344: iterate the UNION of (source, tier) keys across both
+    current and previous, not just current's keys. A tier present in
+    previous but completely absent from current (``actual_count=0``)
+    is the worst regression class — every consumer of that tier
+    silently breaks. The pre-#344 code skipped these via
+    ``if current is None: continue``.
     """
     rows = load_aggregated_counts(metrics_path)
 
@@ -150,15 +157,16 @@ def find_regressions(
     for (source, tier), group in by_key.items():
         group.sort(key=lambda r: (r["release_tag"], r.get("timestamp", "")))
         current = next((r for r in group if r["release_tag"] == current_tag), None)
-        if current is None:
-            continue
         prior = [r for r in group if r["release_tag"] < current_tag]
         if not prior:
-            continue
+            continue  # first-ever release; nothing to regress against
         previous = prior[-1]
         if previous["actual_count"] <= 0:
-            continue
-        ratio = current["actual_count"] / previous["actual_count"]
+            continue  # previous was empty (free-pass per existing semantics)
+        # mat-vis#344: tier-missing-from-current → actual_count = 0,
+        # ratio = 0, which violates any min_ratio > 0.
+        curr_count = current["actual_count"] if current is not None else 0
+        ratio = curr_count / previous["actual_count"]
         if ratio < min_ratio:
             regressions.append(
                 {
@@ -166,9 +174,12 @@ def find_regressions(
                     "tier": tier,
                     "current_tag": current_tag,
                     "previous_tag": previous["release_tag"],
-                    "actual_count": current["actual_count"],
+                    "actual_count": curr_count,
                     "previous_count": previous["actual_count"],
                     "ratio": ratio,
+                    # mat-vis#344: distinguishes "tier shrunk" from
+                    # "tier vanished entirely" for operator triage.
+                    "kind": "tier_missing" if current is None else "count_drop",
                 }
             )
     return regressions
@@ -307,15 +318,21 @@ def find_regressions_from_hf(
     if not previous_baked:
         return []
 
+    # mat-vis#344: iterate the UNION of keys, not just current's. A
+    # tier present in previous but missing from current is the
+    # worst-case regression — every consumer of that tier silently
+    # breaks. Pre-#344 the loop iterated current_baked.items() and
+    # `prev_ids = previous_baked.get(...); if not prev_ids: continue`,
+    # so prev-only keys never entered the loop.
+    all_keys = set(current_baked.keys()) | set(previous_baked.keys())
     regressions: list[dict[str, Any]] = []
-    for (source, tier), curr_ids in current_baked.items():
-        prev_ids = previous_baked.get((source, tier))
-        if not prev_ids:
-            continue
+    for source, tier in sorted(all_keys):
+        prev_ids = previous_baked.get((source, tier)) or set()
+        curr_ids = current_baked.get((source, tier)) or set()
         prev_count = len(prev_ids)
-        curr_count = len(curr_ids)
         if prev_count <= 0:
-            continue
+            continue  # nothing to regress against (newly-added tier)
+        curr_count = len(curr_ids)
         ratio = curr_count / prev_count
         if ratio < min_ratio:
             regressions.append(
@@ -327,6 +344,13 @@ def find_regressions_from_hf(
                     "actual_count": curr_count,
                     "previous_count": prev_count,
                     "ratio": ratio,
+                    # mat-vis#344: tier-vanished is worth flagging
+                    # distinctly so the operator's triage starts in the
+                    # right place ("did upstream go away?" vs "did the
+                    # bake plan get pruned?").
+                    "kind": (
+                        "tier_missing" if (source, tier) not in current_baked else "count_drop"
+                    ),
                 }
             )
     return regressions

--- a/tests/test_validate_release_per_file.py
+++ b/tests/test_validate_release_per_file.py
@@ -454,3 +454,103 @@ def test_find_tier_parity_violations_from_hf_detects_gap():
     assert v["tier"] == "2k"
     assert v["actual_count"] == 200
     assert v["leader_count"] == 1000
+
+
+# ── mat-vis#344: tier-missing-from-current is the worst regression class ──
+
+
+def test_regression_detects_tier_completely_missing_from_current(tmp_path):
+    """A tier that existed in the previous release but is gone from
+    the current one is the worst-case regression — every consumer of
+    that tier breaks immediately. Pre-#344 the metrics path skipped
+    these (only iterated rows where current existed)."""
+    p = tmp_path / "per-file-metrics.parquet"
+    _seed(
+        p,
+        # v2026.04.0 had gpuopen at 1k AND 512.
+        {
+            "release_tag": "v2026.04.0",
+            "source": "gpuopen",
+            "tier": "1k",
+            "materials_committed": 454,
+        },
+        {
+            "release_tag": "v2026.04.0",
+            "source": "gpuopen",
+            "tier": "512",
+            "materials_committed": 454,
+        },
+        # v2026.04.1 has only 1k (the matrix-only-declares-1k bug).
+        {
+            "release_tag": "v2026.04.1",
+            "source": "gpuopen",
+            "tier": "1k",
+            "materials_committed": 454,
+        },
+    )
+
+    regressions = find_regressions(p, current_tag="v2026.04.1", min_ratio=0.95)
+    # 1k is fine; 512 is the violation.
+    assert len(regressions) == 1
+    r = regressions[0]
+    assert r["source"] == "gpuopen"
+    assert r["tier"] == "512"
+    assert r["actual_count"] == 0
+    assert r["previous_count"] == 454
+    assert r["ratio"] == 0.0
+    assert r["kind"] == "tier_missing"
+
+
+def test_existing_count_drop_still_marked_as_count_drop(tmp_path):
+    """The existing v2026.04.0 reproduction (1k stays present but
+    drops count) keeps its semantics — kind=count_drop, not
+    tier_missing."""
+    p = tmp_path / "per-file-metrics.parquet"
+    _seed(
+        p,
+        {
+            "release_tag": "v2026.04.0",
+            "source": "gpuopen",
+            "tier": "1k",
+            "materials_committed": 2234,
+        },
+        {
+            "release_tag": "v2026.04.1",
+            "source": "gpuopen",
+            "tier": "1k",
+            "materials_committed": 10,
+        },
+    )
+    [r] = find_regressions(p, current_tag="v2026.04.1", min_ratio=0.95)
+    assert r["kind"] == "count_drop"
+
+
+def test_regression_from_hf_detects_tier_completely_missing(tmp_path):
+    """Same blind-spot fix on the --from-hf path. Mock baked_ids so
+    previous has gpuopen at {1k, 512} and current has only {1k}."""
+    from unittest.mock import patch
+
+    api = MagicMock()
+    current = {("gpuopen", "1k"): {f"m{i}" for i in range(454)}}
+    previous = {
+        ("gpuopen", "1k"): {f"m{i}" for i in range(454)},
+        ("gpuopen", "512"): {f"m{i}" for i in range(454)},
+    }
+    with patch(
+        "scripts.validate_release.baked_ids_from_release_manifest",
+        side_effect=lambda _api, _repo, tag: current if tag == "v2026.04.1" else previous,
+    ):
+        regressions = find_regressions_from_hf(
+            api,
+            repo_id="gerchowl/mat-vis",
+            current_tag="v2026.04.1",
+            previous_tag="v2026.04.0",
+            min_ratio=0.95,
+        )
+
+    assert len(regressions) == 1
+    r = regressions[0]
+    assert r["source"] == "gpuopen"
+    assert r["tier"] == "512"
+    assert r["actual_count"] == 0
+    assert r["kind"] == "tier_missing"


### PR DESCRIPTION
## Summary

Closes #344. The regression gate's blind spot: iterated CURRENT keys only, so a tier present in previous but vanished from current was never flagged. The worst-case regression — every consumer of that tier silently breaks.

## Fix

Both paths now iterate \`set(current_keys) | set(previous_keys)\`:
- \`find_regressions\` (\`--metrics\`): drop \`if current is None: continue\`; treat \`curr_count=0\` when missing.
- \`find_regressions_from_hf\` (\`--from-hf\`): iterate union; same treat-missing-as-zero semantics.

New \`kind\` field on each violation distinguishes:
- \`tier_missing\`: tier vanished entirely (curr_count=0, prev>0)
- \`count_drop\`: tier present but below min_ratio (the existing v2026.04.0 case)

So operator triage starts in the right place ("did upstream go away?" vs "did the bake plan get pruned?").

## Tests

3 new in \`tests/test_validate_release_per_file.py\`:
- Tier-completely-missing on metrics path → flagged as \`tier_missing\`
- Existing v2026.04.0 reproduction stays as \`count_drop\` (no semantic regression)
- Tier-completely-missing on \`--from-hf\` path → same

23/23 validate tests green.

## Why this matters now

Surfaced while scoping #306's matrix coverage: production v2026.04.2 ships 6 tiers/source from bake+derive+ktx2; the matrix declares only the bake cell (1k). Without this fix, a future cut that drops the matrix-undeclared tiers would pass every gate. Combined with #345 (prod pre-flight), this completes the rail.

## References

- mat-vis#344 (closed)
- mat-vis#306 (matrix coverage — the architectural gap that surfaced this)
- mat-vis#345 (prod pre-flight — complements this gate; agent-resistant escape hatch)
- v2026.04.0 regression class (\`gpuopen-1k 2234→10\`) — original motivation for #263 phase C; this is the inverse failure mode