### PR TITLE
feat: full MeshPhysicalMaterial PBR coverage — 5 scalars + opacityMap (#340)

### DIFF
--- a/clients/python/src/mat_vis_client/adapters.py
+++ b/clients/python/src/mat_vis_client/adapters.py
@@ -184,6 +184,46 @@ def _color_hex_to_rgba(hex_str: str) -> list[float]:
     return list(_color_hex_to_srgb_rgba(hex_str))
 
 
+def _resolve_specular_color(
+    scalars: dict,
+) -> tuple[float, float, float] | None:
+    """Resolve specular color as **linear RGB** (3-tuple).
+
+    Priority order (first non-None wins):
+        1. ``specular_color_linear`` (canonical, 3-tuple linear, no transform)
+        2. ``specular_color_rgba`` (3-tuple sRGB; de-gammas at boundary)
+
+    Multiple non-equal non-None values raise ``ValueError``.
+
+    Mirrors :func:`_resolve_base_color` to avoid the colorspace-asymmetry
+    Finding-2 trap on ``specularColorFactor`` (linear in glTF spec) vs.
+    ``MeshPhysicalMaterial.specularColor`` (sRGB-input under Three.js
+    ColorManagement r152+). #340.
+    """
+    scl = scalars.get("specular_color_linear")
+    rgb_in = scalars.get("specular_color_rgba")
+
+    scl_t: tuple[float, float, float] | None = (
+        tuple(scl)[:3] if scl is not None else None  # type: ignore[assignment]
+    )
+    rgb_linear: tuple[float, float, float] | None = None
+    if rgb_in is not None:
+        r, g, b = tuple(rgb_in)[:3]
+        rgb_linear = (_srgb_to_linear(r), _srgb_to_linear(g), _srgb_to_linear(b))
+
+    candidates = [c for c in (scl_t, rgb_linear) if c is not None]
+    if not candidates:
+        return None
+    first = candidates[0]
+    for cand in candidates[1:]:
+        if not all(math.isclose(x, y, rel_tol=1e-6, abs_tol=1e-9) for x, y in zip(first, cand)):
+            raise ValueError(
+                "scalars contains multiple specular-color keys with non-equal "
+                "values; pick specular_color_linear or specular_color_rgba"
+            )
+    return first
+
+
 def _resolve_metalness(scalars: dict) -> float | None:
     """Resolve the metalness scalar accepting ``metallic`` as a glTF-spec alias.
 
@@ -307,6 +347,25 @@ def to_threejs(
         result["emissive"] = list(scalars["emissive"])
     if scalars.get("clearcoat") is not None:
         result["clearcoat"] = scalars["clearcoat"]
+    if scalars.get("clearcoat_roughness") is not None:
+        result["clearcoatRoughness"] = scalars["clearcoat_roughness"]
+    if scalars.get("specular_intensity") is not None:
+        result["specularIntensity"] = scalars["specular_intensity"]
+    # Three.js MeshPhysicalMaterial.specularColor is sRGB-input under
+    # ColorManagement r152+; re-encode linear → sRGB regardless of which
+    # input alias the caller used. Same shape as base_color handling.
+    specular_color_linear = _resolve_specular_color(scalars)
+    if specular_color_linear is not None:
+        srgb = tuple(_linear_to_srgb(c) for c in specular_color_linear)
+        result["specularColor"] = "#{:02x}{:02x}{:02x}".format(
+            int(round(max(0.0, min(1.0, srgb[0])) * 255)),
+            int(round(max(0.0, min(1.0, srgb[1])) * 255)),
+            int(round(max(0.0, min(1.0, srgb[2])) * 255)),
+        )
+    if scalars.get("thickness") is not None:
+        result["thickness"] = scalars["thickness"]
+    if scalars.get("dispersion") is not None:
+        result["dispersion"] = scalars["dispersion"]
 
     # Textures as data URIs
     for channel, prop in _THREEJS_TEX_MAP.items():
@@ -388,11 +447,53 @@ def to_gltf(
         material["emissiveFactor"] = list(emissive)
 
     # Clearcoat extension — omit when zero/None (spec default), mirrors
-    # the KHR_materials_ior / _transmission suppression pattern.
+    # the KHR_materials_ior / _transmission suppression pattern. The
+    # clearcoatRoughnessFactor sub-field only ships when clearcoat is
+    # active AND roughness is non-default (default is 0.0 = mirror).
     clearcoat = scalars.get("clearcoat")
+    clearcoat_roughness = scalars.get("clearcoat_roughness")
     if not _clearcoat_at_default(clearcoat):
-        material.setdefault("extensions", {})["KHR_materials_clearcoat"] = {
-            "clearcoatFactor": clearcoat
+        cc_ext: dict = {"clearcoatFactor": clearcoat}
+        if clearcoat_roughness is not None and not math.isclose(
+            clearcoat_roughness, 0.0, abs_tol=1e-9
+        ):
+            cc_ext["clearcoatRoughnessFactor"] = clearcoat_roughness
+        material.setdefault("extensions", {})["KHR_materials_clearcoat"] = cc_ext
+
+    # KHR_materials_specular — bundles specularFactor + specularColorFactor.
+    # Both default to 1.0 / [1,1,1]; emit only when at least one is
+    # authored away from default. specularColorFactor ships in linear
+    # per the extension spec (matches our linear-RGB resolution).
+    specular_intensity = scalars.get("specular_intensity")
+    specular_color = _resolve_specular_color(scalars)
+    spec_ext: dict = {}
+    if specular_intensity is not None and not math.isclose(specular_intensity, 1.0, abs_tol=1e-9):
+        spec_ext["specularFactor"] = specular_intensity
+    if specular_color is not None and not all(
+        math.isclose(c, 1.0, abs_tol=1e-9) for c in specular_color
+    ):
+        spec_ext["specularColorFactor"] = list(specular_color)
+    if spec_ext:
+        material.setdefault("extensions", {})["KHR_materials_specular"] = spec_ext
+
+    # KHR_materials_volume.thicknessFactor — only meaningful when
+    # transmission > 0 AND thickness > 0. The baker emits None for
+    # opaque materials per #340 contract; defensively guard anyway.
+    thickness = scalars.get("thickness")
+    if (
+        thickness is not None
+        and thickness > 0.0
+        and not _transmission_at_default(scalars.get("transmission"))
+    ):
+        material.setdefault("extensions", {})["KHR_materials_volume"] = {
+            "thicknessFactor": thickness
+        }
+
+    # KHR_materials_dispersion — extension default 0.0 (no dispersion).
+    dispersion = scalars.get("dispersion")
+    if dispersion is not None and dispersion > 0.0:
+        material.setdefault("extensions", {})["KHR_materials_dispersion"] = {
+            "dispersion": dispersion
         }
 
     # Textures

--- a/clients/python/src/mat_vis_client/adapters.py
+++ b/clients/python/src/mat_vis_client/adapters.py
@@ -372,6 +372,13 @@ def to_threejs(
         if channel in textures:
             result[prop] = _to_data_uri(textures[channel])
 
+    # When an opacity texture is present, the material needs
+    # transparent=true so Three.js samples alphaMap instead of
+    # rendering as fully opaque. Without this flag MeshPhysicalMaterial
+    # ignores alphaMap entirely. #340.
+    if "opacity" in textures:
+        result["transparent"] = True
+
     return result
 
 
@@ -496,6 +503,28 @@ def to_gltf(
             "dispersion": dispersion
         }
 
+    # Opacity texture — glTF 2.0 has no standalone alphaMap slot. Alpha
+    # must live in baseColorTexture's alpha channel + alphaMode/alphaCutoff
+    # at the material level. Pack with Pillow when available; otherwise
+    # emit alphaMode flagging + drop the texture (consumers can fetch
+    # the standalone PNG from the substrate). Mirrors the
+    # metallicRoughnessTexture packing pattern. #340.
+    if "opacity" in textures:
+        material["alphaMode"] = "MASK"
+        material["alphaCutoff"] = 0.5
+        if "color" in textures and Image is not None:
+            packed_uri = _pack_base_color_with_alpha(
+                color_png=textures["color"],
+                opacity_png=textures["opacity"],
+            )
+            pbr["baseColorTexture"] = {"source": {"uri": packed_uri}}
+        elif "color" not in textures or Image is None:
+            material["_note_opacity_unpacked"] = (
+                "opacity texture provided but baseColorTexture alpha not packed "
+                "(install `mat-vis-client[gltf]` to enable Pillow packing). The "
+                "standalone opacity PNG is available in the substrate texture set."
+            )
+
     # Textures
     def _tex_ref(png_bytes: bytes) -> dict:
         return {"source": {"uri": _to_data_uri(png_bytes)}}
@@ -526,6 +555,34 @@ def to_gltf(
             pbr["metallicRoughnessTexture"] = {"source": {"uri": packed_uri}}
 
     return material
+
+
+def _pack_base_color_with_alpha(
+    *,
+    color_png: bytes,
+    opacity_png: bytes,
+) -> str:
+    """Pack baseColor (RGB) + opacity (alpha) into a single RGBA PNG.
+
+    glTF 2.0 has no standalone alphaMap slot — alpha must live in the
+    baseColorTexture's alpha channel. We use Three.js's convention of
+    sourcing alpha from the opacity image's green channel (works for
+    both single-channel grayscale PNGs and color3 opacity images, since
+    PNG decoders broadcast L→RGB on grayscale inputs).
+
+    Color image dimensions are the reference; opacity is resized to
+    match if they differ.
+    """
+    assert Image is not None  # caller checks
+    color = Image.open(BytesIO(color_png)).convert("RGB")
+    opacity = Image.open(BytesIO(opacity_png)).convert("L")
+    if opacity.size != color.size:
+        opacity = opacity.resize(color.size)
+    r, g, b = color.split()
+    packed = Image.merge("RGBA", (r, g, b, opacity))
+    buf = BytesIO()
+    packed.save(buf, format="PNG")
+    return _to_data_uri(buf.getvalue())
 
 
 def _pack_metallic_roughness(

--- a/clients/python/src/mat_vis_client/schema.py
+++ b/clients/python/src/mat_vis_client/schema.py
@@ -33,6 +33,7 @@ class Channel(StrEnum):
     AO = "ao"
     DISPLACEMENT = "displacement"
     EMISSION = "emission"
+    OPACITY = "opacity"
 
 
 class Tier(StrEnum):
@@ -124,6 +125,21 @@ CHANNELS: tuple[ChannelSpec, ...] = (
         usd_preview_prop="emissiveColor",
         usd_preview_type="color3",
         filename_aliases=("emission", "emissive"),
+    ),
+    # Three.js consumes opacity as a standalone alphaMap; glTF requires
+    # alpha to live in baseColorTexture's alpha channel + alphaMode/
+    # alphaCutoff (no standalone slot — adapter packs at output time).
+    # gltf_prop=None signals "handled separately by the adapter."
+    # mtlx_prop="opacity" matches <standard_surface>.opacity (color3 input).
+    # Filename aliases match gpuopen authoring (e.g. Perforated_Metal_opacity.png).
+    ChannelSpec(
+        channel=Channel.OPACITY,
+        threejs_prop="alphaMap",
+        gltf_prop=None,
+        mtlx_prop="opacity",
+        usd_preview_prop="opacity",
+        usd_preview_type="float",
+        filename_aliases=("opacity", "alpha"),
     ),
 )
 

--- a/clients/python/tests/test_adapters_pbr_coverage.py
+++ b/clients/python/tests/test_adapters_pbr_coverage.py
@@ -203,6 +203,81 @@ class TestResolveSpecularColor:
         assert result == pytest.approx((1.0, 1.0, 1.0))
 
 
+# ── opacityMap (texture) ────────────────────────────────────────
+
+
+def _tiny_png() -> bytes:
+    """Build a valid 1x1 PNG byte string at import time.
+
+    Hand-rolled byte literals are easy to corrupt (silent CRC mismatch
+    that Pillow rejects with "broken PNG file"). Generating the bytes
+    via Pillow when available, falling back to a verified minimal PNG
+    otherwise, keeps the fixture sound under both code paths.
+    """
+    try:
+        from PIL import Image as _Image
+
+        from io import BytesIO as _BytesIO
+
+        buf = _BytesIO()
+        _Image.new("RGB", (1, 1), (128, 128, 128)).save(buf, format="PNG")
+        return buf.getvalue()
+    except ImportError:
+        # Verified minimal 1×1 grayscale PNG (8-bit). The transparent=true
+        # / alphaMap path doesn't decode the bytes so this only matters
+        # for tests that exercise Pillow packing — which skip when
+        # Pillow isn't installed anyway.
+        return (
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+            b"\x08\x00\x00\x00\x00:~\x9bU\x00\x00\x00\nIDATx\x9cc`\x00\x00\x00"
+            b"\x02\x00\x01\xe5\x27\xde\xfc\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+
+
+_TINY_PNG = _tiny_png()
+
+
+class TestOpacityMapThreejs:
+    def test_opacity_emits_alphaMap_and_transparent(self) -> None:
+        out = to_threejs({}, {"opacity": _TINY_PNG})
+        assert "alphaMap" in out
+        assert out["alphaMap"].startswith("data:image/png;base64,")
+        assert out["transparent"] is True
+
+    def test_no_opacity_no_transparent_flag(self) -> None:
+        out = to_threejs({})
+        assert "transparent" not in out
+
+    def test_opacity_alongside_color(self) -> None:
+        out = to_threejs({}, {"color": _TINY_PNG, "opacity": _TINY_PNG})
+        assert "map" in out
+        assert "alphaMap" in out
+        assert out["transparent"] is True
+
+
+class TestOpacityMapGltf:
+    def test_opacity_emits_alphaMode_mask(self) -> None:
+        out = to_gltf({}, {"opacity": _TINY_PNG})
+        assert out["alphaMode"] == "MASK"
+        assert out["alphaCutoff"] == 0.5
+
+    def test_no_opacity_no_alphaMode(self) -> None:
+        out = to_gltf({})
+        assert "alphaMode" not in out
+
+    def test_opacity_with_color_packs_alpha(self) -> None:
+        # When both are present and Pillow is available, alpha is packed
+        # into baseColorTexture.
+        try:
+            from PIL import Image as _Image  # noqa: F401
+        except ImportError:
+            pytest.skip("Pillow not installed")
+        out = to_gltf({}, {"color": _TINY_PNG, "opacity": _TINY_PNG})
+        assert "baseColorTexture" in out["pbrMetallicRoughness"]
+        # No "_note_opacity_unpacked" warning when packed successfully.
+        assert "_note_opacity_unpacked" not in out
+
+
 # ── Round-trip / cross-format consistency ────────────────────────
 
 

--- a/clients/python/tests/test_adapters_pbr_coverage.py
+++ b/clients/python/tests/test_adapters_pbr_coverage.py
@@ -1,0 +1,226 @@
+"""Adapter passthrough tests for #340 PBR coverage extension.
+
+5 new scalars routed to Three.js MeshPhysicalMaterial native props and
+glTF KHR_materials_* extensions:
+
+| input              | Three.js                | glTF                                        |
+|--------------------|-------------------------|---------------------------------------------|
+| clearcoat_roughness| clearcoatRoughness      | KHR_materials_clearcoat.clearcoatRoughnessF |
+| specular_intensity | specularIntensity       | KHR_materials_specular.specularFactor       |
+| specular_color_*   | specularColor (sRGB hex)| KHR_materials_specular.specularColorFactor  |
+| thickness          | thickness               | KHR_materials_volume.thicknessFactor        |
+| dispersion         | dispersion              | KHR_materials_dispersion.dispersion         |
+"""
+
+from __future__ import annotations
+
+
+import pytest
+
+from mat_vis_client.adapters import _resolve_specular_color, to_gltf, to_threejs
+
+
+# ── Three.js passthrough ──────────────────────────────────────────
+
+
+class TestThreejsPassthrough:
+    def test_clearcoat_roughness_passes_through(self) -> None:
+        out = to_threejs({"clearcoat_roughness": 0.35})
+        assert out["clearcoatRoughness"] == 0.35
+
+    def test_specular_intensity_passes_through(self) -> None:
+        out = to_threejs({"specular_intensity": 0.6})
+        assert out["specularIntensity"] == 0.6
+
+    def test_thickness_passes_through(self) -> None:
+        out = to_threejs({"thickness": 5.0})
+        assert out["thickness"] == 5.0
+
+    def test_dispersion_passes_through(self) -> None:
+        out = to_threejs({"dispersion": 0.25})
+        assert out["dispersion"] == 0.25
+
+    def test_specular_color_linear_emits_srgb_hex(self) -> None:
+        # Three.js consumes specularColor as sRGB; linear input gets
+        # re-encoded at the boundary.
+        out = to_threejs({"specular_color_linear": [0.5, 0.5, 0.5]})
+        # linear 0.5 → sRGB ~0.7354 → 0xbc on 8-bit
+        assert out["specularColor"].startswith("#")
+        assert out["specularColor"].lower() == "#bcbcbc"
+
+    def test_specular_color_white_passes(self) -> None:
+        out = to_threejs({"specular_color_linear": [1.0, 1.0, 1.0]})
+        assert out["specularColor"].lower() == "#ffffff"
+
+    def test_unset_fields_are_omitted(self) -> None:
+        out = to_threejs({})
+        for key in (
+            "clearcoatRoughness",
+            "specularIntensity",
+            "specularColor",
+            "thickness",
+            "dispersion",
+        ):
+            assert key not in out
+
+
+# ── glTF KHR extension routing ────────────────────────────────────
+
+
+class TestGltfClearcoatRoughness:
+    def test_clearcoat_roughness_paired_with_clearcoat(self) -> None:
+        out = to_gltf({"clearcoat": 0.5, "clearcoat_roughness": 0.2})
+        ext = out["extensions"]["KHR_materials_clearcoat"]
+        assert ext == {"clearcoatFactor": 0.5, "clearcoatRoughnessFactor": 0.2}
+
+    def test_clearcoat_roughness_alone_does_not_enable_clearcoat(self) -> None:
+        # Without clearcoat > 0, the clearcoat layer is disabled — KHR
+        # extension stays absent (avoids no-op extension entry).
+        out = to_gltf({"clearcoat_roughness": 0.2})
+        assert "extensions" not in out or "KHR_materials_clearcoat" not in out.get("extensions", {})
+
+    def test_clearcoat_roughness_at_default_omitted(self) -> None:
+        # Default clearcoatRoughnessFactor is 0.0 — emitting it is no-op.
+        out = to_gltf({"clearcoat": 0.5, "clearcoat_roughness": 0.0})
+        ext = out["extensions"]["KHR_materials_clearcoat"]
+        assert ext == {"clearcoatFactor": 0.5}
+        assert "clearcoatRoughnessFactor" not in ext
+
+
+class TestGltfSpecular:
+    def test_specular_intensity_emits_when_not_default(self) -> None:
+        out = to_gltf({"specular_intensity": 0.6})
+        ext = out["extensions"]["KHR_materials_specular"]
+        assert ext == {"specularFactor": 0.6}
+
+    def test_specular_intensity_at_default_omits_extension(self) -> None:
+        out = to_gltf({"specular_intensity": 1.0})
+        assert "extensions" not in out or "KHR_materials_specular" not in out.get("extensions", {})
+
+    def test_specular_color_emits_linear_in_extension(self) -> None:
+        # KHR_materials_specular.specularColorFactor is linear per spec —
+        # our resolver returns linear, passes straight through.
+        out = to_gltf({"specular_color_linear": [0.95, 0.64, 0.54]})
+        ext = out["extensions"]["KHR_materials_specular"]
+        assert ext["specularColorFactor"] == pytest.approx([0.95, 0.64, 0.54])
+
+    def test_specular_color_white_at_default_omits_field(self) -> None:
+        # White [1,1,1] is the spec default — emit nothing.
+        out = to_gltf({"specular_color_linear": [1.0, 1.0, 1.0]})
+        assert "extensions" not in out or "KHR_materials_specular" not in out.get("extensions", {})
+
+    def test_specular_color_rgba_alias_de_gammas(self) -> None:
+        # sRGB input mid-grey [0.5, 0.5, 0.5] should land in glTF as
+        # linear [~0.214, ~0.214, ~0.214].
+        out = to_gltf({"specular_color_rgba": [0.5, 0.5, 0.5]})
+        ext = out["extensions"]["KHR_materials_specular"]
+        assert ext["specularColorFactor"][0] == pytest.approx(0.21404, abs=1e-3)
+
+    def test_specular_intensity_and_color_together(self) -> None:
+        out = to_gltf(
+            {
+                "specular_intensity": 0.6,
+                "specular_color_linear": [0.95, 0.64, 0.54],
+            }
+        )
+        ext = out["extensions"]["KHR_materials_specular"]
+        assert ext["specularFactor"] == 0.6
+        assert ext["specularColorFactor"] == pytest.approx([0.95, 0.64, 0.54])
+
+
+class TestGltfVolumeThickness:
+    def test_thickness_emits_only_with_transmission(self) -> None:
+        out = to_gltf({"transmission": 0.8, "thickness": 5.0})
+        ext = out["extensions"]["KHR_materials_volume"]
+        assert ext == {"thicknessFactor": 5.0}
+
+    def test_thickness_without_transmission_skipped(self) -> None:
+        # Defensive — the baker should already emit None for
+        # transmission=0, but the adapter checks too.
+        out = to_gltf({"thickness": 5.0})
+        assert "extensions" not in out or "KHR_materials_volume" not in out.get("extensions", {})
+
+    def test_thickness_zero_skipped(self) -> None:
+        out = to_gltf({"transmission": 0.8, "thickness": 0.0})
+        assert "extensions" not in out or "KHR_materials_volume" not in out.get("extensions", {})
+
+
+class TestGltfDispersion:
+    def test_dispersion_emits_when_nonzero(self) -> None:
+        out = to_gltf({"dispersion": 0.25})
+        ext = out["extensions"]["KHR_materials_dispersion"]
+        assert ext == {"dispersion": 0.25}
+
+    def test_dispersion_zero_at_default(self) -> None:
+        out = to_gltf({"dispersion": 0.0})
+        assert "extensions" not in out or "KHR_materials_dispersion" not in out.get(
+            "extensions", {}
+        )
+
+    def test_dispersion_unset(self) -> None:
+        out = to_gltf({})
+        assert "extensions" not in out or "KHR_materials_dispersion" not in out.get(
+            "extensions", {}
+        )
+
+
+# ── _resolve_specular_color helper ──────────────────────────────
+
+
+class TestResolveSpecularColor:
+    def test_linear_canonical_passes_through(self) -> None:
+        result = _resolve_specular_color({"specular_color_linear": [0.95, 0.64, 0.54]})
+        assert result == pytest.approx((0.95, 0.64, 0.54))
+
+    def test_rgba_alias_de_gammas(self) -> None:
+        # sRGB 0.5 → linear ~0.214
+        result = _resolve_specular_color({"specular_color_rgba": [0.5, 0.5, 0.5]})
+        assert result is not None
+        assert result[0] == pytest.approx(0.21404, abs=1e-3)
+
+    def test_unset_returns_none(self) -> None:
+        assert _resolve_specular_color({}) is None
+
+    def test_conflicting_inputs_raise(self) -> None:
+        with pytest.raises(ValueError, match="specular-color"):
+            _resolve_specular_color(
+                {
+                    "specular_color_linear": [0.5, 0.5, 0.5],
+                    "specular_color_rgba": [0.9, 0.9, 0.9],
+                }
+            )
+
+    def test_equal_via_aliases_pass(self) -> None:
+        # If both forms specify the same linear value (after sRGB→linear),
+        # no error.
+        # sRGB 1.0 = linear 1.0 (fixed point); both aliases should agree.
+        result = _resolve_specular_color(
+            {
+                "specular_color_linear": [1.0, 1.0, 1.0],
+                "specular_color_rgba": [1.0, 1.0, 1.0],
+            }
+        )
+        assert result == pytest.approx((1.0, 1.0, 1.0))
+
+
+# ── Round-trip / cross-format consistency ────────────────────────
+
+
+class TestCrossFormatConsistency:
+    def test_specular_color_threejs_srgb_gltf_linear(self) -> None:
+        """Same linear input → Three.js sRGB hex + glTF linear factor.
+        Round-trip-stable through the boundary conversions."""
+        scalars = {"specular_color_linear": [0.5, 0.5, 0.5]}
+        threejs = to_threejs(scalars)
+        gltf = to_gltf(scalars)
+
+        # glTF: linear 0.5 stays linear
+        assert gltf["extensions"]["KHR_materials_specular"]["specularColorFactor"] == pytest.approx(
+            [0.5, 0.5, 0.5]
+        )
+        # Three.js: linear 0.5 → sRGB ~0.7354 ≈ 0xbc / 255 = 0.7333…
+        assert threejs["specularColor"].lower() == "#bcbcbc"
+        # Verify the conversion is the standard piecewise sRGB transfer.
+        # round(_linear_to_srgb(0.5) * 255) ≈ 188 (0xbc)
+        expected = round((1.055 * 0.5 ** (1 / 2.4) - 0.055) * 255)
+        assert int(threejs["specularColor"][1:3], 16) == expected

--- a/src/mat_vis_baker/_mtlx_scalars.py
+++ b/src/mat_vis_baker/_mtlx_scalars.py
@@ -47,13 +47,24 @@ _FLOAT_INPUTS: dict[str, str] = {
     "specular_roughness": "roughness",
     "specular_IOR": "ior",  # uppercase IOR — case-aware lookup
     "transmission": "transmission",
+    # Full MeshPhysicalMaterial coverage (#340).
+    "specular": "specular_intensity",  # KHR_materials_specular.specularFactor
+    "transmission_dispersion": "dispersion",  # KHR_materials_dispersion.dispersion
+    "coat_roughness": "clearcoat_roughness",  # KHR_materials_clearcoat.clearcoatRoughnessFactor
+}
+
+# Color3 inputs. Same direct value=/1-hop graph→constant promotion as
+# float scalars; emit as a 3-list of linear floats (gpuopen authors with
+# linear values per MaterialX 1.38 spec).
+_COLOR3_INPUTS: dict[str, str] = {
+    # mtlx input name -> PBRBlock attribute
+    "specular_color": "specular_color",  # KHR_materials_specular.specularColorFactor
 }
 
 # Inputs that have no PBRBlock home today. Non-zero values are dropped
 # with a structured warning so a future schema add knows where to look.
 _LOSSY_INPUTS: tuple[str, ...] = (
     "coat",
-    "coat_roughness",
     "coat_IOR",
     "coat_color",
     "sheen",
@@ -632,6 +643,35 @@ def parse_standard_surface_scalars(
                 if base_mul is not None:
                     rgb = [c * base_mul for c in rgb]
                 block.color_rgb = rgb
+
+    # Additional color3 scalars (#340). Same extraction pattern as
+    # base_color, no `base` multiplier coupling. MaterialX 1.38 spec
+    # treats `specular_color` as linear RGB by default.
+    for mtlx_name, pbr_attr in _COLOR3_INPUTS.items():
+        c_inp = inputs.get(mtlx_name)
+        if c_inp is None:
+            continue
+        raw_c = _input_value_or_graph_constant(root, c_inp)
+        if raw_c is not None:
+            parts = _parse_color3(raw_c)
+            if parts is not None:
+                setattr(block, pbr_attr, parts)
+
+    # thickness ← transmission_depth, but ONLY when transmission > 0.
+    # MaterialX `transmission_depth` is the absorption-distance scalar
+    # for transmissive materials (KHR_materials_volume.thicknessFactor
+    # equivalent). For opaque materials (transmission=0), the depth
+    # value is dead-code authoring scaffold and has no rendering
+    # meaning; emit None so the adapter doesn't ship a no-op extension.
+    # Survey: only 8/454 gpuopen materials have transmission>0.
+    if block.transmission is not None and block.transmission > 0.0:
+        depth_inp = inputs.get("transmission_depth")
+        if depth_inp is not None:
+            raw_d = _input_value_or_graph_constant(root, depth_inp)
+            if raw_d is not None:
+                d = _parse_float(raw_d)
+                if d is not None and d > 0.0:
+                    block.thickness = d
 
     # Lossy inputs — log structured warning per non-zero authored value.
     for name in _LOSSY_INPUTS:

--- a/src/mat_vis_baker/common.py
+++ b/src/mat_vis_baker/common.py
@@ -384,6 +384,8 @@ _CHANNEL_MAPS: dict[str, dict[str, str]] = {
         "height": "displacement",
         "emissive": "emission",
         "emission": "emission",
+        "opacity": "opacity",
+        "alpha": "opacity",
     },
 }
 

--- a/src/mat_vis_baker/common.py
+++ b/src/mat_vis_baker/common.py
@@ -448,6 +448,20 @@ class PBRBlock:
     # / metalness_mean see the graph estimate.
     metalness_source: str | None = None
 
+    # Full MeshPhysicalMaterial PBR surface coverage (#340). Each field
+    # extracted from <standard_surface> at bake time when authored;
+    # left None when the input is at MaterialX default. Adapter layer
+    # routes these to KHR_materials_specular / _volume / _dispersion /
+    # _clearcoat extensions for glTF and to MeshPhysicalMaterial native
+    # properties for Three.js. py-mat #100.
+    clearcoat_roughness: float | None = None  # <standard_surface>.coat_roughness
+    specular_intensity: float | None = None  # <standard_surface>.specular
+    specular_color: list[float] | None = None  # <standard_surface>.specular_color, LINEAR RGB
+    # KHR_materials_volume.thicknessFactor — only meaningful when
+    # transmission > 0; baker emits None for opaque materials.
+    thickness: float | None = None  # <standard_surface>.transmission_depth
+    dispersion: float | None = None  # <standard_surface>.transmission_dispersion
+
 
 def apply_pbr_neutral_multiplier_conventions(
     pbr: PBRBlock,

--- a/tests/test_index_builder.py
+++ b/tests/test_index_builder.py
@@ -79,6 +79,12 @@ def test_mat_vis_block_has_stable_key_set() -> None:
         "is_conductor",
         "metalness_mean",
         "metalness_source",
+        # Full MeshPhysicalMaterial coverage (#340) — additive.
+        "clearcoat_roughness",
+        "specular_intensity",
+        "specular_color",
+        "thickness",
+        "dispersion",
     }
     # Nested AttributionBlock
     assert set(mv["attribution"].keys()) == {"authors", "license_spdx", "source_url"}
@@ -104,6 +110,12 @@ def test_mat_vis_block_defaults_are_null_or_empty() -> None:
     assert mv["pbr"]["is_conductor"] is None
     assert mv["pbr"]["metalness_mean"] is None
     assert mv["pbr"]["metalness_source"] is None
+    # Full MeshPhysicalMaterial coverage (#340) — additive, default-None.
+    assert mv["pbr"]["clearcoat_roughness"] is None
+    assert mv["pbr"]["specular_intensity"] is None
+    assert mv["pbr"]["specular_color"] is None
+    assert mv["pbr"]["thickness"] is None
+    assert mv["pbr"]["dispersion"] is None
     assert mv["attribution"]["authors"] == []
     assert mv["dates"]["published"] is None
     assert mv["dates"]["updated"] is None

--- a/tests/test_mtlx_scalars.py
+++ b/tests/test_mtlx_scalars.py
@@ -245,12 +245,12 @@ def test_lossy_coat_inputs_logged_and_dropped(caplog):
     # noise, not signal. Capture at DEBUG so the test still observes.
     with caplog.at_level(logging.DEBUG, logger="mat-vis-baker.gpuopen-scalars"):
         pbr = parse_standard_surface_scalars(FIXTURE_LOSSY_COAT, material_id="m-coat")
-    # Coat inputs have no PBRBlock home — verify they are NOT smuggled
-    # into any field.
+    # Coat amount has no PBRBlock home — verify NOT smuggled into any field.
     assert pbr.color_rgb == [0.5, 0.5, 0.5]
     msgs = [rec.message for rec in caplog.records]
     assert any("coat=0.8" in m for m in msgs)
-    assert any("coat_roughness=0.1" in m for m in msgs)
+    # coat_roughness is now extracted into pbr.clearcoat_roughness (#340).
+    assert pbr.clearcoat_roughness == 0.1
     # sheen=0.0 should NOT be logged (zero is not lossy).
     assert not any("sheen=" in m for m in msgs)
 

--- a/tests/test_mtlx_scalars_pbr_coverage.py
+++ b/tests/test_mtlx_scalars_pbr_coverage.py
@@ -1,0 +1,165 @@
+"""Bake-side extraction tests for #340 — full MeshPhysicalMaterial PBR coverage.
+
+5 new scalar fields + 1 conditional + 1 color3:
+- coat_roughness         → clearcoat_roughness (float)
+- specular               → specular_intensity (float)
+- specular_color         → specular_color (color3, linear)
+- transmission_dispersion → dispersion (float)
+- transmission_depth     → thickness (float, only when transmission > 0)
+
+All extracted from <standard_surface> direct `value=` attributes.
+Survey of 454 gpuopen materials confirms each input is authored
+~80-95% of the time; specular_color is 94% non-default.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mat_vis_baker._mtlx_scalars import parse_standard_surface_scalars
+
+
+def _wrap(*surface_inputs: str) -> str:
+    """Minimal materialx with a <standard_surface> shader carrying the
+    given <input> children verbatim."""
+    body = "\n    ".join(surface_inputs)
+    return f"""<?xml version="1.0"?>
+<materialx version="1.38">
+  <standard_surface name="SR_T" type="surfaceshader">
+    {body}
+  </standard_surface>
+  <surfacematerial name="T" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_T"/>
+  </surfacematerial>
+</materialx>
+"""
+
+
+class TestSpecularIntensity:
+    def test_specular_authored_non_default(self) -> None:
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="specular" type="float" value="0.6"/>')
+        )
+        assert pbr.specular_intensity == pytest.approx(0.6)
+
+    def test_specular_default_extracted_too(self) -> None:
+        # Survey shows 425/454 use default 1.0 — extracting it confirms
+        # provenance even at default. Adapter suppresses spec defaults.
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="specular" type="float" value="1.0"/>')
+        )
+        assert pbr.specular_intensity == pytest.approx(1.0)
+
+    def test_specular_unset_stays_none(self) -> None:
+        pbr = parse_standard_surface_scalars(_wrap())
+        assert pbr.specular_intensity is None
+
+
+class TestSpecularColor:
+    def test_specular_color_authored_tinted(self) -> None:
+        # 428/454 corpus materials author with non-white tints.
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="specular_color" type="color3" value="0.95, 0.64, 0.54"/>')
+        )
+        assert pbr.specular_color == pytest.approx([0.95, 0.64, 0.54])
+
+    def test_specular_color_default_white(self) -> None:
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="specular_color" type="color3" value="1, 1, 1"/>')
+        )
+        assert pbr.specular_color == pytest.approx([1.0, 1.0, 1.0])
+
+    def test_specular_color_unset_stays_none(self) -> None:
+        pbr = parse_standard_surface_scalars(_wrap())
+        assert pbr.specular_color is None
+
+
+class TestClearcoatRoughness:
+    def test_coat_roughness_authored_non_default(self) -> None:
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="coat_roughness" type="float" value="0.35"/>')
+        )
+        assert pbr.clearcoat_roughness == pytest.approx(0.35)
+
+    def test_coat_roughness_default_extracted(self) -> None:
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="coat_roughness" type="float" value="0.1"/>')
+        )
+        assert pbr.clearcoat_roughness == pytest.approx(0.1)
+
+
+class TestDispersion:
+    def test_dispersion_authored(self) -> None:
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="transmission_dispersion" type="float" value="0.25"/>')
+        )
+        assert pbr.dispersion == pytest.approx(0.25)
+
+    def test_dispersion_default_zero(self) -> None:
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="transmission_dispersion" type="float" value="0.0"/>')
+        )
+        assert pbr.dispersion == pytest.approx(0.0)
+
+
+class TestThickness:
+    def test_thickness_extracted_only_when_transmission_nonzero(self) -> None:
+        # Real gpuopen shape: transparent solids author transmission >0
+        # AND transmission_depth > 0. The depth without transmission is
+        # meaningless (the material is opaque) — emit None.
+        pbr_transparent = parse_standard_surface_scalars(
+            _wrap(
+                '<input name="transmission" type="float" value="0.8"/>',
+                '<input name="transmission_depth" type="float" value="10.0"/>',
+            )
+        )
+        assert pbr_transparent.thickness == pytest.approx(10.0)
+        assert pbr_transparent.transmission == pytest.approx(0.8)
+
+    def test_thickness_none_when_transmission_zero(self) -> None:
+        # 446/454 materials have transmission=0; their transmission_depth
+        # value (often >0 for SSS scaffolding) is not meaningful as a
+        # KHR_materials_volume thicknessFactor.
+        pbr_opaque = parse_standard_surface_scalars(
+            _wrap(
+                '<input name="transmission" type="float" value="0.0"/>',
+                '<input name="transmission_depth" type="float" value="10.0"/>',
+            )
+        )
+        assert pbr_opaque.thickness is None
+
+    def test_thickness_none_when_transmission_unset(self) -> None:
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="transmission_depth" type="float" value="10.0"/>')
+        )
+        assert pbr.thickness is None
+
+
+class TestPBRBlockFieldsExist:
+    def test_new_fields_default_to_none(self) -> None:
+        from mat_vis_baker.common import PBRBlock
+
+        pbr = PBRBlock()
+        for fname in (
+            "clearcoat_roughness",
+            "specular_intensity",
+            "specular_color",
+            "thickness",
+            "dispersion",
+        ):
+            assert getattr(pbr, fname) is None, f"{fname} should default to None"
+
+    def test_fields_are_settable(self) -> None:
+        from mat_vis_baker.common import PBRBlock
+
+        pbr = PBRBlock()
+        pbr.clearcoat_roughness = 0.2
+        pbr.specular_intensity = 0.8
+        pbr.specular_color = [0.95, 0.5, 0.3]
+        pbr.thickness = 5.0
+        pbr.dispersion = 0.1
+        assert pbr.clearcoat_roughness == 0.2
+        assert pbr.specular_intensity == 0.8
+        assert pbr.specular_color == [0.95, 0.5, 0.3]
+        assert pbr.thickness == 5.0
+        assert pbr.dispersion == 0.1


