### PR TITLE
bugfix(ci): bake matrix silently expanded to 0 iterations post-#351 (closes #353)

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -241,7 +241,15 @@ jobs:
           # --all-extras`); only this plan job invokes the CLI directly.
           payload=$(uv run --with '.[baker]' mat-vis-baker matrix list "$LINE" "${extra[@]}")
           echo "matrix payload: $payload"
-          cells=$(printf '%s' "$payload" | python3 -c 'import json,sys; print(json.dumps(json.load(sys.stdin)["cells"]))')
+          # mat-vis#353: post-#351 the matrix CLI emits DAG-shaped cells
+          # with `produces` / `inputs` keys alongside `source` / `tier`.
+          # GitHub Actions silently produces zero matrix iterations when
+          # any cell entry carries a key named `inputs` (collides with the
+          # workflow_dispatch `inputs` context). Project the cells down to
+          # the matrix-relevant subset (source, tier) before writing to
+          # GITHUB_OUTPUT — schema additions upstream don't leak into the
+          # matrix shape consumed by the bake job.
+          cells=$(printf '%s' "$payload" | python3 -c 'import json,sys; cells=json.load(sys.stdin)["cells"]; print(json.dumps([{"source":c["source"],"tier":c["tier"]} for c in cells]))')
           if [ "$cells" = "[]" ]; then
             echo "::error::no cells matched line=$LINE filter-source=${FILTER_SOURCE:-} filter-tier=${FILTER_TIER:-}"
             exit 1


### PR DESCRIPTION
## Summary

Closes #353. Spot-test bakes since #351 merged silently expanded to zero matrix jobs because the new DAG-shaped cells carry an `inputs: []` key that collides with GitHub Actions' top-level `inputs` context.

Project the matrix-consumed cells down to `{source, tier}` in the plan job's bash. Decouples the matrix shape from any future DAG-schema additions upstream.

## Test plan

- [ ] CI green
- [ ] Re-dispatch the #340/#346 spot-test bake on `gerchowl/mat-vis-tst` once this lands; expect a non-zero matrix expansion this time