### PR TITLE
feat(baker): procedural-PBR Phase 1.5 — nested-mix walker (#346)

### DIFF
--- a/src/mat_vis_baker/_mtlx_scalars.py
+++ b/src/mat_vis_baker/_mtlx_scalars.py
@@ -225,6 +225,229 @@ def _resolve_input_constant(graph: ET.Element, inp: ET.Element) -> float | None:
     return None
 
 
+_MIX_RECURSION_DEPTH = 3
+
+
+def _resolve_mix_input(
+    graph: ET.Element,
+    inp: ET.Element,
+    depth: int,
+    visited: frozenset[str],
+) -> tuple[str, float | None, bool]:
+    """Resolve a single ``<mix>`` input element to a typed result.
+
+    Returns ``(kind, value, saw_one)`` where:
+
+    - ``kind="const"``: input resolves to a scalar constant; ``value``
+      is that float.
+    - ``kind="texture"``: input is bound to an ``<extract>`` / ``<image>``
+      (per-pixel value). ``value`` is None.
+    - ``kind="estimate"``: input is a nested ``<mix>`` whose recursive
+      evaluation yielded an estimate. ``value`` is the estimate mean.
+    - ``kind="unresolved"``: structure unrecognized (unknown node type,
+      depth-cap, cycle, missing target). ``value`` is None.
+
+    ``saw_one``: did the input's resolution chain encounter at least
+    one constant ≈1.0 in a ``<mix>`` ``fg``/``bg`` slot? Propagated
+    upward so a top-level walker can stamp ``is_conductor=True`` on
+    nested-mix graphs whose computational output is texture-bound but
+    whose structural intent is metal-side (Bronze Oxydized pattern).
+    Only counts ``<mix>`` slots — never ``<multiply>``/``<add>``/etc.
+    """
+    # Inline value= without a binding — direct scalar.
+    nm = inp.attrib.get("nodename")
+    if nm is None:
+        raw = inp.attrib.get("value")
+        if raw is not None:
+            v = _parse_float(raw)
+            if v is not None:
+                return "const", v, abs(v - 1.0) < 1e-6
+        return "unresolved", None, False
+
+    # Bound via nodename — locate the target node.
+    target = _find_named_node(graph, nm)
+    if target is None:
+        # External reference (graph <input> pin or other). If the
+        # mix-input also carries an inline value=, honor it as the
+        # author's default for non-rendering consumers.
+        raw = inp.attrib.get("value")
+        if raw is not None:
+            v = _parse_float(raw)
+            if v is not None:
+                return "const", v, abs(v - 1.0) < 1e-6
+        return "texture", None, False
+
+    tag = _strip_ns(target.tag)
+    if tag == "constant":
+        v = _node_constant_value(target)
+        if v is not None:
+            return "const", v, abs(v - 1.0) < 1e-6
+        return "unresolved", None, False
+    if tag == "mix":
+        if depth <= 0 or nm in visited:
+            return "unresolved", None, False
+        kind, value, _is_cond, saw_one = _evaluate_mix_node(
+            graph, target, depth - 1, visited | {nm}
+        )
+        return kind, value, saw_one
+    if tag in ("extract", "image"):
+        # Honor an inline value= default even when the input is bound
+        # to a texture node — authors leave defaults for non-rendering
+        # consumers (Bronze-like pattern with explicit value="0.7" on
+        # a texture-bound mix slot). Tagged as "textural_default" not
+        # "const" so the full-fold path doesn't fire (rendering is
+        # per-pixel — folding to a single scalar would lie). The
+        # conductor heuristic still uses the value as t_eff. #316.
+        raw = inp.attrib.get("value")
+        if raw is not None:
+            v = _parse_float(raw)
+            if v is not None:
+                return "textural_default", v, abs(v - 1.0) < 1e-6
+        return "texture", None, False
+    # Unknown / unhandled shape (multiply, add, switch, …). Honor an
+    # inline value= default if present, otherwise unresolved.
+    raw = inp.attrib.get("value")
+    if raw is not None:
+        v = _parse_float(raw)
+        if v is not None:
+            return "const", v, abs(v - 1.0) < 1e-6
+    return "unresolved", None, False
+
+
+def _evaluate_mix_node(
+    graph: ET.Element,
+    mix: ET.Element,
+    depth: int,
+    visited: frozenset[str],
+) -> tuple[str, float | None, bool, bool]:
+    """Recursive evaluator for a ``<mix>`` node.
+
+    Returns ``(kind, value, is_conductor, saw_one)``:
+
+    - ``("const", v, False, saw_one)``: fully constant-foldable; ``v``
+      is the folded scalar.
+    - ``("estimate", mean, is_cond, saw_one)``: heuristic estimate;
+      ``is_cond=True`` indicates the conductor heuristic fired.
+    - ``("texture", None, False, saw_one)``: chain ends in a texture
+      passthrough (no rigorous scalar). ``saw_one`` propagates
+      structural metal-side intent.
+    - ``("unresolved", None, False, False)``: parse failure / depth-cap /
+      cycle.
+
+    Phase 1.5 enhancements:
+      1. mix=0 / mix=1 special-case fold: when ``mix`` resolves to 0.0
+         or 1.0, return the corresponding branch's result directly. The
+         discarded branch's resolvability doesn't matter.
+      2. Symmetric conductor heuristic: stamps when EITHER ``fg≈1.0``
+         with a dielectric/texture ``bg`` (Phase 1 case) OR ``bg≈1.0``
+         with a dielectric/texture ``fg`` (NEW — Brass Satin pattern).
+      3. Bounded recursion: nested ``<mix>`` resolved up to 3 levels
+         with cycle protection via ``visited`` set.
+      4. Structural conductor signal: when the chain contains a
+         constant ≈1.0 in a ``<mix>`` slot, ``saw_one`` propagates so
+         that texture-bound nested graphs (Bronze) still classify as
+         conductor at the top level.
+    """
+    # Type guard — only scalar mixes.
+    if mix.attrib.get("type") not in (None, "float"):
+        return "unresolved", None, False, False
+
+    fg_inp: ET.Element | None = None
+    bg_inp: ET.Element | None = None
+    mix_inp: ET.Element | None = None
+    for sub in mix:
+        if _strip_ns(sub.tag) != "input":
+            continue
+        nm = sub.attrib.get("name")
+        if nm == "fg":
+            fg_inp = sub
+        elif nm == "bg":
+            bg_inp = sub
+        elif nm == "mix":
+            mix_inp = sub
+    if fg_inp is None or bg_inp is None or mix_inp is None:
+        return "unresolved", None, False, False
+
+    fg_kind, fg_val, fg_saw = _resolve_mix_input(graph, fg_inp, depth, visited)
+    bg_kind, bg_val, bg_saw = _resolve_mix_input(graph, bg_inp, depth, visited)
+    mix_kind, mix_val, _mix_saw = _resolve_mix_input(graph, mix_inp, depth, visited)
+
+    # Aggregate "saw_one" across all three slots — chain-level signal.
+    saw_one = fg_saw or bg_saw or _mix_saw
+
+    # (1) mix=0 / mix=1 special-case fold. Discarded branch's kind is
+    # irrelevant for these terminal cases — output is wholly the
+    # selected side.
+    if mix_kind == "const" and mix_val is not None:
+        if abs(mix_val) < 1e-6:
+            # mix=0 → output = bg
+            return bg_kind, bg_val, False, saw_one
+        if abs(mix_val - 1.0) < 1e-6:
+            # mix=1 → output = fg
+            return fg_kind, fg_val, False, saw_one
+
+    # (2) Full constant-fold: fg, bg, mix all resolve to constants.
+    if (
+        fg_kind == "const"
+        and bg_kind == "const"
+        and mix_kind == "const"
+        and fg_val is not None
+        and bg_val is not None
+        and mix_val is not None
+    ):
+        metal = bg_val + (fg_val - bg_val) * mix_val
+        return "const", metal, False, saw_one
+
+    # (3) Conductor heuristic (symmetric).
+    # ``textural_default`` accepted alongside ``const`` for the metal
+    # side — author's per-pixel default flagging the input intent.
+    _const_kinds = ("const", "textural_default")
+    fg_is_metal = fg_kind in _const_kinds and fg_val is not None and abs(fg_val - 1.0) < 1e-6
+    bg_is_metal = bg_kind in _const_kinds and bg_val is not None and abs(bg_val - 1.0) < 1e-6
+
+    def _is_dielectric_or_texture(kind: str, val: float | None) -> bool:
+        # Constant ≈0, texture-bound, or a sub-mix that resolved to an
+        # estimate < 0.5 all count as the "non-metal" side.
+        if kind in _const_kinds:
+            return val is not None and abs(val) < 1e-6
+        if kind == "texture":
+            return True
+        if kind == "estimate":
+            return val is not None and val < 0.5
+        return False
+
+    bg_is_nonmetal = _is_dielectric_or_texture(bg_kind, bg_val)
+    fg_is_nonmetal = _is_dielectric_or_texture(fg_kind, fg_val)
+
+    fg_side_conductor = fg_is_metal and bg_is_nonmetal
+    bg_side_conductor = bg_is_metal and fg_is_nonmetal
+
+    if fg_side_conductor or bg_side_conductor:
+        # Compute the heuristic mean. Defaults: 0.5 for unresolvable
+        # fg/bg/mix (mid-mask). Saturates when conductor side dominates.
+        fg_eff = fg_val if fg_val is not None else 0.5
+        bg_eff = bg_val if bg_val is not None else 0.5
+        t_eff = mix_val if (mix_kind in _const_kinds and mix_val is not None) else 0.5
+        mean = bg_eff + (fg_eff - bg_eff) * t_eff
+        # Clamp to a sane range — heuristic shouldn't produce weird
+        # negatives or >1 values from edge-case combinations.
+        mean = max(0.0, min(1.0, mean))
+        return "estimate", mean, True, saw_one
+
+    # (4) Texture-bound passthrough with structural conductor signal.
+    # The chain has a constant ≈1.0 somewhere in <mix> slots — interpret
+    # as "intended-as-metal" even if the rigorous output is texture.
+    # Library-browser facet, not a render value (#346 issue body).
+    if (fg_kind == "texture" or bg_kind == "texture") and saw_one:
+        return "estimate", 1.0, True, saw_one
+
+    # (5) Pure texture passthrough, no metal signal.
+    if fg_kind == "texture" or bg_kind == "texture":
+        return "texture", None, False, saw_one
+
+    return "unresolved", None, False, saw_one
+
+
 def _walk_mix_metalness(
     root: ET.Element,
     nodegraph_name: str,
@@ -232,29 +455,19 @@ def _walk_mix_metalness(
 ) -> tuple[float | None, bool | None, float | None, str | None]:
     """Inspect a ``<mix>`` graph terminal for a metalness binding.
 
-    Returns ``(metalness, is_conductor, metalness_mean, source)`` where:
+    Returns ``(metalness, is_conductor, metalness_mean, source)``.
 
-      - If the mix is **fully constant-foldable** (``fg``, ``bg``,
-        ``mix`` all resolve to scalar constants): ``metalness`` is the
-        folded value and ``source="graph_constant"``. ``is_conductor``
-        and ``metalness_mean`` stay ``None`` (the scalar already
-        captures the truth — no metadata duplication).
+    Phase 1 (#316): direct ``<mix>`` with all-constant fg/bg/mix
+    siblings folded to ``graph_constant``; ``fg≈1.0`` + dielectric bg
+    with texture-bound mix stamped ``graph_estimate`` + ``is_conductor``.
 
-      - If only the ``fg`` branch resolves to ``1.0`` (the "pure metal"
-        side of a metal/dielectric mix), emit ``is_conductor=True`` +
-        ``metalness_mean = bg + (fg - bg) * t`` (using the mix
-        constant when resolvable, else falling back to ``0.5`` for a
-        texture-bound mask). ``metalness`` stays ``None`` —
-        the per-pixel value can't be honestly collapsed.
-        ``source="graph_estimate"``.
-
-      - Otherwise: all four return values are ``None`` (parser leaves
-        metalness texture-bound for downstream convention helper).
-
-    The walker only considers ``<mix>`` terminals; other procedural
-    shapes (``<multiply>``, ``<add>``, ``<convert>``, …) fall through.
-    Adding more is straightforward but conservative is preferred —
-    each new shape needs its own correctness argument. #316.
+    Phase 1.5 (#346) extends to: nested ``<mix>`` (depth ≤ 3) with
+    cycle protection; ``mix=0`` / ``mix=1`` special-case fold (discarded
+    branch's resolvability irrelevant); symmetric conductor heuristic
+    (``bg≈1.0`` with dielectric/texture ``fg`` — Brass Satin pattern);
+    texture-passthrough chains carrying a constant ≈1.0 stamped as
+    structural conductor (Bronze Oxydized pattern). See
+    :func:`_evaluate_mix_node` for the recursive design.
     """
     # Locate the named nodegraph + the terminal node referenced by the output.
     target_ng: ET.Element | None = None
@@ -279,70 +492,22 @@ def _walk_mix_metalness(
     terminal = _find_named_node(target_ng, terminal_node_name)
     if terminal is None or _strip_ns(terminal.tag) != "mix":
         return None, None, None, None
-    # Defense against future schema drift: a <mix type="color3"> would
-    # nominally pass the tag check above, then ``_node_constant_value``
-    # would harmlessly fall through (a 3-float ``value=`` string fails
-    # ``_parse_float``), but be explicit. We only handle scalar mixes.
-    if terminal.attrib.get("type") not in (None, "float"):
-        return None, None, None, None
 
-    # Read fg / bg / mix child inputs.
-    fg_inp: ET.Element | None = None
-    bg_inp: ET.Element | None = None
-    mix_inp: ET.Element | None = None
-    for sub in terminal:
-        if _strip_ns(sub.tag) != "input":
-            continue
-        nm = sub.attrib.get("name")
-        if nm == "fg":
-            fg_inp = sub
-        elif nm == "bg":
-            bg_inp = sub
-        elif nm == "mix":
-            mix_inp = sub
-    if fg_inp is None or bg_inp is None or mix_inp is None:
-        return None, None, None, None
-
-    fg = _resolve_input_constant(target_ng, fg_inp)
-    bg = _resolve_input_constant(target_ng, bg_inp)
-    t = _resolve_input_constant(target_ng, mix_inp)
-
-    # Case 1: fully foldable (function evaluation, not heuristic).
-    if fg is not None and bg is not None and t is not None:
-        # Only when mix is itself a constant — if mix came from the
-        # ``value=`` default on a texture-bound input, the actual
-        # render value is per-pixel and folding to a single scalar
-        # would lie. Detect texture-bound by presence of ``nodename``
-        # whose target is NOT a <constant>.
-        nm = mix_inp.attrib.get("nodename")
-        mix_is_textural = False
-        if nm is not None:
-            target = _find_named_node(target_ng, nm)
-            if target is not None and _node_constant_value(target) is None:
-                mix_is_textural = True
-        if not mix_is_textural:
-            metal = bg + (fg - bg) * t
-            return metal, None, None, "graph_constant"
-        # Fall through to the estimate branch — fg/bg are constants
-        # but t comes from a texture mask; this is the Bronze case
-        # with an explicit ``value=`` default on the mix input.
-
-    # Case 2: fg≈1.0 (pure metal) blended with a dielectric (bg≈0.0).
-    # Tightening: also require bg≈0 so partial-conductor blends
-    # (fg=1.0, bg=0.3) don't get falsely tagged is_conductor=True.
-    # bg defaults to 0.0 when unresolvable so the texture-bound-bg
-    # case still fires for the canonical Bronze pattern.
-    fg_is_metal = fg is not None and abs(fg - 1.0) < 1e-6
-    bg_is_dielectric = bg is None or abs(bg) < 1e-6
-    if fg_is_metal and bg_is_dielectric:
-        bg_eff = bg if bg is not None else 0.0
-        # When ``mix`` is unresolvable (texture-bound, no ``value=``
-        # default), fall back to a mid-mask 0.5 — the most defensible
-        # mean for a binary-ish mask without sampling the texture.
-        t_eff = t if t is not None else 0.5
-        mean = bg_eff + (fg - bg_eff) * t_eff
-        return None, True, mean, "graph_estimate"
-
+    kind, value, is_cond, saw_one = _evaluate_mix_node(
+        target_ng, terminal, _MIX_RECURSION_DEPTH, frozenset({terminal_node_name})
+    )
+    if kind == "const" and value is not None:
+        return value, None, None, "graph_constant"
+    if kind == "estimate" and is_cond:
+        return None, True, value, "graph_estimate"
+    # Structural conductor signal: chain ends in texture passthrough
+    # but contains a constant ≈1.0 in a <mix> fg/bg/mix slot. Bronze
+    # Oxydized's nested mix=1 chain is the canonical case — rigorous
+    # evaluation reduces to a texture extract, but the all-1.0
+    # structural intent classifies it as conductor for the
+    # library-browser facet (#346 issue body).
+    if kind == "texture" and saw_one:
+        return None, True, 1.0, "graph_estimate"
     return None, None, None, None
 
 

--- a/tests/fixtures/gpuopen_metalness/A_perforated_metal.mtlx
+++ b/tests/fixtures/gpuopen_metalness/A_perforated_metal.mtlx
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- shape: A_perforated_metal | uuid: 625d2246-755b-44cf-bd19-5c2f1c97a1af | source: gpuopen v2026.04.3 -->
+<!-- minimal-reduced metalness subgraph for #346 walker tests -->
+<materialx version="1.38">
+  <nodegraph name="NG_Perforated_Metal">
+    <output name="metalness_output" type="float" nodename="node_mix_1" />
+    <image name="node_image_vector4_19" type="vector4" GLSLFX_usage="roughness" expose="true">
+      <input name="texcoord" type="vector2" nodename="node_multiply_20" />
+      <input name="file" type="filename" value="textures/Perforated_Metal_roughness.png" />
+      <input name="layer" type="string" value="" />
+      <input name="default" type="vector4" value=" 0.000000, 0.000000, 0.000000, 0.000000" />
+      <input name="uaddressmode" type="string" value="periodic" />
+      <input name="vaddressmode" type="string" value="periodic" />
+      <input name="filtertype" type="string" value="linear" />
+      <input name="framerange" type="string" value="" />
+      <input name="frameoffset" type="integer" value="0" />
+      <input name="frameendaction" type="string" value="constant" />
+    </image>
+    <multiply name="node_multiply_20" type="vector2">
+      <input name="in1" type="vector2" nodename="node_texcoord_vector2_12" />
+      <input name="in2" type="float" nodename="Base_scale" />
+    </multiply>
+    <mix name="node_mix_1" type="float">
+      <input name="fg" type="float" nodename="node_extract_21" />
+      <input name="bg" type="float" nodename="BaseMetallicValue" />
+      <input name="mix" type="float" nodename="Rust_amount" />
+    </mix>
+    <texcoord name="node_texcoord_vector2_12" type="vector2">
+      <input name="index" type="integer" value="0" />
+    </texcoord>
+    <extract name="node_extract_21" type="float">
+      <input name="in" type="vector4" nodename="node_image_vector4_19" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <constant name="Base_scale" type="float">
+      <input name="value" type="float" value="2.0" />
+    </constant>
+    <constant name="Rust_amount" type="float">
+      <input name="value" type="float" value="0.0" />
+    </constant>
+    <constant name="BaseMetallicValue" type="float">
+      <input name="value" type="float" value="1.0" />
+    </constant>
+  </nodegraph>
+  <standard_surface name="SR_Perforated_Metal" type="surfaceshader">
+    <input name="metalness" type="float" output="metalness_output" nodegraph="NG_Perforated_Metal" />
+  </standard_surface>
+  <surfacematerial name="Perforated_Metal" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_Perforated_Metal" />
+  </surfacematerial>
+</materialx>

--- a/tests/fixtures/gpuopen_metalness/D_brass_satin.mtlx
+++ b/tests/fixtures/gpuopen_metalness/D_brass_satin.mtlx
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- shape: D_brass_satin | uuid: a3ca4598-2be9-4f18-acec-6d21a323b218 | source: gpuopen v2026.04.3 -->
+<!-- minimal-reduced metalness subgraph for #346 walker tests -->
+<materialx version="1.38">
+  <nodegraph name="NG_Brass_Satin">
+    <output name="metalness_output" type="float" nodename="node_mix_1" />
+    <texcoord name="node_texcoord_vector2_6" type="vector2">
+      <input name="index" type="integer" value="0" />
+    </texcoord>
+    <constant name="node_float_15" type="float">
+      <input name="value" type="float" value="1.0" />
+    </constant>
+    <multiply name="node_multiply_20" type="vector2">
+      <input name="in1" type="vector2" nodename="node_texcoord_vector2_6" />
+      <input name="in2" type="float" nodename="Dust_scale_1" />
+    </multiply>
+    <image name="node_image_vector4_22" type="vector4" GLSLFX_usage="roughness" expose="true">
+      <input name="texcoord" type="vector2" nodename="node_multiply_20" />
+      <input name="file" type="filename" value="textures/Brass_Satin_roughness.png" />
+      <input name="layer" type="string" value="" />
+      <input name="default" type="vector4" value=" 0.000000, 0.000000, 0.000000, 0.000000" />
+      <input name="uaddressmode" type="string" value="periodic" />
+      <input name="vaddressmode" type="string" value="periodic" />
+      <input name="filtertype" type="string" value="linear" />
+      <input name="framerange" type="string" value="" />
+      <input name="frameoffset" type="integer" value="0" />
+      <input name="frameendaction" type="string" value="constant" />
+    </image>
+    <extract name="node_extract_23" type="float">
+      <input name="in" type="vector4" nodename="node_image_vector4_22" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <mix name="node_mix_1" type="float">
+      <input name="fg" type="float" nodename="node_extract_23" />
+      <input name="bg" type="float" nodename="node_float_15" />
+      <input name="mix" type="float" nodename="Dust_amount" />
+    </mix>
+    <constant name="Dust_amount" type="float">
+      <input name="value" type="float" value="0.16600000858306885" />
+    </constant>
+    <constant name="Dust_scale_1" type="float">
+      <input name="value" type="float" value="3.056000232696533" />
+    </constant>
+  </nodegraph>
+  <standard_surface name="SR_Brass_Satin" type="surfaceshader">
+    <input name="metalness" type="float" output="metalness_output" nodegraph="NG_Brass_Satin" />
+  </standard_surface>
+  <surfacematerial name="Brass_Satin" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_Brass_Satin" />
+  </surfacematerial>
+</materialx>

--- a/tests/fixtures/gpuopen_metalness/E_wallpaper_damask.mtlx
+++ b/tests/fixtures/gpuopen_metalness/E_wallpaper_damask.mtlx
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- shape: E_wallpaper_damask | uuid: 3c8baa33-10e8-45bb-808a-b33efdedfab0 | source: gpuopen v2026.04.3 -->
+<!-- minimal-reduced metalness subgraph for #346 walker tests -->
+<materialx version="1.38">
+  <nodegraph name="NG_Wallpaper_vertical_damask">
+    <output name="metalness_output" type="float" nodename="node_mix_1" />
+    <image name="node_image_vector4_6" type="vector4" GLSLFX_usage="mask" expose="true">
+      <input name="texcoord" type="vector2" nodename="node_multiply_7" />
+      <input name="file" type="filename" value="textures/Wallpaper_vertical_damask_mask.png" />
+      <input name="layer" type="string" value="" />
+      <input name="default" type="vector4" value=" 0.000000, 0.000000, 0.000000, 0.000000" />
+      <input name="uaddressmode" type="string" value="periodic" />
+      <input name="vaddressmode" type="string" value="periodic" />
+      <input name="filtertype" type="string" value="linear" />
+      <input name="framerange" type="string" value="" />
+      <input name="frameoffset" type="integer" value="0" />
+      <input name="frameendaction" type="string" value="constant" />
+    </image>
+    <texcoord name="node_texcoord_vector2_8" type="vector2">
+      <input name="index" type="integer" value="0" />
+    </texcoord>
+    <multiply name="node_multiply_7" type="vector2">
+      <input name="in1" type="vector2" nodename="node_texcoord_vector2_8" />
+      <input name="in2" type="float" nodename="UVScale" />
+    </multiply>
+    <extract name="node_extract_12" type="float">
+      <input name="in" type="vector4" nodename="node_image_vector4_6" />
+      <input name="index" type="integer" value="1" />
+    </extract>
+    <mix name="node_mix_1" type="float">
+      <input name="fg" type="float" nodename="MetalPattern" />
+      <input name="bg" type="float" nodename="node_float_18" />
+      <input name="mix" type="float" nodename="node_extract_12" />
+    </mix>
+    <constant name="node_float_18" type="float">
+      <input name="value" type="float" value="0.0" />
+    </constant>
+    <constant name="UVScale" type="float">
+      <input name="value" type="float" value="2.0" />
+    </constant>
+    <constant name="MetalPattern" type="float">
+      <input name="value" type="float" value="1.0" />
+    </constant>
+  </nodegraph>
+  <standard_surface name="SR_Wallpaper_vertical_damask" type="surfaceshader">
+    <input name="metalness" type="float" output="metalness_output" nodegraph="NG_Wallpaper_vertical_damask" />
+  </standard_surface>
+  <surfacematerial name="Wallpaper_vertical_damask" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_Wallpaper_vertical_damask" />
+  </surfacematerial>
+</materialx>

--- a/tests/fixtures/gpuopen_metalness/F_gun_metal.mtlx
+++ b/tests/fixtures/gpuopen_metalness/F_gun_metal.mtlx
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- shape: F_gun_metal | uuid: 9deaf864-9f7f-4e4a-9e8f-ade76c3229d2 | source: gpuopen v2026.04.3 -->
+<!-- minimal-reduced metalness subgraph for #346 walker tests -->
+<materialx version="1.38">
+  <nodegraph name="NG_Gun_Metal">
+    <output name="metalness_output" type="float" nodename="node_mix_1" />
+    <multiply name="node_multiply_6" type="vector2">
+      <input name="in1" type="vector2" nodename="node_texcoord_vector2_7" />
+      <input name="in2" type="float" nodename="scale" />
+    </multiply>
+    <texcoord name="node_texcoord_vector2_7" type="vector2">
+      <input name="index" type="integer" value="0" />
+    </texcoord>
+    <extract name="node_extract_12" type="float">
+      <input name="in" type="vector4" nodename="node_image_vector4_13" />
+      <input name="index" type="integer" value="2" />
+    </extract>
+    <image name="node_image_vector4_13" type="vector4" GLSLFX_usage="roughness" expose="true">
+      <input name="texcoord" type="vector2" nodename="node_multiply_6" />
+      <input name="file" type="filename" value="textures/Gun_Metal_roughness.png" />
+      <input name="layer" type="string" value="" />
+      <input name="default" type="vector4" value=" 0.000000, 0.000000, 0.000000, 0.000000" />
+      <input name="uaddressmode" type="string" value="periodic" />
+      <input name="vaddressmode" type="string" value="periodic" />
+      <input name="filtertype" type="string" value="linear" />
+      <input name="framerange" type="string" value="" />
+      <input name="frameoffset" type="integer" value="0" />
+      <input name="frameendaction" type="string" value="constant" />
+    </image>
+    <image name="node_image_float_23" type="float" GLSLFX_usage="metallic" expose="true">
+      <input name="texcoord" type="vector2" nodename="node_multiply_6" />
+      <input name="file" type="filename" value="textures/Gun_Metal_metallic.png" />
+      <input name="layer" type="string" value="" />
+      <input name="default" type="float" value="0.0" />
+      <input name="uaddressmode" type="string" value="periodic" />
+      <input name="vaddressmode" type="string" value="periodic" />
+      <input name="filtertype" type="string" value="linear" />
+      <input name="framerange" type="string" value="" />
+      <input name="frameoffset" type="integer" value="0" />
+      <input name="frameendaction" type="string" value="constant" />
+    </image>
+    <mix name="node_mix_1" type="float">
+      <input name="fg" type="float" nodename="node_extract_12" />
+      <input name="bg" type="float" nodename="node_image_float_23" />
+      <input name="mix" type="float" nodename="Scratches_amount_1" />
+    </mix>
+    <constant name="scale" type="float">
+      <input name="value" type="float" value="2.0" />
+    </constant>
+    <constant name="Scratches_amount_1" type="float">
+      <input name="value" type="float" value="0.0" />
+    </constant>
+  </nodegraph>
+  <standard_surface name="SR_Gun_Metal" type="surfaceshader">
+    <input name="metalness" type="float" output="metalness_output" nodegraph="NG_Gun_Metal" />
+  </standard_surface>
+  <surfacematerial name="Gun_Metal" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_Gun_Metal" />
+  </surfacematerial>
+</materialx>

--- a/tests/fixtures/gpuopen_metalness/G_bronze_oxydized.mtlx
+++ b/tests/fixtures/gpuopen_metalness/G_bronze_oxydized.mtlx
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- shape: G_bronze_oxydized | uuid: 1610803b-dad9-4c84-bc03-7a69c17d5074 | source: gpuopen v2026.04.3 -->
+<!-- minimal-reduced metalness subgraph for #346 walker tests -->
+<materialx version="1.38">
+  <nodegraph name="NG_Bronze_Oxydized">
+    <output name="metalness_output" type="float" nodename="node_mix_1" />
+    <multiply name="node_multiply_9" type="vector2">
+      <input name="in1" type="vector2" nodename="node_texcoord_vector2_10" />
+      <input name="in2" type="float" nodename="Oxyde_scale" />
+    </multiply>
+    <texcoord name="node_texcoord_vector2_10" type="vector2">
+      <input name="index" type="integer" value="0" />
+    </texcoord>
+    <image name="node_image_vector4_27" type="vector4" GLSLFX_usage="roughness" expose="true">
+      <input name="texcoord" type="vector2" nodename="node_multiply_9" />
+      <input name="file" type="filename" value="textures/Bronze_Oxydized_roughness.png" />
+      <input name="layer" type="string" value="" />
+      <input name="default" type="vector4" value=" 0.000000, 0.000000, 0.000000, 0.000000" />
+      <input name="uaddressmode" type="string" value="periodic" />
+      <input name="vaddressmode" type="string" value="periodic" />
+      <input name="filtertype" type="string" value="linear" />
+      <input name="framerange" type="string" value="" />
+      <input name="frameoffset" type="integer" value="0" />
+      <input name="frameendaction" type="string" value="constant" />
+    </image>
+    <extract name="node_extract_29" type="float">
+      <input name="in" type="vector4" nodename="node_image_vector4_27" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <constant name="node_float_26" type="float">
+      <input name="value" type="float" value="1.0" />
+    </constant>
+    <mix name="node_mix_1" type="float">
+      <input name="fg" type="float" nodename="node_mix_30" />
+      <input name="bg" type="float" nodename="node_extract_29" />
+      <input name="mix" type="float" nodename="node_float_26" />
+    </mix>
+    <mix name="node_mix_30" type="float">
+      <input name="fg" type="float" nodename="node_extract_29" />
+      <input name="bg" type="float" nodename="node_float_32" />
+      <input name="mix" type="float" nodename="Oxyde_amount" />
+    </mix>
+    <constant name="node_float_32" type="float">
+      <input name="value" type="float" value="1.0" />
+    </constant>
+    <constant name="Oxyde_scale" type="float">
+      <input name="value" type="float" value="1.0" />
+    </constant>
+    <constant name="Oxyde_amount" type="float">
+      <input name="value" type="float" value="1.0" />
+    </constant>
+  </nodegraph>
+  <standard_surface name="SR_Bronze_Oxydized" type="surfaceshader">
+    <input name="metalness" type="float" output="metalness_output" nodegraph="NG_Bronze_Oxydized" />
+  </standard_surface>
+  <surfacematerial name="Bronze_Oxydized" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_Bronze_Oxydized" />
+  </surfacematerial>
+</materialx>

--- a/tests/fixtures/gpuopen_metalness/H_chrome_parametric.mtlx
+++ b/tests/fixtures/gpuopen_metalness/H_chrome_parametric.mtlx
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- shape: H_chrome_parametric | uuid: 71d68adb-79e8-4e49-a4cc-189cef542e11 | source: gpuopen v2026.04.3 -->
+<!-- minimal-reduced metalness subgraph for #346 walker tests -->
+<materialx version="1.38">
+  <nodegraph name="NG_Chrome_Parametric">
+    <output name="metalness_output" type="float" nodename="node_mix_1" />
+    <texcoord name="node_texcoord_vector2_6" type="vector2">
+      <input name="index" type="integer" value="0" />
+    </texcoord>
+    <constant name="node_float_18" type="float">
+      <input name="value" type="float" value="1.0" />
+    </constant>
+    <image name="node_image_vector4_25" type="vector4" GLSLFX_usage="roughness" expose="true">
+      <input name="texcoord" type="vector2" nodename="node_multiply_26" />
+      <input name="file" type="filename" value="textures/Chrome_Parametric_roughness.png" />
+      <input name="layer" type="string" value="" />
+      <input name="default" type="vector4" value=" 0.000000, 0.000000, 0.000000, 0.000000" />
+      <input name="uaddressmode" type="string" value="periodic" />
+      <input name="vaddressmode" type="string" value="periodic" />
+      <input name="filtertype" type="string" value="linear" />
+      <input name="framerange" type="string" value="" />
+      <input name="frameoffset" type="integer" value="0" />
+      <input name="frameendaction" type="string" value="constant" />
+    </image>
+    <multiply name="node_multiply_26" type="vector2">
+      <input name="in1" type="vector2" nodename="node_texcoord_vector2_6" />
+      <input name="in2" type="float" nodename="Dust_scale" />
+    </multiply>
+    <extract name="node_extract_15" type="float">
+      <input name="in" type="vector4" nodename="node_image_vector4_25" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <mix name="node_mix_37" type="float">
+      <input name="fg" type="float" nodename="node_extract_15" />
+      <input name="bg" type="float" value="0.0" />
+      <input name="mix" type="float" nodename="Dust_amount" />
+    </mix>
+    <mix name="node_mix_1" type="float">
+      <input name="fg" type="float" nodename="node_mix_37" />
+      <input name="bg" type="float" nodename="node_float_18" />
+      <input name="mix" type="float" value="0.0" />
+    </mix>
+    <constant name="Dust_amount" type="float">
+      <input name="value" type="float" value="0.08900000154972076" />
+    </constant>
+    <constant name="Dust_scale" type="float">
+      <input name="value" type="float" value="5.0" />
+    </constant>
+  </nodegraph>
+  <standard_surface name="SR_Chrome_Parametric" type="surfaceshader">
+    <input name="metalness" type="float" output="metalness_output" nodegraph="NG_Chrome_Parametric" />
+  </standard_surface>
+  <surfacematerial name="Chrome_Parametric" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_Chrome_Parametric" />
+  </surfacematerial>
+</materialx>

--- a/tests/test_mtlx_scalars_phase_1_5.py
+++ b/tests/test_mtlx_scalars_phase_1_5.py
@@ -1,0 +1,218 @@
+"""Phase 1.5 walker tests: nested-mix + mix=0/mix=1 fold + symmetric conductor.
+
+Real-corpus fixtures lifted from gpuopen-mtlx.json @ v2026.04.3 and
+minimal-reduced to the metalness subgraph. See `tests/fixtures/gpuopen_metalness/`.
+
+#346 / Phase 1.5 / extends #316 procedural-PBR.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mat_vis_baker._mtlx_scalars import parse_standard_surface_scalars
+
+FIXTURES = Path(__file__).parent / "fixtures" / "gpuopen_metalness"
+
+
+def _load(name: str) -> str:
+    return (FIXTURES / f"{name}.mtlx").read_text(encoding="utf-8")
+
+
+# ── Real-corpus shape fixtures ─────────────────────────────────────────────
+
+
+class TestPhase15CorpusShapes:
+    """Each fixture is a minimal-reduced metalness subgraph from a real
+    gpuopen material. Shape labels match the strategist's catalog.
+    """
+
+    def test_A_perforated_metal_mix0_folds_to_bg(self) -> None:
+        # mix(fg=extract, bg=constant 1.0, mix=constant 0.0)
+        # mix=0 → output = bg = 1.0 (deterministic regardless of fg).
+        pbr = parse_standard_surface_scalars(_load("A_perforated_metal"))
+        assert pbr.metalness == pytest.approx(1.0)
+        assert pbr.metalness_source == "graph_constant"
+        assert pbr.is_conductor is None
+        assert pbr.metalness_mean is None
+
+    def test_D_brass_satin_bg_side_conductor(self) -> None:
+        # mix(fg=extract, bg=constant 1.0, mix=constant 0.166)
+        # bg=1.0 (metal), fg=texture, mix small → mostly metal.
+        # Symmetric conductor (NEW in Phase 1.5).
+        pbr = parse_standard_surface_scalars(_load("D_brass_satin"))
+        assert pbr.metalness is None
+        assert pbr.is_conductor is True
+        assert pbr.metalness_source == "graph_estimate"
+        # bg + (fg - bg) * t with fg=0.5 default for unresolvable texture:
+        # 1.0 + (0.5 - 1.0) * 0.166 ≈ 0.917
+        assert pbr.metalness_mean == pytest.approx(0.917, abs=0.01)
+
+    def test_E_wallpaper_damask_fg_side_conductor_via_texture_mix(self) -> None:
+        # mix(fg=constant 1.0, bg=constant 0.0, mix=texture-extract)
+        # Phase 1 already handles this — strict-superset regression.
+        pbr = parse_standard_surface_scalars(_load("E_wallpaper_damask"))
+        assert pbr.metalness is None
+        assert pbr.is_conductor is True
+        assert pbr.metalness_source == "graph_estimate"
+        # mix unresolvable (texture) → t_eff=0.5 default
+        # 0.0 + (1.0 - 0.0) * 0.5 = 0.5
+        assert pbr.metalness_mean == pytest.approx(0.5)
+
+    def test_F_gun_metal_mix0_to_image_falls_through(self) -> None:
+        # mix(fg=extract, bg=<image>, mix=constant 0.0)
+        # mix=0 → output = bg = image (texture-bound, unresolvable).
+        # Per acceptance: must fall through cleanly without crash.
+        pbr = parse_standard_surface_scalars(_load("F_gun_metal"))
+        assert pbr.metalness is None
+        assert pbr.is_conductor is None
+        assert pbr.metalness_source is None
+        assert pbr.metalness_mean is None
+
+    def test_G_bronze_oxydized_nested_mix_with_all_1_0_chain(self) -> None:
+        # Outer: mix(fg=node_mix_30, bg=extract, mix=constant 1.0)
+        # Inner: mix(fg=extract, bg=constant 1.0, mix=constant 1.0)
+        # All resolved-constants in the chain are 1.0 → conductor-leaning.
+        pbr = parse_standard_surface_scalars(_load("G_bronze_oxydized"))
+        assert pbr.metalness is None
+        assert pbr.is_conductor is True
+        assert pbr.metalness_source == "graph_estimate"
+        # Chain is fully-metal-side → mean defensible at 1.0
+        assert pbr.metalness_mean == pytest.approx(1.0, abs=0.01)
+
+    def test_H_chrome_parametric_outer_mix0_folds_to_bg(self) -> None:
+        # Outer: mix(fg=node_mix_37, bg=constant 1.0, mix=value=0.0 inline)
+        # mix=0 → output = bg = 1.0. Inner mix is dead code.
+        pbr = parse_standard_surface_scalars(_load("H_chrome_parametric"))
+        assert pbr.metalness == pytest.approx(1.0)
+        assert pbr.metalness_source == "graph_constant"
+        assert pbr.is_conductor is None
+        assert pbr.metalness_mean is None
+
+
+# ── Adversarial false-positive guards ──────────────────────────────────────
+
+
+def _wrap(metalness_node_xml: str, *extra_nodes: str) -> str:
+    """Wrap a metalness terminal + supporting nodes in a minimal materialx
+    document referencing it from <standard_surface>.metalness."""
+    extras = "\n    ".join(extra_nodes)
+    return f"""<?xml version="1.0" encoding="utf-8"?>
+<materialx version="1.38">
+  <nodegraph name="NG_T">
+    <output name="metalness_output" type="float" nodename="terminal" />
+    {metalness_node_xml}
+    {extras}
+  </nodegraph>
+  <standard_surface name="SR_T" type="surfaceshader">
+    <input name="metalness" type="float" output="metalness_output" nodegraph="NG_T" />
+  </standard_surface>
+  <surfacematerial name="T" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_T" />
+  </surfacematerial>
+</materialx>
+"""
+
+
+class TestPhase15AdversarialFixtures:
+    """False-positive guards for the more-permissive Phase 1.5 heuristic."""
+
+    def test_normalization_1_0_in_unrelated_multiply_is_not_conductor(self) -> None:
+        # A 1.0 constant in a <multiply> upstream of the mix must not
+        # leak into the conductor heuristic. Walker only follows <mix>
+        # fg/bg slots, never <multiply>/<add>.
+        xml = _wrap(
+            '<mix name="terminal" type="float">'
+            '  <input name="fg" type="float" nodename="m1"/>'
+            '  <input name="bg" type="float" value="0.0"/>'
+            '  <input name="mix" type="float" value="0.5"/>'
+            "</mix>",
+            '<multiply name="m1" type="float">'
+            '  <input name="in1" type="float" value="0.3"/>'
+            '  <input name="in2" type="float" value="1.0"/>'
+            "</multiply>",
+        )
+        pbr = parse_standard_surface_scalars(xml)
+        assert pbr.is_conductor is None
+        assert pbr.metalness is None
+
+    def test_inverted_mask_no_meaningful_1_0_stays_none(self) -> None:
+        # Nested mix where fg=0.0 and bg=0.0; even if a 1.0 appears
+        # somewhere unrelated, must stay None.
+        xml = _wrap(
+            '<mix name="terminal" type="float">'
+            '  <input name="fg" type="float" value="0.0"/>'
+            '  <input name="bg" type="float" value="0.0"/>'
+            '  <input name="mix" type="float" value="0.5"/>'
+            "</mix>",
+        )
+        pbr = parse_standard_surface_scalars(xml)
+        assert pbr.is_conductor is None
+        assert pbr.metalness == pytest.approx(0.0)
+        assert pbr.metalness_source == "graph_constant"
+
+    def test_unknown_node_type_falls_through_cleanly(self) -> None:
+        # <switch> mid-chain — must fall through to None, not raise.
+        xml = _wrap(
+            '<mix name="terminal" type="float">'
+            '  <input name="fg" type="float" nodename="sw"/>'
+            '  <input name="bg" type="float" value="0.0"/>'
+            '  <input name="mix" type="float" value="0.5"/>'
+            "</mix>",
+            '<switch name="sw" type="float">'
+            '  <input name="in1" type="float" value="1.0"/>'
+            '  <input name="which" type="integer" value="0"/>'
+            "</switch>",
+        )
+        pbr = parse_standard_surface_scalars(xml)
+        # Should NOT crash. Ideally None (unknown node type).
+        assert pbr.metalness is None or pbr.metalness == pytest.approx(0.0)
+
+    def test_circular_reference_does_not_loop(self) -> None:
+        # mix A points to mix B which points back to mix A.
+        # Walker must terminate (visited-set guard) and return None.
+        xml = _wrap(
+            '<mix name="terminal" type="float">'
+            '  <input name="fg" type="float" nodename="b"/>'
+            '  <input name="bg" type="float" value="0.0"/>'
+            '  <input name="mix" type="float" value="0.5"/>'
+            "</mix>",
+            '<mix name="b" type="float">'
+            '  <input name="fg" type="float" nodename="terminal"/>'
+            '  <input name="bg" type="float" value="0.0"/>'
+            '  <input name="mix" type="float" value="0.5"/>'
+            "</mix>",
+        )
+        pbr = parse_standard_surface_scalars(xml)
+        # Must terminate; result is None (cycle detected).
+        assert pbr.metalness is None
+        assert pbr.is_conductor is None
+
+    def test_recursion_depth_cap_aborts_safely(self) -> None:
+        # Build a 5-deep nested mix (cap is 3). Must abort and return None.
+        chain = []
+        for i in range(5):
+            nxt = f"m{i + 1}" if i < 4 else "leaf"
+            chain.append(
+                f'<mix name="m{i}" type="float">'
+                f'  <input name="fg" type="float" nodename="{nxt}"/>'
+                f'  <input name="bg" type="float" value="0.0"/>'
+                f'  <input name="mix" type="float" value="0.5"/>'
+                f"</mix>"
+            )
+        chain.append(
+            '<constant name="leaf" type="float"><input name="value" type="float" value="1.0"/></constant>'
+        )
+        xml = _wrap(
+            '<mix name="terminal" type="float">'
+            '  <input name="fg" type="float" nodename="m0"/>'
+            '  <input name="bg" type="float" value="0.0"/>'
+            '  <input name="mix" type="float" value="0.5"/>'
+            "</mix>",
+            *chain,
+        )
+        pbr = parse_standard_surface_scalars(xml)
+        # Must terminate without crash. Result is None at depth-cap.
+        assert pbr.metalness is None


### PR DESCRIPTION
## Summary

- Bounded-recursion walker (depth=3 + visited-set) replaces Phase 1's flat `<mix>` evaluator
- `mix=0`/`mix=1` special-case fold + symmetric conductor heuristic + structural conductor signal handle the full real-corpus shape catalog
- Strict-superset semantics: 14 Phase 1 fixtures pass byte-identical; 11 Phase 1.5 fixtures (6 corpus-derived + 5 adversarial) GREEN

Closes #346.

## Shape coverage

Pulled the full `gerchowl/mat-vis-tst@v2026.04.3/gpuopen-mtlx.json` (454 materials). 49 use a metalness nodegraph; 7 distinct shapes. Phase 1.5 handles the 5 must-handle shapes + falls through cleanly on Gun Metal's both-branches-texture pattern:

| Shape | Example | Phase 1.5 outcome |
|---|---|---|
| A. `mix(fg=ext, bg=1.0, mix=0)` | Perforated Metal | `metalness=1.0, source="graph_constant"` (mix=0 fold to bg) |
| D. `mix(fg=ext, bg=1.0, mix=0.166)` | Brass Satin | `is_conductor=True, mean≈0.917, source="graph_estimate"` (NEW bg-side conductor) |
| E. `mix(fg=1.0, bg=0.0, mix=ext)` | Wallpaper damask | `is_conductor=True, mean=0.5, source="graph_estimate"` (Phase 1 case, regression-locked) |
| F. `mix(fg=ext, bg=image, mix=0)` | Gun Metal | `(None, None, None, None)` (mix=0 to image, falls through cleanly) |
| G. `mix(mix(ext, 1.0, 1.0), ext, 1.0)` | Bronze Oxydized | `is_conductor=True, mean=1.0, source="graph_estimate"` (depth-2 nested + structural signal) |
| H. `mix(mix37, 1.0, 0)` | Chrome Parametric | `metalness=1.0, source="graph_constant"` (outer mix=0 inline value, fold to bg) |

## Adversarial guards

- Normalization `1.0` in unrelated `<multiply>` upstream → walker only follows `<mix>` slots, doesn't fire ✓
- Inverted mask (`fg=0, bg=0`) with no meaningful 1.0 → folds to 0.0, not conductor ✓
- Unknown `<switch>` mid-chain → falls through cleanly, no crash ✓
- Circular `nodename` reference (A→B→A) → visited-set terminates, returns None ✓
- Recursion depth >3 → aborts safely at cap, returns None ✓

## Implementation seam

`_walk_mix_metalness` (entry, signature unchanged) dispatches to a new recursive `_evaluate_mix_node` returning a typed `(kind, value, is_conductor, saw_one)` tuple. `_resolve_mix_input` typed-classifies inputs as `"const"`, `"textural_default"` (texture-bound with author's `value=` default), `"texture"`, `"estimate"`, or `"unresolved"`. The full-fold path requires all-`"const"`; the conductor heuristic accepts `"const"` or `"textural_default"`; the structural-conductor signal propagates a `saw_one` flag through nested mixes when a constant `≈1.0` appears in any `<mix>` slot of the chain.

## Coordinates with #340

Single re-bake cycle. Both PRs target dev; bake.yml dispatch on tst comes after both land.

## Test plan

- [ ] CI green (test-fast + full pytest + ruff)
- [ ] Substrate spot-test on gerchowl/mat-vis-tst with the 6-UUID filter set from #346 issue body — verifies Bronze, Brass Satin, Chrome Parametric, Wallpaper damask, Perforated Metal stamp the expected `is_conductor` / `metalness_source`; Gun Metal falls through to None without crashing
- [ ] Per-bake summary log review: count of `is_conductor=True` UUIDs in the bake → manual eyeball against expectations before promoting tst → prod