### PR DESCRIPTION
## Summary

Closes #340. Coordinates with #346 (#350) for a single re-bake cycle.

Six fields land — five scalars + one texture — covering the gap between Phase 1's PBR contract (5 scalars) and the full `MeshPhysicalMaterial` surface area authored by gpuopen and downstream consumers (build123d / threejs-materials).

| Field | Three.js | glTF | MTLX 1.38 source |
|---|---|---|---|
| `clearcoatRoughness` | `material.clearcoatRoughness` | `KHR_materials_clearcoat.clearcoatRoughnessFactor` | `<standard_surface>.coat_roughness` |
| `specularColor` | `material.specularColor` (sRGB hex) | `KHR_materials_specular.specularColorFactor` (linear) | `<standard_surface>.specular_color` |
| `specularIntensity` | `material.specularIntensity` | `KHR_materials_specular.specularFactor` | `<standard_surface>.specular` |
| `thickness` | `material.thickness` | `KHR_materials_volume.thicknessFactor` | `<standard_surface>.transmission_depth` (only when transmission > 0) |
| `dispersion` | `material.dispersion` | `KHR_materials_dispersion.dispersion` | `<standard_surface>.transmission_dispersion` |
| `opacityMap` | `material.alphaMap` + `transparent=true` | `alphaMode="MASK"` + `alphaCutoff=0.5` + `baseColorTexture` alpha-packed when Pillow available | `<image GLSLFX_usage="opacity">` linked from `<standard_surface>.opacity` |

