### PR TITLE
bugfix(ci): bake matrix silently skipped via preflight cascade (closes #356)

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -259,6 +259,14 @@ jobs:
 
   bake:
     needs: plan
+    # mat-vis#356: GH Actions auto-cascades a `skipped` ancestor through
+    # the dependency chain unless every downstream job explicitly opts
+    # out via `if:`. The plan job has its own override; bake + validate-
+    # release need theirs too. Without this, dispatches with allow-prod=
+    # false (preflight skipped) silently skip the entire bake matrix.
+    if: |
+      always() &&
+      needs.plan.result == 'success'
     name: hf-bake ${{ matrix.cell.source }} ${{ matrix.cell.tier }}
     runs-on: ubuntu-latest
     # GH-hosted runners hard-cap at 360 min; 350 leaves headroom for
@@ -379,7 +387,12 @@ jobs:
   validate:
     name: validate-release ${{ inputs.release-tag }}
     needs: bake
-    if: inputs.dry-run != true
+    # mat-vis#356: skip-cascade through preflight/plan/bake; require
+    # explicit always() so the dry-run check actually evaluates.
+    if: |
+      always() &&
+      needs.bake.result == 'success' &&
+      inputs.dry-run != true
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:


### PR DESCRIPTION
## Summary

Closes #356. Companion to #354 — same symptom (silent skipped bake matrix on tst dispatches), different root cause.

After #348 introduced the `preflight` job (skipped when `allow-prod=false`, the default for tst dispatches), GitHub Actions' implicit skip-cascade silently zeroed out the bake + validate-release jobs. The plan job has its own `always() && (preflight.result == success || skipped)` override; bake and validate-release didn't, so the cascade won.

Add the same explicit override pattern to bake and validate-release.

## Test plan

- [ ] CI green
- [ ] Re-dispatch the #340/#346 spot-test bake on `gerchowl/mat-vis-tst` once this lands