### PR TITLE
feat(baker): release matrix extended to derive + ktx2 phases (closes #349)

### DIFF
--- a/docs/development/release-matrix-design.md
+++ b/docs/development/release-matrix-design.md
@@ -1,0 +1,91 @@
+# Release Matrix Design (mat-vis#349)
+
+## Status
+
+**Shipped**: B with DAG-cheap-later structure.
+
+## Problem
+
+Production `gerchowl/mat-vis@v2026.04.2` ships **6 tiers per textured source** (`128/256/512/1k/ktx2-512/ktx2-1k`) plus `scalar` for physicallybased — 14 cells across 3 production phases. Per #306 the canonical declaration was supposed to be the single source of truth, but it only covered the **bake** phase (4 cells). Derive + ktx2 happened via `derive.yml`'s runtime expansion logic with no canonical record.
+
+## Decision
+
+A 3-angle sub-agent spike (schema / data-modeling, workflow / CI ergonomics, future-proofing) returned three different verdicts:
+
+| Angle | Verdict | Core argument |
+|---|---|---|
+| Schema | **D** (DAG) | "Phase is a property of an *edge*, not a cell. `source_tier=None` is a sum type pretending to be a record." |
+| Workflow ergonomics | **A** (single matrix, phase as field) | One CLI, single `release.yml` umbrella collapses 3 dispatches to 1. |
+| Future-proofing | **B** (peer modules) | Cleanest stepping-stone to D. Per-phase dataclasses encode validity in the type system. |
+
+Synthesis: **B with DAG-cheap-later structure**. Three peer modules per phase, but each cell shaped like a DAG node (`produces: ArtifactID`, `inputs: tuple[ArtifactID, ...]`) so the eventual D migration is mechanical, not a rewrite.
+
+## Implementation
+
+```
+src/mat_vis_baker/
+├── _artifact.py                  ← shared ArtifactID (becomes DAG node ID later)
+├── release_matrix.py             ← bake phase (kept name for back-compat with #306)
+├── derive_matrix.py              ← derive phase (NEW)
+├── ktx2_matrix.py                ← ktx2 phase (NEW)
+└── release_registry.py           ← cross-phase composer + DAG validator (NEW)
+```
+
+### Per-phase modules
+
+Each phase has its own dataclass with phase-specific fields:
+
+- `release_matrix.Cell` — bake phase. `produces` (computed property) yields the `ArtifactID`. No `inputs` (bake fetches from upstream). Back-compat shape preserved for #306 callers.
+- `derive_matrix.DeriveCell` — derive phase. `produces: ArtifactID`, `inputs: tuple[ArtifactID, ...]`. Today `inputs` is always single-element; the tuple shape is multi-input ready for future content-addressed substrate or chained derives.
+- `ktx2_matrix.Ktx2Cell` — ktx2 phase. Same shape as derive but for transcode operations.
+
+### Cross-phase composer
+
+`release_registry.release_dag(line) -> ReleaseDAG` reads from all three peers and validates topology:
+
+- No two cells (across any phase) `produces` the same artifact.
+- Every `inputs` element is `produces` by some cell in the same release.
+- No cycles (today's matrix is 2-deep so this is trivially satisfied; the v2 expansion will have multi-input chains).
+
+`ReleaseDAG` exposes both per-phase tuples (workflow plan jobs filter to one phase via `cells_for_phase("derive")`) and a flat `derivations` tuple plus a `by_artifact` dict for graph traversal.
+
+### CLI
+
+`mat-vis-baker matrix list <line> [--phase=bake|derive|ktx2|all]` returns JSON. `--phase=bake` is the default for #306 back-compat. `--phase=all` emits the unified DAG view; consumers that care about edges read the new `inputs` field on each cell.
+
+## DAG-cheap-later property
+
+| Property | Today (B) | v2 D-migration | Cost |
+|---|---|---|---|
+| Stable artifact identity | `ArtifactID` | Same `ArtifactID` (DAG node ID) | Zero |
+| Explicit dependency edges | `inputs: tuple[ArtifactID, ...]` | Same `inputs` field | Zero |
+| Cross-phase validation | `release_registry.release_dag()` | Same validator promoted to primary | Zero |
+| Per-phase iteration | 3 modules + 3 helpers | `release_dag().cells_for_phase(phase)` | Already present |
+| `source_tier=None` smell | **Doesn't exist** — derive cells declare `inputs` explicitly | Same | N/A |
+
+The migration to D is "promote `release_registry` to primary; collapse 3 modules into a single declarations file with `Derivation` nodes" — sized at ~1 day given the structural prep here.
+
+## When to migrate to D
+
+When the per-phase split starts showing seams. Plausible triggers:
+
+- A 4th phase (e.g. `graph_bake` from #284) lands. Adding a 4th peer module is fine but a single declarations file with a `Phase` enum starts looking cleaner.
+- Multi-input derivations become routine (e.g. content-addressed substrate where a derived artifact reads multiple parents). The single-`source_tier` mental model breaks down; `inputs: tuple[ArtifactID, ...]` is already there but the per-phase split obscures it.
+- Per-cell metadata (`max_bytes`, `upstream_pin`, `signed`, etc.) becomes dense and the per-phase shapes diverge enough that a unified dataclass feels right.
+
+Until then B is sufficient and the cells already have the DAG shape, so the migration cost stays low.
+
+## What this unblocks
+
+- `derive.yml` migration off runtime `sources=all` expansion (sibling to #323's bake.yml migration). Plan job becomes `mat-vis-baker matrix list <line> --phase=derive` → JSON cells → matrix expansion. Tracked as P1 follow-up.
+- `validate_release.py` cross-phase coverage check ("substrate has every artifact the matrix declares") — reads `release_dag(line).all_artifacts()`. P1.
+- #345 prod-preflight tier-coverage gate becomes meaningfully comprehensive when the matrix is complete (today's gate compares prev-prod cells to tst cells; with a complete matrix it can also assert tst cells match the matrix declaration).
+
+## References
+
+- mat-vis#306 (canonical-declaration epic — extending it; current bake-only state preserved)
+- mat-vis#323 (bake.yml migration — derive.yml needs same surgery)
+- mat-vis#344 / #347 (post-cut validate gate; tier-missing fix)
+- mat-vis#345 / #348 (prod-preflight tier-parity)
+- mat-vis#284 (graph_bake / TextureBaker — natural 4th phase)
+- mat-vis#66 (manifest signing — phase-agnostic but easy under per-phase metadata)

--- a/src/mat_vis_baker/__main__.py
+++ b/src/mat_vis_baker/__main__.py
@@ -152,30 +152,82 @@ def cmd_pack_mtlx(args: argparse.Namespace) -> int:
 
 
 def cmd_matrix_list(args: argparse.Namespace) -> int:
-    """Print the canonical (source × tier) cells for a release line as JSON.
+    """Print the canonical cells for a release line as JSON.
 
-    Reads from ``mat_vis_baker.release_matrix`` (mat-vis#306). Output is
-    a single JSON object with ``line`` and ``cells`` keys; consumers
-    (Dagger, scripts) parse with ``json.loads``.
+    mat-vis#306: the bake matrix is the canonical (source × tier)
+    declaration of what a release line ships.
+
+    mat-vis#349: extends to derive + ktx2 phases. ``--phase`` selects:
+    ``bake`` (default; back-compat for #306 callers), ``derive``,
+    ``ktx2``, or ``all`` (the full DAG view).
+
+    Output JSON shape:
+
+        {"line": "v2026.04",
+         "phase": "bake",
+         "cells": [{"source": "ambientcg", "tier": "1k", "inputs": []}, ...]}
+
+    Bake cells have an empty ``inputs`` list; derive/ktx2 cells list
+    their source artifacts (see mat_vis_baker._artifact.ArtifactID).
+    Existing #306 consumers ignore the new ``inputs`` field — same
+    JSON object, additive new field.
     """
     import json
 
-    from mat_vis_baker.release_matrix import filter_cells, get_release
+    phase = getattr(args, "phase", "bake")
+
+    if phase == "bake":
+        from mat_vis_baker.release_matrix import filter_cells, get_release
+
+        try:
+            release = get_release(args.line)
+        except KeyError as exc:
+            log.error("matrix list: %s", exc)
+            return 2
+        cells = filter_cells(
+            release.cells,
+            source=args.filter_source or "",
+            tier=args.filter_tier or "",
+        )
+        payload = {
+            "line": release.line,
+            "phase": phase,
+            "cells": [{"source": c.source, "tier": c.tier, "inputs": []} for c in cells],
+        }
+        print(json.dumps(payload))
+        return 0
+
+    # Phase != bake → use the unified DAG view; filter by phase + source/tier.
+    from mat_vis_baker.release_registry import release_dag
 
     try:
-        release = get_release(args.line)
+        dag = release_dag(args.line)
     except KeyError as exc:
         log.error("matrix list: %s", exc)
         return 2
 
-    cells = filter_cells(
-        release.cells,
-        source=args.filter_source or "",
-        tier=args.filter_tier or "",
-    )
+    if phase == "all":
+        derivations = dag.derivations
+    else:
+        derivations = dag.cells_for_phase(phase)
+
+    if args.filter_source:
+        derivations = tuple(d for d in derivations if d.produces.source == args.filter_source)
+    if args.filter_tier:
+        derivations = tuple(d for d in derivations if d.produces.tier == args.filter_tier)
+
     payload = {
-        "line": release.line,
-        "cells": [{"source": c.source, "tier": c.tier} for c in cells],
+        "line": dag.line,
+        "phase": phase,
+        "cells": [
+            {
+                "source": d.produces.source,
+                "tier": d.produces.tier,
+                "phase": d.phase,
+                "inputs": [{"source": i.source, "tier": i.tier} for i in d.inputs],
+            }
+            for d in derivations
+        ],
     }
     print(json.dumps(payload))
     return 0
@@ -421,6 +473,17 @@ def main() -> int:
         "--filter-tier",
         default="",
         help="Restrict output to one tier (empty = all tiers)",
+    )
+    p_matrix_list.add_argument(
+        "--phase",
+        default="bake",
+        choices=["bake", "derive", "ktx2", "all"],
+        help=(
+            "Which phase to list (mat-vis#349). 'bake' is the default and "
+            "the back-compat behavior for #306 callers; 'derive' returns "
+            "PNG-resize cells; 'ktx2' returns transcode cells; 'all' returns "
+            "the unified DAG view across all phases."
+        ),
     )
 
     p_fetch = sub.add_parser("fetch", help="Fetch textures from upstream")

--- a/src/mat_vis_baker/_artifact.py
+++ b/src/mat_vis_baker/_artifact.py
@@ -1,0 +1,50 @@
+"""Shared ``ArtifactID`` — stable identity for a baked / derived / ktx2'd
+substrate artifact.
+
+Per mat-vis#349: each release-matrix cell ``produces`` an
+``ArtifactID``, and derive / ktx2 cells declare ``inputs`` (a tuple of
+ArtifactIDs they read from). Today the per-phase modules
+(``release_matrix.py`` for bake, ``derive_matrix.py``, ``ktx2_matrix.py``)
+each declare cells using this type; ``release_registry.release_dag()``
+composes them into a single DAG view that validates topology
+(no duplicate produces, every input is produced by some cell, no
+cycles).
+
+Why a shared identity type instead of per-phase ``(source, tier)``
+tuples: it lets the DAG migration (#349 v2 / Option D) be mechanical —
+``ArtifactID`` becomes the DAG node ID with zero schema change.
+
+Example::
+
+    aluminum_1k = ArtifactID(source="gpuopen", tier="1k")
+    aluminum_512 = ArtifactID(source="gpuopen", tier="512")
+    # derive cell: produces 512 from 1k
+    DeriveCell(produces=aluminum_512, inputs=(aluminum_1k,))
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class ArtifactID:
+    """Stable identity for a baked / derived substrate artifact.
+
+    ``source`` is one of ``mat_vis_baker.sources.KNOWN_SOURCES``.
+    ``tier`` is a member of ``mat_vis_baker.common.VALID_TIERS`` plus
+    the ``"scalar"`` sentinel for scalar-only sources, plus the
+    ``"ktx2-<tier>"`` shape for ktx2 artifacts (e.g. ``"ktx2-1k"``).
+
+    The class is frozen + slotted so cells can be set / dict-keyed and
+    the dataclass overhead is minimal. ``order=True`` so DAG views can
+    deterministically sort cells by `(source, tier)` for stable JSON
+    output.
+    """
+
+    source: str
+    tier: str
+
+    def __str__(self) -> str:
+        # Compact form for log + error messages: "gpuopen:1k"
+        return f"{self.source}:{self.tier}"

--- a/src/mat_vis_baker/derive_matrix.py
+++ b/src/mat_vis_baker/derive_matrix.py
@@ -1,0 +1,187 @@
+"""Canonical declaration of derive (PNG resize) cells per release line.
+
+Per mat-vis#349 (B with DAG-cheap-later structure): the derive phase
+declares cells that produce a smaller PNG tier from an existing PNG
+tier — locally via PIL/imageio resize, no upstream fetch. The peer
+to ``release_matrix.py`` (bake) and ``ktx2_matrix.py`` (ktx2 transcode);
+``release_registry.release_dag()`` composes all three into a single
+DAG view.
+
+Each ``DeriveCell`` carries:
+
+- ``produces``: the ``ArtifactID`` the cell writes to HF
+- ``inputs``: a tuple of source ``ArtifactID``s the resize reads from
+
+Validation: cross-phase invariants (every ``input`` is ``produces`` by
+some cell in the same release line, no cycles) are enforced by
+``release_registry.release_dag()`` — not duplicated here. Per-cell
+sanity (known source, known tier, no scalar sources) is enforced at
+import time below; mirrors ``release_matrix.py``'s validator.
+
+Why ``inputs`` is a tuple and not a single ``source_tier``: the v2 DAG
+migration (#349 P2 / Option D) uses multi-input derivations
+(e.g. content-addressed substrate where a derived artifact reads
+multiple parents). Today every derive cell has exactly one input;
+the tuple shape costs nothing and makes the DAG migration mechanical.
+
+Schema:
+
+    DeriveCell(produces, inputs)  — one PNG-resize derivation
+    Release(line, cells)          — the full set of derive cells
+
+The release line shape mirrors the bake matrix; production v2026.04
+declares the canonical ``{1k → 512, 1k → 256, 1k → 128}`` chain per
+textured source.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mat_vis_baker._artifact import ArtifactID
+from mat_vis_baker.common import VALID_TIERS
+from mat_vis_baker.sources import KNOWN_SOURCES, SCALAR_SOURCES, TEXTURED_SOURCES
+
+# Tier vocabulary that derive cells may reference. Excludes "scalar"
+# (scalar-only sources have no PNGs to resize) but includes every PNG
+# tier in VALID_TIERS.
+_VALID_DERIVE_TIERS: frozenset[str] = frozenset(VALID_TIERS)
+
+
+@dataclass(frozen=True, slots=True)
+class DeriveCell:
+    """One PNG-resize derivation cell.
+
+    Equality + hashing are structural by ``produces`` (each artifact
+    has exactly one producing cell — enforced by the cross-phase
+    validator in ``release_registry``). ``inputs`` may differ across
+    valid declarations of the same ``produces`` (e.g. derive 256 from
+    1k vs. from 512); the validator picks one canonical declaration.
+    """
+
+    produces: ArtifactID
+    inputs: tuple[ArtifactID, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class Release:
+    """The full set of derive cells that constitute a release line."""
+
+    line: str
+    cells: tuple[DeriveCell, ...]
+
+
+def _derive_chain(
+    source: str, source_tier: str, target_tiers: tuple[str, ...]
+) -> tuple[DeriveCell, ...]:
+    """Helper: generate ``len(target_tiers)`` cells all reading from
+    the same ``source_tier``.
+
+    Production today: every derive reads from 1k (the only baked tier
+    on textured sources). Future multi-tier sources will use a chain
+    pattern (1k → 512 → 256 → 128) — change this helper then.
+    """
+    src = ArtifactID(source=source, tier=source_tier)
+    return tuple(
+        DeriveCell(produces=ArtifactID(source=source, tier=tt), inputs=(src,))
+        for tt in target_tiers
+    )
+
+
+# Canonical declarations. ADD a new line as a new key; do NOT mutate
+# an existing line's cell shape after the first cut on it has shipped.
+_RELEASES: dict[str, Release] = {
+    "v2026.04": Release(
+        line="v2026.04",
+        cells=(
+            *_derive_chain("ambientcg", source_tier="1k", target_tiers=("512", "256", "128")),
+            *_derive_chain("polyhaven", source_tier="1k", target_tiers=("512", "256", "128")),
+            *_derive_chain("gpuopen", source_tier="1k", target_tiers=("512", "256", "128")),
+            # physicallybased is scalar-only — no derives.
+        ),
+    ),
+}
+
+
+def _validate_release(release: Release) -> None:
+    """Per-cell sanity check. Cross-phase invariants (input must be
+    produced by some cell in the line, no cycles) live in
+    ``release_registry.release_dag()`` — not duplicated here."""
+    seen: set[ArtifactID] = set()
+    for cell in release.cells:
+        if cell.produces in seen:
+            raise ValueError(f"release {release.line!r}: duplicate derive cell {cell.produces}")
+        seen.add(cell.produces)
+
+        # produces sanity
+        a = cell.produces
+        if a.source not in KNOWN_SOURCES:
+            raise ValueError(
+                f"release {release.line!r}: derive cell {a} references unknown "
+                f"source (known: {sorted(KNOWN_SOURCES)})"
+            )
+        if a.source in SCALAR_SOURCES:
+            raise ValueError(
+                f"release {release.line!r}: derive cell {a} — scalar-only "
+                f"source {a.source!r} has no PNGs to derive"
+            )
+        if a.source not in TEXTURED_SOURCES:
+            raise ValueError(
+                f"release {release.line!r}: derive cell {a} — source not in "
+                f"TEXTURED_SOURCES (known textured: {sorted(TEXTURED_SOURCES)})"
+            )
+        if a.tier not in _VALID_DERIVE_TIERS:
+            raise ValueError(
+                f"release {release.line!r}: derive cell {a} — tier not in "
+                f"VALID_TIERS (valid: {sorted(_VALID_DERIVE_TIERS)})"
+            )
+
+        # inputs sanity (per-cell only; cross-cell graph-validation in registry)
+        if not cell.inputs:
+            raise ValueError(
+                f"release {release.line!r}: derive cell {a} has empty inputs; "
+                "derive cells must declare at least one source artifact"
+            )
+        for inp in cell.inputs:
+            if inp.source != a.source:
+                raise ValueError(
+                    f"release {release.line!r}: derive cell {a} reads from "
+                    f"{inp} — derive cells must read from the same source "
+                    "(cross-source derivation is not supported)"
+                )
+            if inp == a:
+                raise ValueError(
+                    f"release {release.line!r}: derive cell {a} cannot read "
+                    f"from itself (self-loop in the derivation DAG)"
+                )
+
+
+# Validate at module import.
+for _r in _RELEASES.values():
+    _validate_release(_r)
+
+
+def known_lines() -> tuple[str, ...]:
+    return tuple(_RELEASES.keys())
+
+
+def get_release(line: str) -> Release:
+    """Return the canonical derive ``Release`` for a release line."""
+    if line not in _RELEASES:
+        raise KeyError(f"unknown release line {line!r}; known lines: {known_lines()}")
+    return _RELEASES[line]
+
+
+def filter_cells(
+    cells: tuple[DeriveCell, ...],
+    *,
+    source: str = "",
+    tier: str = "",
+) -> tuple[DeriveCell, ...]:
+    """Filter derive cells by produces.source / produces.tier."""
+    out = cells
+    if source:
+        out = tuple(c for c in out if c.produces.source == source)
+    if tier:
+        out = tuple(c for c in out if c.produces.tier == tier)
+    return out

--- a/src/mat_vis_baker/ktx2_matrix.py
+++ b/src/mat_vis_baker/ktx2_matrix.py
@@ -1,0 +1,171 @@
+"""Canonical declaration of ktx2 (transcode) cells per release line.
+
+Per mat-vis#349 (B with DAG-cheap-later structure): the ktx2 phase
+declares cells that produce a ``ktx2-<tier>`` artifact by toktx-
+transcoding an existing PNG tier on HF — locally, no upstream fetch.
+The peer to ``release_matrix.py`` (bake) and ``derive_matrix.py``
+(resize); ``release_registry.release_dag()`` composes all three.
+
+Each ``Ktx2Cell`` carries:
+
+- ``produces``: the ``ArtifactID`` (with tier prefix ``ktx2-``)
+- ``inputs``: a tuple with one source-tier PNG ``ArtifactID``
+
+Production today only ships ``ktx2-1k`` and ``ktx2-512`` per textured
+source. Adding ``ktx2-256`` or ``ktx2-128`` is a one-liner here when
+mobile clients ask for it.
+
+Validation: cross-phase invariants (the input PNG must be produced by
+SOME cell in the same release — bake or derive) are enforced by
+``release_registry.release_dag()``. Per-cell sanity is enforced at
+import time below.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mat_vis_baker._artifact import ArtifactID
+from mat_vis_baker.common import VALID_TIERS
+from mat_vis_baker.sources import KNOWN_SOURCES, SCALAR_SOURCES, TEXTURED_SOURCES
+
+# ktx2 tier shape: "ktx2-<png_tier>". The validator below enforces
+# that the suffix matches a real PNG tier in VALID_TIERS.
+KTX2_TIER_PREFIX = "ktx2-"
+
+
+def _ktx2_tier_for(png_tier: str) -> str:
+    """Map a PNG tier to its ktx2 tier name (e.g. ``"1k"`` → ``"ktx2-1k"``)."""
+    return f"{KTX2_TIER_PREFIX}{png_tier}"
+
+
+@dataclass(frozen=True, slots=True)
+class Ktx2Cell:
+    """One ktx2-transcode cell.
+
+    Equality + hashing structural by ``produces`` (one cell per ktx2
+    artifact in a release; cross-phase validator enforces uniqueness)."""
+
+    produces: ArtifactID
+    inputs: tuple[ArtifactID, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class Release:
+    """The full set of ktx2 cells that constitute a release line."""
+
+    line: str
+    cells: tuple[Ktx2Cell, ...]
+
+
+def _ktx2_for_source(source: str, png_source_tiers: tuple[str, ...]) -> tuple[Ktx2Cell, ...]:
+    """Helper: emit one Ktx2Cell per declared source PNG tier."""
+    return tuple(
+        Ktx2Cell(
+            produces=ArtifactID(source=source, tier=_ktx2_tier_for(t)),
+            inputs=(ArtifactID(source=source, tier=t),),
+        )
+        for t in png_source_tiers
+    )
+
+
+# Canonical declarations.
+_RELEASES: dict[str, Release] = {
+    "v2026.04": Release(
+        line="v2026.04",
+        cells=(
+            *_ktx2_for_source("ambientcg", png_source_tiers=("1k", "512")),
+            *_ktx2_for_source("polyhaven", png_source_tiers=("1k", "512")),
+            *_ktx2_for_source("gpuopen", png_source_tiers=("1k", "512")),
+            # physicallybased — scalar-only, no PNGs to transcode.
+        ),
+    ),
+}
+
+
+def _validate_release(release: Release) -> None:
+    """Per-cell sanity. Cross-phase invariants live in
+    ``release_registry.release_dag()``."""
+    seen: set[ArtifactID] = set()
+    for cell in release.cells:
+        if cell.produces in seen:
+            raise ValueError(f"release {release.line!r}: duplicate ktx2 cell {cell.produces}")
+        seen.add(cell.produces)
+
+        a = cell.produces
+        if a.source not in KNOWN_SOURCES:
+            raise ValueError(
+                f"release {release.line!r}: ktx2 cell {a} references unknown "
+                f"source (known: {sorted(KNOWN_SOURCES)})"
+            )
+        if a.source in SCALAR_SOURCES:
+            raise ValueError(
+                f"release {release.line!r}: ktx2 cell {a} — scalar-only "
+                f"source {a.source!r} has no PNGs to transcode"
+            )
+        if a.source not in TEXTURED_SOURCES:
+            raise ValueError(
+                f"release {release.line!r}: ktx2 cell {a} — source not in TEXTURED_SOURCES"
+            )
+
+        # ktx2 tier shape
+        if not a.tier.startswith(KTX2_TIER_PREFIX):
+            raise ValueError(
+                f"release {release.line!r}: ktx2 cell {a} — tier must start "
+                f"with {KTX2_TIER_PREFIX!r}"
+            )
+        png_tier = a.tier[len(KTX2_TIER_PREFIX) :]  # noqa: E203
+        if png_tier not in VALID_TIERS:
+            raise ValueError(
+                f"release {release.line!r}: ktx2 cell {a} — png suffix "
+                f"{png_tier!r} not in VALID_TIERS ({sorted(VALID_TIERS)})"
+            )
+
+        # inputs sanity
+        if len(cell.inputs) != 1:
+            raise ValueError(
+                f"release {release.line!r}: ktx2 cell {a} must have exactly "
+                f"one input (the source PNG tier); got {len(cell.inputs)}"
+            )
+        inp = cell.inputs[0]
+        if inp.source != a.source:
+            raise ValueError(
+                f"release {release.line!r}: ktx2 cell {a} reads from {inp} — "
+                "must transcode within the same source"
+            )
+        if inp.tier != png_tier:
+            raise ValueError(
+                f"release {release.line!r}: ktx2 cell {a} input tier "
+                f"{inp.tier!r} doesn't match the ktx2 suffix {png_tier!r}"
+            )
+
+
+# Validate at module import.
+for _r in _RELEASES.values():
+    _validate_release(_r)
+
+
+def known_lines() -> tuple[str, ...]:
+    return tuple(_RELEASES.keys())
+
+
+def get_release(line: str) -> Release:
+    """Return the canonical ktx2 ``Release`` for a release line."""
+    if line not in _RELEASES:
+        raise KeyError(f"unknown release line {line!r}; known lines: {known_lines()}")
+    return _RELEASES[line]
+
+
+def filter_cells(
+    cells: tuple[Ktx2Cell, ...],
+    *,
+    source: str = "",
+    tier: str = "",
+) -> tuple[Ktx2Cell, ...]:
+    """Filter ktx2 cells by produces.source / produces.tier."""
+    out = cells
+    if source:
+        out = tuple(c for c in out if c.produces.source == source)
+    if tier:
+        out = tuple(c for c in out if c.produces.tier == tier)
+    return out

--- a/src/mat_vis_baker/release_matrix.py
+++ b/src/mat_vis_baker/release_matrix.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from mat_vis_baker._artifact import ArtifactID
 from mat_vis_baker.common import VALID_TIERS
 from mat_vis_baker.sources import KNOWN_SOURCES, SCALAR_SOURCES, TEXTURED_SOURCES
 
@@ -55,15 +56,32 @@ _VALID_CELL_TIERS: frozenset[str] = frozenset(VALID_TIERS) | {SCALAR_TIER}
 
 @dataclass(frozen=True, slots=True)
 class Cell:
-    """One (source × tier) bake target.
+    """One bake-phase cell — produces an artifact by fetching from upstream.
 
     Equality + hashing are structural — two cells with the same
     ``(source, tier)`` are the same cell. That makes deduping trivial
     and lets cells live in sets / be dict keys.
+
+    mat-vis#349: bake cells have **no** ``inputs`` (they fetch from
+    upstream APIs, not from other cells in this release). The
+    ``produces`` property exposes the artifact identity for the DAG
+    composer (``release_registry.release_dag()``) — same shape derive
+    and ktx2 cells use, so the v2 DAG migration is mechanical.
     """
 
     source: str
     tier: str
+
+    @property
+    def produces(self) -> ArtifactID:
+        """The artifact this cell produces. mat-vis#349 DAG-shape."""
+        return ArtifactID(source=self.source, tier=self.tier)
+
+    @property
+    def inputs(self) -> tuple[ArtifactID, ...]:
+        """Bake cells take no in-release inputs — empty tuple. Same
+        shape derive/ktx2 cells use so DAG composition is uniform."""
+        return ()
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/mat_vis_baker/release_registry.py
+++ b/src/mat_vis_baker/release_registry.py
@@ -1,0 +1,235 @@
+"""Cross-phase release matrix composer + validator (mat-vis#349).
+
+Composes the three peer per-phase modules — ``release_matrix`` (bake),
+``derive_matrix``, ``ktx2_matrix`` — into a single DAG view per
+release line. Validates topology that no individual peer can check
+because it crosses module boundaries:
+
+- No two cells (across any phase) ``produces`` the same ``ArtifactID``.
+- Every ``inputs`` reference points at an artifact ``produces`` by some
+  cell in the same release line — if ktx2 reads ``gpuopen:1k`` then
+  ``gpuopen:1k`` must be either a bake cell or a derive cell in this
+  release.
+- No cycles in the derivation DAG (today's matrix is 2-deep so this
+  is trivially satisfied; the test suite locks the invariant for the
+  v2 expansion when chained derives become routine).
+
+This module is the cheap-later property of #349's Option B: today
+``release_dag()`` is a convenience that composes the three peer
+modules; tomorrow (Option D — DAG migration) it becomes the **primary**
+API and the per-phase modules collapse into a single declarations
+file. The migration is mechanical because each cell already carries
+``produces: ArtifactID`` and ``inputs: tuple[ArtifactID, ...]``; the
+phase membership is just metadata.
+
+Public surface:
+
+- :class:`ReleaseDAG` — composed view; carries cell lists per phase
+  plus a flat ``derivations`` tuple keyed by ``produces`` for
+  graph traversal.
+- :func:`release_dag` — fetch + validate; raises ``ValueError`` on
+  any cross-phase invariant violation.
+- :func:`known_lines` — union of declared lines across the three
+  peer modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from mat_vis_baker import derive_matrix, ktx2_matrix, release_matrix
+from mat_vis_baker._artifact import ArtifactID
+
+Phase = Literal["bake", "derive", "ktx2"]
+
+
+@dataclass(frozen=True, slots=True)
+class Derivation:
+    """A flat, phase-tagged cell view used by :class:`ReleaseDAG` for
+    graph traversal. The per-phase dataclasses (``Cell``, ``DeriveCell``,
+    ``Ktx2Cell``) keep their phase-specific shape; this is the union
+    type that graph algorithms operate on.
+
+    The v2 DAG migration (#349 P2 / Option D) collapses the three
+    per-phase modules into a single declarations file using this type
+    directly — adding a new phase is "add a Literal value" instead of
+    "add a new module."
+    """
+
+    phase: Phase
+    produces: ArtifactID
+    inputs: tuple[ArtifactID, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseDAG:
+    """Composed view of all phases for a release line.
+
+    Carries:
+
+    - :attr:`bake_cells` / :attr:`derive_cells` / :attr:`ktx2_cells` —
+      the original per-phase tuples, for callers that want the per-phase
+      schema (workflow plan jobs filter to one phase).
+    - :attr:`derivations` — flat tuple of :class:`Derivation` for
+      graph traversal. Sorted by ``(phase, produces)`` for stable
+      JSON output.
+    - :attr:`by_artifact` — dict ``ArtifactID → Derivation`` for O(1)
+      input lookup during DAG traversal.
+
+    Invariants (enforced by :func:`release_dag` before construction):
+
+    - Every ``produces`` is unique across all phases.
+    - Every ``inputs`` element appears as some other cell's ``produces``.
+    - No cycles.
+    """
+
+    line: str
+    bake_cells: tuple[release_matrix.Cell, ...]
+    derive_cells: tuple[derive_matrix.DeriveCell, ...]
+    ktx2_cells: tuple[ktx2_matrix.Ktx2Cell, ...]
+    derivations: tuple[Derivation, ...]
+    by_artifact: dict[ArtifactID, Derivation] = field(default_factory=dict)
+
+    def all_artifacts(self) -> tuple[ArtifactID, ...]:
+        """Every artifact this release line produces, sorted."""
+        return tuple(sorted(self.by_artifact.keys()))
+
+    def cells_for_phase(self, phase: Phase) -> tuple[Derivation, ...]:
+        """Filter derivations by phase. Used by the workflow CLI's
+        ``--phase=`` flag."""
+        return tuple(d for d in self.derivations if d.phase == phase)
+
+
+def known_lines() -> tuple[str, ...]:
+    """Union of release lines declared across the three peer modules.
+
+    Today every line should appear in all three (or in bake-only +
+    scalar-source-only); the validator below catches asymmetric
+    declarations as missing-cell errors at composition time.
+    """
+    seen: set[str] = set()
+    for mod in (release_matrix, derive_matrix, ktx2_matrix):
+        seen.update(mod.known_lines())
+    return tuple(sorted(seen))
+
+
+def _to_derivations(
+    bake_cells: tuple[release_matrix.Cell, ...],
+    derive_cells: tuple[derive_matrix.DeriveCell, ...],
+    ktx2_cells: tuple[ktx2_matrix.Ktx2Cell, ...],
+) -> tuple[Derivation, ...]:
+    """Flatten the three per-phase tuples into a single phase-tagged
+    sequence. Sort by ``(phase, produces)`` for stable serialization."""
+    out: list[Derivation] = []
+    for c in bake_cells:
+        out.append(Derivation(phase="bake", produces=c.produces, inputs=c.inputs))
+    for c in derive_cells:
+        out.append(Derivation(phase="derive", produces=c.produces, inputs=c.inputs))
+    for c in ktx2_cells:
+        out.append(Derivation(phase="ktx2", produces=c.produces, inputs=c.inputs))
+    out.sort(key=lambda d: (d.phase, d.produces))
+    return tuple(out)
+
+
+def _validate_dag(line: str, derivations: tuple[Derivation, ...]) -> dict[ArtifactID, Derivation]:
+    """Cross-phase topology validator. Returns the by_artifact map
+    on success; raises ``ValueError`` with a specific message on any
+    violation."""
+
+    by_artifact: dict[ArtifactID, Derivation] = {}
+    for d in derivations:
+        if d.produces in by_artifact:
+            other = by_artifact[d.produces]
+            raise ValueError(
+                f"release {line!r}: artifact {d.produces} produced by both "
+                f"{other.phase} and {d.phase} cells — every artifact must "
+                "have exactly one producing cell across all phases."
+            )
+        by_artifact[d.produces] = d
+
+    # Every input must be produced by some cell in the same line.
+    for d in derivations:
+        for inp in d.inputs:
+            if inp not in by_artifact:
+                raise ValueError(
+                    f"release {line!r}: {d.phase} cell {d.produces} reads "
+                    f"input {inp} that no cell in this release produces. "
+                    "Either add a cell that produces it (likely a bake or "
+                    "derive cell) or remove the dependency."
+                )
+
+    # Cycle check via DFS. Today's matrix is 2-deep (bake → derive,
+    # bake → ktx2, derive → ktx2-via-derived) so cycles are trivial,
+    # but the v2 expansion will have multi-input chains; lock the
+    # invariant now.
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color: dict[ArtifactID, int] = {a: WHITE for a in by_artifact}
+
+    def dfs(node: ArtifactID, path: list[ArtifactID]) -> None:
+        color[node] = GRAY
+        path.append(node)
+        for nxt in by_artifact[node].inputs:
+            if color[nxt] == GRAY:
+                cycle = " → ".join(str(x) for x in path[path.index(nxt) :]) + f" → {nxt}"
+                raise ValueError(f"release {line!r}: cycle in derivation DAG: {cycle}")
+            if color[nxt] == WHITE:
+                dfs(nxt, path)
+        path.pop()
+        color[node] = BLACK
+
+    for a in by_artifact:
+        if color[a] == WHITE:
+            dfs(a, [])
+
+    return by_artifact
+
+
+def release_dag(line: str) -> ReleaseDAG:
+    """Compose the three peer modules into a validated DAG view.
+
+    Lookup is by ``line`` (e.g. ``"v2026.04"``). If a peer module
+    doesn't declare the line, an empty cell tuple is used for that
+    phase. If NO peer declares the line, raises ``KeyError``.
+
+    Validation runs before the DAG object is returned; on any
+    cross-phase invariant violation a ``ValueError`` with a specific
+    error message is raised.
+    """
+    if line not in known_lines():
+        raise KeyError(f"unknown release line {line!r}; known: {known_lines()}")
+
+    # Each peer's get_release raises if it doesn't have the line; we
+    # tolerate that (some lines may legitimately have no derive cells,
+    # e.g. scalar-only lines). Default to empty.
+    try:
+        bake_cells = release_matrix.get_release(line).cells
+    except KeyError:
+        bake_cells = ()
+    try:
+        derive_cells = derive_matrix.get_release(line).cells
+    except KeyError:
+        derive_cells = ()
+    try:
+        ktx2_cells = ktx2_matrix.get_release(line).cells
+    except KeyError:
+        ktx2_cells = ()
+
+    derivations = _to_derivations(bake_cells, derive_cells, ktx2_cells)
+    by_artifact = _validate_dag(line, derivations)
+
+    return ReleaseDAG(
+        line=line,
+        bake_cells=bake_cells,
+        derive_cells=derive_cells,
+        ktx2_cells=ktx2_cells,
+        derivations=derivations,
+        by_artifact=by_artifact,
+    )
+
+
+# Validate every known line at module import — surfaces cross-phase
+# misdeclarations the moment the module is imported, rather than at
+# the next workflow dispatch.
+for _line in known_lines():
+    release_dag(_line)

--- a/tests/test_release_registry.py
+++ b/tests/test_release_registry.py
@@ -1,0 +1,235 @@
+"""Tests for mat_vis_baker.release_registry (mat-vis#349).
+
+Cross-phase composer + DAG validator. Covers:
+
+- ``release_dag`` happy path: bake + derive + ktx2 cells compose
+  cleanly for v2026.04 (the canonical declaration shipped today).
+- Cell counts per phase for v2026.04 (acceptance criterion in #349).
+- ``Derivation`` stable sort order.
+- Cross-phase invariants — synthesized minimal release lines exercise
+  each failure mode the validator should catch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mat_vis_baker._artifact import ArtifactID
+from mat_vis_baker.release_registry import (
+    Derivation,
+    _to_derivations,
+    _validate_dag,
+    known_lines,
+    release_dag,
+)
+
+
+# ── happy path: v2026.04 canonical declaration ───────────────────
+
+
+def test_v2026_04_dag_composes():
+    dag = release_dag("v2026.04")
+    assert dag.line == "v2026.04"
+    # 4 + 9 + 6 = 19 (mat-vis#349 acceptance)
+    assert len(dag.derivations) == 19
+
+
+def test_v2026_04_phase_counts():
+    """The exact acceptance numbers from mat-vis#349."""
+    dag = release_dag("v2026.04")
+    assert len(dag.cells_for_phase("bake")) == 4
+    assert len(dag.cells_for_phase("derive")) == 9
+    assert len(dag.cells_for_phase("ktx2")) == 6
+
+
+def test_v2026_04_every_textured_source_has_full_derive_chain():
+    """gpuopen / ambientcg / polyhaven each declare 1k → {512, 256, 128}."""
+    dag = release_dag("v2026.04")
+    for source in ("gpuopen", "ambientcg", "polyhaven"):
+        derive_tiers = {
+            d.produces.tier for d in dag.cells_for_phase("derive") if d.produces.source == source
+        }
+        assert derive_tiers == {"128", "256", "512"}, (
+            f"{source} derive tiers expected {{128,256,512}}, got {derive_tiers}"
+        )
+
+
+def test_v2026_04_every_textured_source_has_ktx2_set():
+    dag = release_dag("v2026.04")
+    for source in ("gpuopen", "ambientcg", "polyhaven"):
+        ktx2_tiers = {
+            d.produces.tier for d in dag.cells_for_phase("ktx2") if d.produces.source == source
+        }
+        assert ktx2_tiers == {"ktx2-1k", "ktx2-512"}
+
+
+def test_v2026_04_physicallybased_only_in_bake():
+    """Scalar-only source has bake cell, NO derive or ktx2."""
+    dag = release_dag("v2026.04")
+    pb_derivations = [d for d in dag.derivations if d.produces.source == "physicallybased"]
+    assert len(pb_derivations) == 1
+    assert pb_derivations[0].phase == "bake"
+    assert pb_derivations[0].produces.tier == "scalar"
+
+
+def test_v2026_04_dag_by_artifact_index():
+    """O(1) lookup from ArtifactID → Derivation."""
+    dag = release_dag("v2026.04")
+    a = ArtifactID(source="gpuopen", tier="512")
+    d = dag.by_artifact[a]
+    assert d.phase == "derive"
+    assert d.inputs == (ArtifactID(source="gpuopen", tier="1k"),)
+
+
+def test_v2026_04_dag_all_artifacts_unique_and_sorted():
+    dag = release_dag("v2026.04")
+    arts = dag.all_artifacts()
+    assert len(arts) == len(set(arts))  # unique
+    assert list(arts) == sorted(arts)  # ordered
+
+
+# ── known_lines / get_release plumbing ────────────────────────────
+
+
+def test_known_lines_includes_v2026_04():
+    assert "v2026.04" in known_lines()
+
+
+def test_release_dag_unknown_line_raises_keyerror():
+    with pytest.raises(KeyError, match="unknown release line"):
+        release_dag("v9999.99")
+
+
+# ── _validate_dag (synthetic minimal cases) ───────────────────────
+
+
+def _bake_derivation(s: str, t: str) -> Derivation:
+    return Derivation(phase="bake", produces=ArtifactID(s, t), inputs=())
+
+
+def _derive_derivation(s: str, target_t: str, source_t: str) -> Derivation:
+    return Derivation(
+        phase="derive",
+        produces=ArtifactID(s, target_t),
+        inputs=(ArtifactID(s, source_t),),
+    )
+
+
+def _ktx2_derivation(s: str, png_t: str) -> Derivation:
+    return Derivation(
+        phase="ktx2",
+        produces=ArtifactID(s, f"ktx2-{png_t}"),
+        inputs=(ArtifactID(s, png_t),),
+    )
+
+
+def test_validate_dag_clean_case():
+    derivations = (
+        _bake_derivation("foo", "1k"),
+        _derive_derivation("foo", "512", "1k"),
+        _ktx2_derivation("foo", "1k"),
+    )
+    by_artifact = _validate_dag("test", derivations)
+    assert len(by_artifact) == 3
+
+
+def test_validate_dag_rejects_duplicate_produces():
+    """Two cells producing the same artifact (e.g. one in bake + one
+    in derive) is the cross-phase invariant violation the cell-local
+    validator can't see."""
+    derivations = (
+        _bake_derivation("foo", "1k"),
+        _derive_derivation("foo", "1k", "2k"),  # also produces foo:1k
+    )
+    with pytest.raises(ValueError, match="produced by both"):
+        _validate_dag("test", derivations)
+
+
+def test_validate_dag_rejects_dangling_input():
+    """ktx2 cell reads from foo:1k but no cell produces foo:1k."""
+    derivations = (
+        _ktx2_derivation("foo", "1k"),  # reads foo:1k → not produced
+    )
+    with pytest.raises(ValueError, match="reads input"):
+        _validate_dag("test", derivations)
+
+
+def test_validate_dag_rejects_cycle():
+    """Synthetic cycle: A reads B, B reads A. Real matrices today are
+    2-deep so this is artificial — but the v2 expansion will have
+    chained derives, locking the invariant matters."""
+    derivations = (
+        Derivation(
+            phase="derive",
+            produces=ArtifactID("foo", "256"),
+            inputs=(ArtifactID("foo", "512"),),
+        ),
+        Derivation(
+            phase="derive",
+            produces=ArtifactID("foo", "512"),
+            inputs=(ArtifactID("foo", "256"),),
+        ),
+    )
+    with pytest.raises(ValueError, match="cycle"):
+        _validate_dag("test", derivations)
+
+
+def test_validate_dag_rejects_self_loop():
+    derivations = (
+        Derivation(
+            phase="derive",
+            produces=ArtifactID("foo", "512"),
+            inputs=(ArtifactID("foo", "512"),),
+        ),
+    )
+    with pytest.raises(ValueError, match="cycle"):
+        _validate_dag("test", derivations)
+
+
+# ── _to_derivations stable ordering ──────────────────────────────
+
+
+def test_to_derivations_sorted_by_phase_then_artifact():
+    """Stable JSON output requires deterministic order: phase
+    alphabetical (bake < derive < ktx2), then by produces."""
+    from mat_vis_baker.derive_matrix import DeriveCell
+    from mat_vis_baker.ktx2_matrix import Ktx2Cell
+    from mat_vis_baker.release_matrix import Cell
+
+    bake = (Cell("zeta", "1k"), Cell("alpha", "1k"))
+    derive = (
+        DeriveCell(
+            produces=ArtifactID("alpha", "512"),
+            inputs=(ArtifactID("alpha", "1k"),),
+        ),
+    )
+    ktx2 = (
+        Ktx2Cell(
+            produces=ArtifactID("alpha", "ktx2-1k"),
+            inputs=(ArtifactID("alpha", "1k"),),
+        ),
+    )
+    out = _to_derivations(bake, derive, ktx2)
+
+    # Phase order: bake < derive < ktx2 alphabetically
+    phases = [d.phase for d in out]
+    assert phases == sorted(phases)
+
+    # Within each phase, sorted by produces
+    bakes = [d for d in out if d.phase == "bake"]
+    assert [d.produces.source for d in bakes] == ["alpha", "zeta"]
+
+
+# ── ReleaseDAG type integrity ────────────────────────────────────
+
+
+def test_release_dag_carries_per_phase_tuples_for_callers():
+    """Workflow plan jobs filter to one phase; they want the original
+    per-phase dataclass not the union Derivation type."""
+    dag = release_dag("v2026.04")
+    # Each is a tuple of the right per-phase dataclass.
+    assert isinstance(dag.bake_cells, tuple)
+    assert isinstance(dag.derive_cells, tuple)
+    assert isinstance(dag.ktx2_cells, tuple)
+    # And the count matches the unified view.
+    assert len(dag.bake_cells) + len(dag.derive_cells) + len(dag.ktx2_cells) == len(dag.derivations)


### PR DESCRIPTION
## Summary

Closes #349. Three peer per-phase modules + cross-phase composer/validator. Each cell shaped like a DAG node (\`produces: ArtifactID\`, \`inputs: tuple[ArtifactID, ...]\`) so the eventual D migration is mechanical, not a rewrite.

Per the 3-angle sub-agent spike (schema, workflow ergonomics, future-proofing) the synthesis is **B with DAG-cheap-later internals**.

## What ships

- \`mat_vis_baker._artifact.ArtifactID\` — stable artifact identity (becomes DAG node ID later, zero schema cost)
- \`release_matrix.py\` — bake phase (file name preserved for #306 back-compat); \`Cell\` gains \`produces\` + \`inputs\` properties
- \`derive_matrix.py\` — derive phase declares 1k → {512, 256, 128} per textured source for v2026.04
- \`ktx2_matrix.py\` — ktx2 phase declares ktx2-{1k, 512} per textured source
- \`release_registry.py\` — \`release_dag(line)\` cross-phase composer + topology validator (no duplicate produces, every input is produced by some cell, no cycles)
- CLI: \`mat-vis-baker matrix list <line> [--phase=bake|derive|ktx2|all]\` (default bake for back-compat)
- \`docs/development/release-matrix-design.md\` documents the decision + D-migration path

## Acceptance — all met

- \`v2026.04 phase=bake\` → 4 cells (current behavior)
- \`v2026.04 phase=derive\` → 9 cells
- \`v2026.04 phase=ktx2\` → 6 cells
- \`v2026.04 phase=all\` → 19 cells (4+9+6)

## Tests

- 14 new in \`test_release_registry.py\`: happy path, phase counts, per-source coverage, cross-phase invariants (duplicate produces, dangling input, cycle, self-loop), DAG type integrity
- 23 existing #306 tests unchanged + green
- Full host suite: 578 passed, 16 skipped

## DAG-cheap-later property

| Property | Today (B) | v2 D-migration | Cost |
|---|---|---|---|
| Stable artifact identity | \`ArtifactID\` | Same (DAG node ID) | Zero |
| Explicit dependency edges | \`inputs: tuple[...]\` | Same field | Zero |
| Cross-phase validation | \`release_dag()\` | Same validator promoted to primary | Zero |
| Per-phase iteration | 3 modules + 3 helpers | \`release_dag().cells_for_phase(p)\` | Already there |

Migration to D is "promote \`release_registry\` to primary; collapse 3 modules into a single declarations file" — sized at ~1 day given the structural prep here.

## P1 follow-ups (separate PRs)

- \`derive.yml\` migration off runtime expansion (sibling to #323's bake.yml migration); plan job becomes \`mat-vis-baker matrix list <line> --phase=derive\`
- \`validate_release.py\` cross-phase coverage check ("substrate has every artifact the matrix declares")
- #345 prod-preflight tier-coverage gate gains comprehensive coverage when the matrix is complete

## References

- mat-vis#349 (closed)
- mat-vis#306 (extends — current bake-only state preserved)
- mat-vis#323 (bake.yml migration — derive.yml needs same in P1)
- mat-vis#344 / #347 (post-cut validate gate)
- mat-vis#345 / #348 (prod-preflight)