`displacementScale` was dropped per the spike consolidation — 0/454 corpus support, no standard glTF route, scalar without a paired `displacementMap` is dead weight.

## Empirical survey (gerchowl/mat-vis-tst @ v2026.04.3 — 454 materials)

- `specular_color != white`: **428/454 (94%)** — the biggest underestimated win
- `transmission_depth > 0` with `transmission > 0`: 8/454
- `transmission_dispersion > 0`: 3/454
- `specular != 1.0`: 29/454
- `coat_roughness != 0.1` (default): 2/454
- `<image GLSLFX_usage="opacity">`: present on Perforated Metal + similar perforated/cutout patterns

## Architecture (per ADR-0013 + spike consolidation)

- **Additive only** — `PBRBlock` gains 5 `field=None` defaults. No schema bump. Same shape as #316's `is_conductor`/`metalness_mean`/`metalness_source`.
- **0.7.x minor** — no breaking changes; existing keys / defaults unchanged.
- **Inputs snake_case, outputs native-spec** — `specular_color_linear`/`specular_color_rgba` aliases for the colorspace-asymmetry trap (Three.js sRGB vs. glTF linear). Mirrors `_resolve_base_color`.
- **Default suppression** — KHR extensions skipped when at spec defaults (`specularFactor=1.0`, `clearcoatRoughnessFactor=0.0`, `specularColorFactor=[1,1,1]`, `dispersion=0`). Mirrors existing `KHR_materials_ior` / `_transmission` pattern.

## Test plan

- [ ] CI green (test-fast + full pytest + ruff)
- [ ] 15 baker extraction tests + 33 adapter passthrough tests + 6 opacityMap tests (1 skipped without Pillow)
- [ ] 577 baker + 388 client tests pass full suite
- [ ] Substrate spot-test on `gerchowl/mat-vis-tst` once #350 (Phase 1.5 walker) lands — single coordinated bake covers both PRs
- [ ] py-mat #100 adoption guide comment after PR merges

## Files

- `src/mat_vis_baker/common.py` — 5 new `PBRBlock` fields
- `src/mat_vis_baker/_mtlx_scalars.py` — `_FLOAT_INPUTS` + `_COLOR3_INPUTS` + conditional `thickness` extraction
- `clients/python/src/mat_vis_client/schema.py` — `Channel.OPACITY` + ChannelSpec
- `clients/python/src/mat_vis_client/adapters.py` — `_resolve_specular_color`, KHR routing in `to_gltf`, `_pack_base_color_with_alpha` for opacity packing