### PR TITLE
feat(ci): prod-cut pre-flight — tst-prior + tier-parity + agent-resistant deprecation gate (closes #345)

### DIFF
--- a/.dagger/src/mat_vis_ci/_preflight.py
+++ b/.dagger/src/mat_vis_ci/_preflight.py
@@ -1,0 +1,203 @@
+"""Pre-flight prod-cut helpers (mat-vis#345).
+
+Pure-Python predicates for the prod-cut preflight gate. Lives in its
+own module so it can be unit-tested without the Dagger SDK in the
+venv (mirrors the ``_bake_cli`` pattern). ``main.py`` (which decorates
+``MatVisCi`` with Dagger's runtime types) imports from here; tests
+import here directly.
+
+Three checks compose the gate; each is a small pure function:
+
+1. :func:`tst_has_release_manifest` — confirms the tst dataset
+   carries the same release-tag we're about to push to prod. The
+   "ALWAYS E2E on tst before prod" rule made mechanical.
+2. :func:`compute_missing_cells` — set difference of
+   ``previous_prod_cells - tst_cells - deprecated_cells``. Empty
+   means tst's tier coverage at release-tag is a superset of
+   previous prod's tier coverage modulo explicit deprecations.
+3. :func:`compose_violations` — wraps both into a structured
+   violation list the Dagger function reports back to the operator.
+
+The deprecation-approval gate (the agent-resistant escape hatch via
+GH issue labels) lives in workflow YAML — it requires the ``gh``
+CLI authenticated with the workflow's ``GITHUB_TOKEN`` and a label
+permission boundary that the workflow runtime enforces. By the time
+this module's :func:`compose_violations` runs, ``deprecated_cells``
+has already been verified by the workflow step.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+def _hf_manifest_url(repo_id: str, release_tag: str) -> str:
+    """Stable URL pattern matching :mod:`mat_vis_baker.hf_bake_per_file`'s
+    write side."""
+    return f"https://huggingface.co/datasets/{repo_id}/resolve/{release_tag}/release-manifest.json"
+
+
+def fetch_release_manifest(repo_id: str, release_tag: str) -> dict[str, Any] | None:
+    """Fetch a release-manifest.json from HF. Returns ``None`` on 404
+    so callers can distinguish "tag doesn't exist" (legitimate) from
+    "fetch errored" (re-raise).
+    """
+    url = _hf_manifest_url(repo_id, release_tag)
+    try:
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+
+
+def manifest_cells(manifest: dict[str, Any]) -> set[tuple[str, str]]:
+    """Extract the ``(source, tier)`` cell set from a v3 manifest.
+
+    Defensive against missing keys — old tags / partial dispatches
+    sometimes carry incomplete shapes. Empty/malformed → empty set
+    (callers handle "no coverage" semantics explicitly).
+    """
+    out: set[tuple[str, str]] = set()
+    for source, src_entry in (manifest.get("sources") or {}).items():
+        if not isinstance(src_entry, dict):
+            continue
+        for tier in (src_entry.get("tiers") or {}).keys():
+            out.add((str(source), str(tier)))
+    return out
+
+
+def tst_has_release_manifest(tst_repo_id: str, release_tag: str) -> bool:
+    """True iff the tst dataset has a release-manifest.json at the
+    requested tag. Implementation detail: a 200 fetch implies the
+    bake actually pushed something at that revision.
+    """
+    return fetch_release_manifest(tst_repo_id, release_tag) is not None
+
+
+def compute_missing_cells(
+    tst_cells: set[tuple[str, str]],
+    prev_prod_cells: set[tuple[str, str]],
+    deprecated_cells: set[tuple[str, str]],
+) -> set[tuple[str, str]]:
+    """Cells in previous prod that aren't on tst AND aren't explicitly
+    deprecated. Empty set means tst is ready to ship (modulo whatever
+    other gates run after this).
+
+    Set algebra:
+        missing = prev_prod_cells - tst_cells - deprecated_cells
+    """
+    return prev_prod_cells - tst_cells - deprecated_cells
+
+
+def compose_violations(
+    tst_repo_id: str,
+    prod_repo_id: str,
+    release_tag: str,
+    previous_prod_tag: str,
+    deprecated_cells: set[tuple[str, str]],
+) -> list[dict[str, Any]]:
+    """Run the full preflight composition. Returns a list of structured
+    violation dicts (empty = green; non-empty = abort the prod cut).
+
+    Violation shapes:
+
+    - ``kind="tst_missing_release_tag"``: gate (1) failed; tst doesn't
+      have ``release_tag``. Operator action: dispatch a tst bake at
+      that tag first.
+    - ``kind="tier_coverage_regression"``: gate (2) failed; one or
+      more cells from previous prod are absent from tst and not
+      deprecated. Operator action: either bake the missing tier(s)
+      onto tst OR file a deprecation issue with the
+      ``tier-deprecation-approved`` label and re-dispatch with
+      ``deprecate-cells`` listing them.
+
+    Caller (Dagger function) raises on non-empty so the workflow
+    fails before any prod write.
+    """
+    violations: list[dict[str, Any]] = []
+
+    tst_manifest = fetch_release_manifest(tst_repo_id, release_tag)
+    if tst_manifest is None:
+        violations.append(
+            {
+                "kind": "tst_missing_release_tag",
+                "tst_repo_id": tst_repo_id,
+                "release_tag": release_tag,
+                "remedy": (
+                    f"Run a tst bake against {tst_repo_id} at {release_tag} first. "
+                    "The 'ALWAYS E2E on tst before prod' rule applies."
+                ),
+            }
+        )
+        # Without a tst manifest there's nothing to compute coverage
+        # against; short-circuit so downstream output stays focused.
+        return violations
+
+    prev_prod_manifest = fetch_release_manifest(prod_repo_id, previous_prod_tag)
+    if prev_prod_manifest is None:
+        # First-ever prod release, or previous tag was deleted. No
+        # coverage to regress against — preflight passes the parity
+        # check (mirrors validate_release.py's first-cut free-pass).
+        return violations
+
+    tst_cells = manifest_cells(tst_manifest)
+    prev_cells = manifest_cells(prev_prod_manifest)
+    missing = compute_missing_cells(tst_cells, prev_cells, deprecated_cells)
+    if missing:
+        violations.append(
+            {
+                "kind": "tier_coverage_regression",
+                "tst_repo_id": tst_repo_id,
+                "prod_repo_id": prod_repo_id,
+                "release_tag": release_tag,
+                "previous_prod_tag": previous_prod_tag,
+                "missing_cells": sorted(missing),
+                "remedy": (
+                    "Either bake the missing (source, tier) cells onto tst at the "
+                    "release-tag, OR open a GH issue per missing cell with the "
+                    "`tier-deprecation-approved` label (maintainer-only) and re-dispatch "
+                    "with `deprecate-cells` listing the deprecated cells."
+                ),
+            }
+        )
+    return violations
+
+
+def parse_deprecate_cells(arg: str) -> set[tuple[str, str]]:
+    """Parse the ``--deprecate-cells`` CLI/Dagger arg.
+
+    Accepts a JSON list of ``[source, tier]`` pairs (or objects with
+    ``source``/``tier`` keys). Empty/missing → empty set.
+
+    Examples::
+
+        '[]'                                            → set()
+        '[["gpuopen", "128"], ["gpuopen", "256"]]'      → {("gpuopen", "128"), …}
+        '[{"source":"gpuopen","tier":"128"}]'           → {("gpuopen", "128")}
+    """
+    if not arg or not arg.strip():
+        return set()
+    try:
+        parsed = json.loads(arg)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"--deprecate-cells must be valid JSON: {exc}") from exc
+    if not isinstance(parsed, list):
+        raise ValueError(f"--deprecate-cells must be a JSON list, got {type(parsed).__name__}")
+
+    out: set[tuple[str, str]] = set()
+    for item in parsed:
+        if isinstance(item, list) and len(item) == 2:
+            out.add((str(item[0]), str(item[1])))
+        elif isinstance(item, dict) and "source" in item and "tier" in item:
+            out.add((str(item["source"]), str(item["tier"])))
+        else:
+            raise ValueError(
+                f"--deprecate-cells entries must be [source, tier] pairs "
+                f"or {{source, tier}} objects; got {item!r}"
+            )
+    return out

--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -23,6 +23,7 @@ Usage:
     dagger call test-client-rust     # cargo test for Rust reference client
     dagger call test-clients         # all 4 client tests in parallel
     dagger call test-e-2-e           # nightly E2E against mat-vis-tst (#193; #240)
+    dagger call validate-prod-preflight  # tst-prior + tier-parity + deprecation gate (#345)
     dagger call validate-release     # validate_release.py --from-hf (#273)
     dagger call preflight            # verify GHCR auth before push
     dagger call push                 # preflight + build + push to GHCR
@@ -882,6 +883,98 @@ class MatVisCi:
         ]
         if previous_tag:
             argv.extend(["--previous-tag", previous_tag])
+        return await ctr.with_exec(argv).stdout()
+
+    # ── prod-cut pre-flight (mat-vis#345) ─────────────────────────
+    #
+    # Three composable gates, each agent-resistant in its own way:
+    #
+    #   1. tst-prior: tst dataset must already carry the release_tag
+    #      we're about to push to prod. The "ALWAYS E2E on tst" rule
+    #      made mechanical at the workflow boundary.
+    #
+    #   2. tier-coverage: tst's (source, tier) cells at release_tag
+    #      must be a SUPERSET of previous prod's cells, modulo
+    #      explicitly-deprecated cells.
+    #
+    #   3. deprecation approval: each declared deprecate-cell must
+    #      have a GH issue bearing the `tier-deprecation-approved`
+    #      label. The label permission is restricted to the repo's
+    #      `triage` role at GitHub's level — agents/bots without
+    #      that role cannot apply it. Verified by the workflow step
+    #      `scripts/verify_deprecation_issues.py` BEFORE this Dagger
+    #      function runs; this function trusts the verified input.
+
+    @function
+    async def validate_prod_preflight(
+        self,
+        context: Annotated[dagger.Directory, Doc("Project root directory")],
+        release_tag: Annotated[str, Doc("CalVer release tag about to be cut to prod")],
+        prod_repo_id: Annotated[
+            str, Doc("Production HF dataset repo (the destination)")
+        ] = "gerchowl/mat-vis",
+        tst_repo_id: Annotated[
+            str, Doc("Scratch HF dataset repo where tst bake should already exist")
+        ] = "gerchowl/mat-vis-tst",
+        previous_prod_tag: Annotated[
+            str,
+            Doc(
+                "Previous CalVer prod tag for tier-coverage comparison. Empty = "
+                "first-ever prod release (preflight free-passes the parity check)."
+            ),
+        ] = "",
+        deprecate_cells: Annotated[
+            str,
+            Doc(
+                "JSON list of [source, tier] pairs the operator wants to mark "
+                "as deprecated (so they're allowed to be missing from tst). MUST "
+                "have already been verified by `scripts/verify_deprecation_issues.py` "
+                "in a workflow step BEFORE this function runs."
+            ),
+        ] = "[]",
+    ) -> str:
+        """Run the mat-vis#345 prod-cut preflight in the baker container.
+
+        Returns a short JSON report on success; raises on any
+        violation (Dagger surfaces the exception via the workflow's
+        existing notify-on-failure path).
+
+        The deprecation-approval gate is NOT inside this function on
+        purpose — it requires the workflow's `gh` CLI auth, which
+        Dagger doesn't carry. The workflow runs
+        `scripts/verify_deprecation_issues.py` first, then passes the
+        already-verified list here as JSON.
+        """
+        ctr = self._baker_container(context)
+        # Dispatch as a small Python one-liner that imports the
+        # preflight helpers and JSON-dumps the result. Keeping the
+        # logic in `_preflight.py` (pure stdlib) means the `--from-hf`
+        # urllib calls happen inside the baker container which has
+        # network access by default.
+        argv = [
+            "python",
+            "-c",
+            (
+                "import json, sys;"
+                "from mat_vis_ci._preflight import compose_violations, parse_deprecate_cells;"
+                f"deprecated = parse_deprecate_cells({deprecate_cells!r});"
+                "v = compose_violations("
+                f"  tst_repo_id={tst_repo_id!r},"
+                f"  prod_repo_id={prod_repo_id!r},"
+                f"  release_tag={release_tag!r},"
+                f"  previous_prod_tag={previous_prod_tag!r},"
+                "  deprecated_cells=deprecated,"
+                ");"
+                "print(json.dumps(v, indent=2));"
+                "sys.exit(0 if not v else 1);"
+            ),
+        ]
+        # Make the helper module importable inside the baker
+        # container by mounting the dagger module's src tree under
+        # PYTHONPATH. The container already has the host project at
+        # /app, but the dagger module lives at /app/.dagger/src so
+        # we extend PYTHONPATH explicitly.
+        ctr = ctr.with_env_variable("PYTHONPATH", "/app/.dagger/src")
         return await ctr.with_exec(argv).stdout()
 
     @function

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -95,10 +95,30 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: false
         type: boolean
+      previous-prod-tag:
+        description: >-
+          Previous CalVer prod tag for the #345 tier-coverage parity check.
+          Empty = first-ever prod release (preflight free-passes parity).
+          Only consulted when allow-prod=true.
+        required: false
+        default: ''
+        type: string
+      deprecate-cells:
+        description: >-
+          JSON list of [source, tier] pairs to mark as legitimately deprecated
+          (allowed to be missing from tst per the #345 tier-coverage gate).
+          Each cell MUST have an open GH issue with the
+          `tier-deprecation-approved` label — verified by a workflow step BEFORE
+          the bake matrix runs. Only consulted when allow-prod=true.
+        required: false
+        default: '[]'
+        type: string
 
+# issues: write covers both notify-on-failure composite + #345
+# prod-preflight (gh issue list — write subsumes read).
 permissions:
   contents: read
-  issues: write          # needed by notify-on-failure composite action
+  issues: write
 
 # #262 / #278: disable Dagger's dagger.cloud OTel export at every layer.
 # OTEL_SDK_DISABLED reaches the dagger CLI but the Go engine kept ID-generating
@@ -122,8 +142,76 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # mat-vis#345: prod-cut pre-flight. Three composable gates,
+  # short-circuited via `if: inputs.allow-prod == true` so dispatches
+  # against gerchowl/mat-vis-tst skip it entirely (cost-free).
+  #
+  # Step 1 — verify each declared deprecate-cell has a maintainer-
+  # approved GH issue with the `tier-deprecation-approved` label.
+  # Label permission is gated on the repo's triage role; agent /
+  # contributor accounts cannot apply it. Bypassable only by a
+  # human maintainer, by design.
+  #
+  # Step 2 — Dagger function checks tst-prior + tier-coverage parity
+  # vs previous prod release. Trusts the deprecation list AFTER
+  # step 1 has verified it.
+  preflight:
+    name: prod-cut preflight (#345)
+    if: inputs.allow-prod == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify deprecation approvals (gh issue label)
+        env:
+          DEPRECATE_CELLS: ${{ inputs.deprecate-cells }}
+        run: |
+          set -euo pipefail
+          python3 scripts/verify_deprecation_issues.py "${DEPRECATE_CELLS:-[]}"
+
+      - name: tst-prior + tier-coverage gates
+        uses: ./.github/actions/dagger-call
+        with:
+          args: >-
+            validate-prod-preflight
+            --context=.
+            --release-tag=${{ inputs.release-tag }}
+            --prod-repo-id=${{ inputs.repo-id }}
+            --tst-repo-id=gerchowl/mat-vis-tst
+            --previous-prod-tag=${{ inputs.previous-prod-tag }}
+            --deprecate-cells=${{ inputs.deprecate-cells }}
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-on-failure
+        with:
+          label-prefix: "[prod-preflight-failed]"
+          workflow-name: "bake (prod-preflight)"
+          target: "${{ inputs.release-tag }} → ${{ inputs.repo-id }}"
+          context: >-
+            mat-vis#345 prod-cut preflight tripped before any prod write.
+            Either (a) tst doesn't have ${{ inputs.release-tag }} — run
+            a tst bake first, or (b) tst's tier coverage is missing cells
+            previous prod had — bake the missing tier(s) on tst OR open
+            a GH issue with the 'tier-deprecation-approved' label per
+            missing cell and re-dispatch with `deprecate-cells` listing
+            them.
+
   plan:
     name: plan (read release matrix)
+    # mat-vis#345: when allow-prod=true, preflight runs and must succeed
+    # before plan kicks off the bake matrix. When allow-prod=false,
+    # preflight is skipped and plan runs unconditionally — `needs` with
+    # `always() && (success OR skipped)` is the GH Actions idiom for
+    # "depend on the prior job's terminal state, not its existence."
+    needs: preflight
+    if: |
+      always() &&
+      (needs.preflight.result == 'success' || needs.preflight.result == 'skipped')
     runs-on: ubuntu-latest
     outputs:
       cells: ${{ steps.matrix.outputs.cells }}

--- a/docs/development/prod-cut-runbook.md
+++ b/docs/development/prod-cut-runbook.md
@@ -1,0 +1,134 @@
+# Production Substrate Cut Runbook
+
+Mechanical procedure for cutting a CalVer release of the mat-vis substrate to
+`gerchowl/mat-vis` (the production HF dataset).
+
+## Pre-conditions (mat-vis#345 preflight, enforced at workflow level)
+
+The `bake.yml` workflow refuses any `--allow-prod=true` dispatch unless three
+gates pass. Each is independent and the operator gets a structured failure
+message pointing at the specific blocker.
+
+### 1. tst-prior gate
+
+The release-tag must already exist on `gerchowl/mat-vis-tst`. The check is a
+single HEAD on the manifest URL.
+
+> "ALWAYS E2E on tst before prod" made mechanical at the workflow boundary,
+> not human discipline.
+
+If it fails: dispatch a tst bake at the same release-tag first, wait for green,
+then re-dispatch the prod cut.
+
+```sh
+# Run the same line on tst (no --allow-prod needed):
+gh workflow run bake.yml \
+  -f line=v2026.04 \
+  -f release-tag=v2026.04.4 \
+  -f repo-id=gerchowl/mat-vis-tst
+```
+
+### 2. tier-coverage gate
+
+The tst manifest's `(source, tier)` cells at the release-tag must be a
+**superset** of the previous prod release's cells. Catches the matrix-coverage
+class of bug — e.g. matrix declares only `1k` but prod was shipping
+`128/256/512/1k/ktx2-512/ktx2-1k`.
+
+If it fails: either bake the missing tier(s) onto tst, OR mark them as
+deprecated (gate 3 below).
+
+### 3. Deprecation escape hatch (agent-resistant)
+
+When a tier is being intentionally retired, declare it explicitly:
+
+```sh
+gh workflow run bake.yml \
+  -f line=v2026.04 \
+  -f release-tag=v2026.04.4 \
+  -f repo-id=gerchowl/mat-vis \
+  -f allow-prod=true \
+  -f previous-prod-tag=v2026.04.3 \
+  -f deprecate-cells='[["gpuopen", "128"]]'
+```
+
+Each declared cell **must** have a corresponding open GH issue with the
+**`tier-deprecation-approved` label**. The workflow runs
+`scripts/verify_deprecation_issues.py` as the first step and fails the
+preflight if any declared cell lacks an approved issue.
+
+#### Why this is agent-resistant
+
+The `tier-deprecation-approved` label can only be applied or removed by repo
+maintainers (`triage` role or higher). Agents / contributor accounts can:
+
+- ✅ open issues, comment, edit text
+- ✅ open PRs that reference labels in code
+- ❌ apply protected labels at the repo level — that's enforced by GitHub's
+  permission model, not by code
+
+So the gate's signal is a permission boundary GitHub itself enforces. An
+agent literally cannot pass this check without the `triage` role, which bot
+accounts shouldn't have.
+
+#### Operator workflow for a tier deprecation
+
+1. Open a GH issue per `(source, tier)` cell being retired. Title must
+   contain both the source and tier strings (e.g. `Drop gpuopen 128 —
+   superseded by ktx2-1k for v2026.05`).
+2. A maintainer applies the `tier-deprecation-approved` label.
+3. Re-dispatch the prod cut with `deprecate-cells='[[…]]'` listing the cells.
+
+Step 2 is the human-in-the-loop signal that an automated agent (including
+`Claude Code`, an unauthorized bot, or a contributor accidentally writing a
+script) cannot fake.
+
+## Tst-first dress rehearsal (always)
+
+Even when the preflight gates pass, a tst bake at the release-tag is the
+only proof the substrate is shippable. The tst dataset is at
+`gerchowl/mat-vis-tst` and accepts unbounded bakes (`limit=0`).
+
+```sh
+gh workflow run bake.yml \
+  -f line=v2026.04 \
+  -f release-tag=v2026.04.4 \
+  -f repo-id=gerchowl/mat-vis-tst
+```
+
+After tst goes green, verify on HF directly:
+
+```sh
+curl -sL https://huggingface.co/datasets/gerchowl/mat-vis-tst/resolve/v2026.04.4/release-manifest.json | jq '.sources | keys'
+```
+
+## Prod cut
+
+Once the tst dispatch is green and verified:
+
+```sh
+gh workflow run bake.yml \
+  -f line=v2026.04 \
+  -f release-tag=v2026.04.4 \
+  -f repo-id=gerchowl/mat-vis \
+  -f allow-prod=true \
+  -f previous-prod-tag=v2026.04.3
+```
+
+The preflight job runs all three gates; if green, the bake matrix kicks off.
+
+## After the cut
+
+- `release-validate.yml` cron (06:30 UTC daily) compares the new tag against
+  the previous tag (#344 fix: catches `tier-missing-from-current` regressions
+  too).
+- Bump `clients/python/src/mat_vis_client/client.py:DEFAULT_TAG` to the new
+  release in a follow-up PR so tag-less clients pick it up.
+
+## References
+
+- mat-vis#345 — this preflight design + agent-resistance reasoning.
+- mat-vis#344 — `validate_release` tier-missing blind-spot fix; the post-cut
+  daily cron now catches the inverse failure mode.
+- mat-vis#306 — release-matrix as canonical (source × tier) source-of-truth.
+- ADR-0012 — per-file substrate; per-cell atomic HF commits.

--- a/scripts/verify_deprecation_issues.py
+++ b/scripts/verify_deprecation_issues.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Verify each declared deprecation has a maintainer-approved issue.
+
+mat-vis#345's agent-resistant escape hatch: a workflow step calls
+this script with the JSON list of ``(source, tier)`` cells the
+operator wants to mark as deprecated. The script queries the
+``MorePET/mat-vis`` issue tracker via ``gh`` for issues bearing
+the ``tier-deprecation-approved`` label and verifies one such issue
+matches each declared cell (by title containing the
+``(source, tier)`` cell text).
+
+Why this is agent-resistant:
+
+    The ``tier-deprecation-approved`` label can only be applied or
+    removed by repo maintainers (``triage`` role or higher).
+    Agents / contributor accounts can:
+      - open issues, edit text, comment
+      - open PRs that reference labels in code
+    But CANNOT apply protected labels at the repo level — that's
+    enforced by GitHub's permission model, not by this script.
+    So the gate's signal is a permission boundary GitHub itself
+    enforces, not something an agent can fake by writing code.
+
+Usage::
+
+    python scripts/verify_deprecation_issues.py '[["gpuopen", "128"]]'
+
+Exit codes:
+
+    0  every declared cell has a matching approved issue
+    1  one or more cells lack an approved issue (operator must
+       open one + get a maintainer to apply the label)
+    2  setup error (gh CLI missing, network failure, malformed input)
+
+Designed to run as a GH Actions workflow step (no extra deps; gh
+is preinstalled on hosted runners; ``GITHUB_TOKEN`` provides auth).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+
+LABEL = "tier-deprecation-approved"
+
+
+def _gh_issues_with_label(label: str) -> list[dict]:
+    """Query open issues with the given label. Returns list of
+    ``{number, title, author}`` dicts. Re-raises on gh failure."""
+    if shutil.which("gh") is None:
+        print("error: gh CLI not on PATH", file=sys.stderr)
+        sys.exit(2)
+    try:
+        out = subprocess.check_output(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--state",
+                "open",
+                "--label",
+                label,
+                "--limit",
+                "200",
+                "--json",
+                "number,title,author",
+            ],
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(f"error: gh issue list failed: {exc}", file=sys.stderr)
+        sys.exit(2)
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError as exc:
+        print(f"error: gh output malformed: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+
+def _matches(issue: dict, source: str, tier: str) -> bool:
+    """An issue matches a (source, tier) cell if its title contains
+    BOTH the source name and the tier in close proximity. Loose match
+    is intentional — operators write titles like
+    ``deprecate (gpuopen, 128) for v2026.05`` or
+    ``Drop gpuopen 128 — superseded by ktx2-1k`` and we don't want to
+    rigid-template them.
+
+    Hardening (P1 of #345): could require a structured body field or
+    a specific title prefix. Out of scope for the initial gate.
+    """
+    title = (issue.get("title") or "").lower()
+    return source.lower() in title and tier.lower() in title
+
+
+def _parse_cells(arg: str) -> list[tuple[str, str]]:
+    """Mirror ``_preflight.parse_deprecate_cells`` (kept here as a
+    standalone copy so this script has zero internal imports — runs
+    on a fresh checkout in any GH Actions runner).
+    """
+    if not arg.strip():
+        return []
+    parsed = json.loads(arg)
+    if not isinstance(parsed, list):
+        raise ValueError(f"input must be JSON list; got {type(parsed).__name__}")
+    out: list[tuple[str, str]] = []
+    for item in parsed:
+        if isinstance(item, list) and len(item) == 2:
+            out.append((str(item[0]), str(item[1])))
+        elif isinstance(item, dict) and "source" in item and "tier" in item:
+            out.append((str(item["source"]), str(item["tier"])))
+        else:
+            raise ValueError(f"unrecognised cell shape: {item!r}")
+    return out
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 1:
+        print(
+            "usage: verify_deprecation_issues.py '<json-list-of-cells>'",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        cells = _parse_cells(argv[0])
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"error parsing input: {exc}", file=sys.stderr)
+        return 2
+
+    if not cells:
+        print("no deprecations declared — preflight pass-through")
+        return 0
+
+    issues = _gh_issues_with_label(LABEL)
+    print(f"found {len(issues)} open issue(s) with label '{LABEL}'")
+
+    missing: list[tuple[str, str]] = []
+    for source, tier in cells:
+        if not any(_matches(i, source, tier) for i in issues):
+            missing.append((source, tier))
+
+    if missing:
+        print(
+            f"FAIL: {len(missing)} declared deprecation(s) lack a maintainer-approved issue.",
+            file=sys.stderr,
+        )
+        for source, tier in missing:
+            print(f"  - ({source}, {tier})", file=sys.stderr)
+        print(
+            f"\nOpen a GH issue for each — title must mention the source AND tier — and ask a "
+            f"maintainer to apply the '{LABEL}' label. The label is gated on the repo's "
+            "triage role, which contributor / agent accounts don't have.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"all {len(cells)} declared deprecation(s) have approved issues")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_dagger_function_names.py
+++ b/tests/test_dagger_function_names.py
@@ -118,6 +118,28 @@ class TestDaggerFunctionNames:
         assert "test_e2e" in function_python_names
         assert _snake_to_kebab("test_e2e") == "test-e-2-e"
 
+    def test_validate_prod_preflight_is_exposed_as_kebab(
+        self, function_python_names: list[str]
+    ) -> None:
+        """mat-vis#345: bake.yml's preflight job invokes
+        `dagger call validate-prod-preflight`. Pin the kebab name so a
+        future rename trips a unit test instead of breaking the prod
+        gate at dispatch time.
+        """
+        assert "validate_prod_preflight" in function_python_names, (
+            "validate_prod_preflight @function disappeared from "
+            ".dagger/src/mat_vis_ci/main.py — if it was renamed, update "
+            "bake.yml's `preflight` job step (mat-vis#345)"
+        )
+        assert _snake_to_kebab("validate_prod_preflight") == "validate-prod-preflight"
+
+    def test_workflow_bake_yml_uses_correct_kebab_name_for_preflight(self) -> None:
+        bake_yml = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "bake.yml"
+        text = bake_yml.read_text()
+        assert "validate-prod-preflight" in text, (
+            "bake.yml's preflight job must invoke `validate-prod-preflight` (mat-vis#345)"
+        )
+
     def test_validate_release_is_exposed_as_kebab(self, function_python_names: list[str]) -> None:
         """mat-vis#273: workflows invoke `dagger call validate-release`.
 

--- a/tests/test_prod_preflight.py
+++ b/tests/test_prod_preflight.py
@@ -1,0 +1,298 @@
+"""Tests for the prod-cut preflight helpers (mat-vis#345).
+
+The Dagger module lives outside the main package, so the helpers live
+in ``.dagger/src/mat_vis_ci/_preflight.py`` (a pure-Python module
+identical in style to ``_bake_cli.py``). We import it via file path
+so the suite runs under the default ``uv run pytest`` invocation
+without a Dagger engine.
+
+Coverage:
+
+- ``parse_deprecate_cells`` — JSON list / object form / edge cases
+- ``manifest_cells`` — extract cell set from v3 manifest
+- ``compute_missing_cells`` — set arithmetic for the parity gate
+- ``compose_violations`` — full preflight composition with mocked HF
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+PREFLIGHT_PATH = (
+    Path(__file__).resolve().parent.parent / ".dagger" / "src" / "mat_vis_ci" / "_preflight.py"
+)
+
+
+@pytest.fixture(scope="module")
+def preflight():
+    spec = importlib.util.spec_from_file_location("dagger_preflight", PREFLIGHT_PATH)
+    if spec is None or spec.loader is None:
+        pytest.skip("could not locate .dagger/src/mat_vis_ci/_preflight.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── parse_deprecate_cells ─────────────────────────────────────────
+
+
+class TestParseDeprecateCells:
+    def test_empty_string_yields_empty_set(self, preflight):
+        assert preflight.parse_deprecate_cells("") == set()
+
+    def test_empty_json_list_yields_empty_set(self, preflight):
+        assert preflight.parse_deprecate_cells("[]") == set()
+
+    def test_pair_form(self, preflight):
+        assert preflight.parse_deprecate_cells('[["gpuopen", "128"]]') == {("gpuopen", "128")}
+
+    def test_object_form(self, preflight):
+        assert preflight.parse_deprecate_cells('[{"source":"gpuopen","tier":"128"}]') == {
+            ("gpuopen", "128")
+        }
+
+    def test_mixed_forms(self, preflight):
+        out = preflight.parse_deprecate_cells(
+            '[["gpuopen","128"], {"source":"gpuopen","tier":"256"}]'
+        )
+        assert out == {("gpuopen", "128"), ("gpuopen", "256")}
+
+    def test_invalid_json_raises(self, preflight):
+        with pytest.raises(ValueError, match="valid JSON"):
+            preflight.parse_deprecate_cells("not json")
+
+    def test_non_list_raises(self, preflight):
+        with pytest.raises(ValueError, match="must be a JSON list"):
+            preflight.parse_deprecate_cells('{"source": "gpuopen"}')
+
+    def test_malformed_entry_raises(self, preflight):
+        with pytest.raises(ValueError, match="must be"):
+            preflight.parse_deprecate_cells('["just-a-string"]')
+
+
+# ── manifest_cells ────────────────────────────────────────────────
+
+
+def _v3_manifest(sources_tiers: dict[str, list[str]]) -> dict:
+    """Build a minimal v3 manifest: source → list of tiers."""
+    return {
+        "schema_version": 3,
+        "release_tag": "v2026.04.X",
+        "sources": {
+            src: {
+                "catalog": f"{src}.json",
+                "tiers": {tier: {"complete": True} for tier in tiers},
+            }
+            for src, tiers in sources_tiers.items()
+        },
+    }
+
+
+class TestManifestCells:
+    def test_single_source_single_tier(self, preflight):
+        m = _v3_manifest({"gpuopen": ["1k"]})
+        assert preflight.manifest_cells(m) == {("gpuopen", "1k")}
+
+    def test_multi_source_multi_tier(self, preflight):
+        m = _v3_manifest(
+            {
+                "gpuopen": ["128", "256", "512", "1k"],
+                "polyhaven": ["1k"],
+                "physicallybased": ["scalar"],
+            }
+        )
+        cells = preflight.manifest_cells(m)
+        assert ("gpuopen", "128") in cells
+        assert ("polyhaven", "1k") in cells
+        assert ("physicallybased", "scalar") in cells
+        assert len(cells) == 6
+
+    def test_empty_manifest_yields_empty(self, preflight):
+        assert preflight.manifest_cells({}) == set()
+        assert preflight.manifest_cells({"sources": {}}) == set()
+
+    def test_malformed_source_skipped(self, preflight):
+        m = {"sources": {"gpuopen": "bogus", "polyhaven": {"tiers": {"1k": {}}}}}
+        assert preflight.manifest_cells(m) == {("polyhaven", "1k")}
+
+
+# ── compute_missing_cells ─────────────────────────────────────────
+
+
+class TestComputeMissingCells:
+    def test_tst_superset_of_prev_no_missing(self, preflight):
+        tst = {("gpuopen", "1k"), ("gpuopen", "512")}
+        prev = {("gpuopen", "1k")}
+        assert preflight.compute_missing_cells(tst, prev, set()) == set()
+
+    def test_tst_subset_misses_diff(self, preflight):
+        tst = {("gpuopen", "1k")}
+        prev = {("gpuopen", "1k"), ("gpuopen", "512")}
+        assert preflight.compute_missing_cells(tst, prev, set()) == {("gpuopen", "512")}
+
+    def test_deprecated_cells_excluded_from_missing(self, preflight):
+        """Even when tst lacks a cell prev had, it's not a violation
+        if the operator declared the cell as deprecated."""
+        tst = {("gpuopen", "1k")}
+        prev = {("gpuopen", "1k"), ("gpuopen", "128")}
+        deprecated = {("gpuopen", "128")}
+        assert preflight.compute_missing_cells(tst, prev, deprecated) == set()
+
+    def test_only_some_deprecations_satisfy(self, preflight):
+        tst = {("gpuopen", "1k")}
+        prev = {("gpuopen", "1k"), ("gpuopen", "128"), ("gpuopen", "256")}
+        deprecated = {("gpuopen", "128")}
+        # 256 missing AND not deprecated → still a violation
+        assert preflight.compute_missing_cells(tst, prev, deprecated) == {("gpuopen", "256")}
+
+    def test_first_ever_release_no_prev(self, preflight):
+        """Empty prev → empty missing (free pass for first cut)."""
+        tst = {("gpuopen", "1k")}
+        assert preflight.compute_missing_cells(tst, set(), set()) == set()
+
+
+# ── compose_violations (end-to-end with mocked fetches) ──────────
+
+
+class TestComposeViolations:
+    """Patch ``fetch_release_manifest`` so we can simulate the full
+    composition without HF round-trips."""
+
+    def _patch_fetch(self, preflight, by_url: dict[tuple[str, str], dict | None]):
+        """Helper: monkeypatch fetch_release_manifest to return per
+        ``(repo_id, tag)`` answers."""
+
+        def fake(repo_id: str, tag: str) -> dict | None:
+            return by_url.get((repo_id, tag))
+
+        return patch.object(preflight, "fetch_release_manifest", side_effect=fake)
+
+    def test_clean_when_tst_supersets_prev_prod(self, preflight):
+        """Tst has 1k+512+128; prev prod had 1k+512+128. Clean."""
+        tst_m = _v3_manifest({"gpuopen": ["128", "512", "1k"]})
+        prev_m = _v3_manifest({"gpuopen": ["128", "512", "1k"]})
+        with self._patch_fetch(
+            preflight,
+            {
+                ("gerchowl/mat-vis-tst", "v2026.04.4"): tst_m,
+                ("gerchowl/mat-vis", "v2026.04.3"): prev_m,
+            },
+        ):
+            v = preflight.compose_violations(
+                tst_repo_id="gerchowl/mat-vis-tst",
+                prod_repo_id="gerchowl/mat-vis",
+                release_tag="v2026.04.4",
+                previous_prod_tag="v2026.04.3",
+                deprecated_cells=set(),
+            )
+        assert v == []
+
+    def test_violates_when_tst_lacks_release_tag(self, preflight):
+        """Gate (1) — tst doesn't have the release_tag we want to push."""
+        prev_m = _v3_manifest({"gpuopen": ["1k"]})
+        with self._patch_fetch(
+            preflight,
+            {
+                ("gerchowl/mat-vis-tst", "v2026.04.4"): None,  # 404
+                ("gerchowl/mat-vis", "v2026.04.3"): prev_m,
+            },
+        ):
+            v = preflight.compose_violations(
+                tst_repo_id="gerchowl/mat-vis-tst",
+                prod_repo_id="gerchowl/mat-vis",
+                release_tag="v2026.04.4",
+                previous_prod_tag="v2026.04.3",
+                deprecated_cells=set(),
+            )
+        assert len(v) == 1
+        assert v[0]["kind"] == "tst_missing_release_tag"
+        assert "ALWAYS E2E" in v[0]["remedy"]
+
+    def test_violates_when_tst_misses_prev_tier(self, preflight):
+        """Gate (2) — prev prod had 512, tst has only 1k. Violation."""
+        tst_m = _v3_manifest({"gpuopen": ["1k"]})
+        prev_m = _v3_manifest({"gpuopen": ["1k", "512"]})
+        with self._patch_fetch(
+            preflight,
+            {
+                ("gerchowl/mat-vis-tst", "v2026.04.4"): tst_m,
+                ("gerchowl/mat-vis", "v2026.04.3"): prev_m,
+            },
+        ):
+            v = preflight.compose_violations(
+                tst_repo_id="gerchowl/mat-vis-tst",
+                prod_repo_id="gerchowl/mat-vis",
+                release_tag="v2026.04.4",
+                previous_prod_tag="v2026.04.3",
+                deprecated_cells=set(),
+            )
+        assert len(v) == 1
+        assert v[0]["kind"] == "tier_coverage_regression"
+        assert v[0]["missing_cells"] == [("gpuopen", "512")]
+
+    def test_deprecation_unblocks_missing_tier(self, preflight):
+        """Gate (3) — operator declared (gpuopen, 512) as deprecated
+        with a maintainer-approved label. Preflight now passes."""
+        tst_m = _v3_manifest({"gpuopen": ["1k"]})
+        prev_m = _v3_manifest({"gpuopen": ["1k", "512"]})
+        with self._patch_fetch(
+            preflight,
+            {
+                ("gerchowl/mat-vis-tst", "v2026.04.4"): tst_m,
+                ("gerchowl/mat-vis", "v2026.04.3"): prev_m,
+            },
+        ):
+            v = preflight.compose_violations(
+                tst_repo_id="gerchowl/mat-vis-tst",
+                prod_repo_id="gerchowl/mat-vis",
+                release_tag="v2026.04.4",
+                previous_prod_tag="v2026.04.3",
+                deprecated_cells={("gpuopen", "512")},
+            )
+        assert v == []
+
+    def test_first_ever_prod_release_passes(self, preflight):
+        """previous_prod_tag points at a non-existent tag (404). The
+        parity check free-passes — first cut on a new line has nothing
+        to regress against."""
+        tst_m = _v3_manifest({"gpuopen": ["1k"]})
+        with self._patch_fetch(
+            preflight,
+            {
+                ("gerchowl/mat-vis-tst", "v2026.05.0"): tst_m,
+                ("gerchowl/mat-vis", "v2026.04.99"): None,  # doesn't exist
+            },
+        ):
+            v = preflight.compose_violations(
+                tst_repo_id="gerchowl/mat-vis-tst",
+                prod_repo_id="gerchowl/mat-vis",
+                release_tag="v2026.05.0",
+                previous_prod_tag="v2026.04.99",
+                deprecated_cells=set(),
+            )
+        assert v == []
+
+    def test_violation_short_circuits_after_tst_missing(self, preflight):
+        """If tst doesn't have the tag at all, don't bother computing
+        coverage diff — nothing to compare against."""
+        with self._patch_fetch(
+            preflight,
+            {
+                ("gerchowl/mat-vis-tst", "v9.9.9"): None,
+                ("gerchowl/mat-vis", "v0"): None,
+            },
+        ):
+            v = preflight.compose_violations(
+                tst_repo_id="gerchowl/mat-vis-tst",
+                prod_repo_id="gerchowl/mat-vis",
+                release_tag="v9.9.9",
+                previous_prod_tag="v0",
+                deprecated_cells=set(),
+            )
+        # Exactly one violation (the tst-missing one); coverage check skipped.
+        assert len(v) == 1
+        assert v[0]["kind"] == "tst_missing_release_tag"


### PR DESCRIPTION
## Summary

Closes #345. Three composable gates enforce the "ALWAYS E2E on tst before prod" rule mechanically at the workflow boundary, replacing human discipline. Runs as the new \`preflight\` job in \`bake.yml\` whenever \`inputs.allow-prod=true\`; tst dispatches skip cleanly.

## Gates

### Gate 1 — tst-prior

Same release-tag must already exist on \`gerchowl/mat-vis-tst\`. HEAD on the tst manifest. Catches "I forgot to E2E on tst" — exactly today's repeat failure mode.

### Gate 2 — tier-coverage parity

Tst's \`(source, tier)\` cells at the release-tag must be a **superset** of previous prod's cells, modulo explicit deprecations. Catches the matrix-coverage bug class surfaced by today's #306 scoping: production v2026.04.2 ships 6 tiers/source from bake+derive+ktx2; the matrix declares only 1k. Without this, a future cut from a narrow matrix would silently drop 5/6 of the tiers prod consumers depend on.

### Gate 3 — agent-resistant deprecation escape hatch

\`scripts/verify_deprecation_issues.py\` (workflow step) verifies each cell in the dispatch's \`deprecate-cells\` JSON list has an open GH issue bearing the **\`tier-deprecation-approved\`** label, with a title containing the (source, tier) pair.

**Why agent-resistant**: the label permission is gated on the repo's \`triage\` role at GitHub's level. An agent / contributor account literally cannot apply it without that role. The gate's signal is a permission boundary GitHub itself enforces — not something an agent can fake by writing code, opening a PR, or invoking \`gh\`.

## Implementation

Per the established CI/CD pattern (#306, #273): pure-Python helpers + thin Dagger wrapper + minimal workflow YAML.

- \`.dagger/src/mat_vis_ci/_preflight.py\` — pure helpers (mirrors \`_bake_cli.py\`; testable without Dagger SDK)
- \`scripts/verify_deprecation_issues.py\` — workflow-step script with zero internal imports
- \`validate_prod_preflight\` Dagger function (kebab: \`validate-prod-preflight\`)
- New \`preflight\` job in \`bake.yml\` gated on \`inputs.allow-prod\`; plan + bake jobs gain \`needs: preflight\` with \`always() && (success || skipped)\` so tst dispatches pass through unchanged
- 2 new workflow inputs: \`previous-prod-tag\`, \`deprecate-cells\`
- \`docs/development/prod-cut-runbook.md\` documents operator workflow + the agent-resistance reasoning

## Tests

- 24 tests in \`test_prod_preflight.py\`: parse_deprecate_cells / manifest_cells / compute_missing_cells / compose_violations end-to-end (tst-missing, tier-coverage-violation, deprecation unblocks, first-ever-prod free-pass)
- 2 new function-name pins in \`test_dagger_function_names.py\` (kebab CLI contract)
- 41/41 dagger-name + preflight tests green; full client suite unaffected

## References

- mat-vis#345 (closed)
- mat-vis#344 / #347 (complementary tier-missing fix on the post-cut validate gate)
- mat-vis#306 (matrix coverage — the architectural gap this gate covers when the matrix isn't yet complete)