### PR TITLE
feat(client): unify search/index/asset via Match dict-subclass (closes #359)

### DIFF
--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -141,7 +141,11 @@ class MatVisError(Exception):
 
 
 class NotFoundError(MatVisError):
-    """A key was not found in a mat-vis registry."""
+    """A key was not found in a mat-vis registry.
+
+    #359: ``candidates`` carries top-3 fuzzy did-you-mean suggestions
+    auto-computed from ``available`` when not provided explicitly.
+    """
 
     kind: str = "item"
 
@@ -150,13 +154,23 @@ class NotFoundError(MatVisError):
         key: str,
         available: list[str] | None = None,
         context: str = "",
+        candidates: list[str] | None = None,
     ) -> None:
+        import difflib as _difflib
+
         self.key = key
         self.available = list(available or [])
         self.context = context
+        if candidates is None and available:
+            candidates = _difflib.get_close_matches(key, list(available), n=3, cutoff=0.6)
+        self.candidates = list(candidates or [])
         where = f" in {context}" if context else ""
-        hint = f". Available: {self.available}" if self.available else ""
-        super().__init__(f"{self.kind} {key!r} not found{where}{hint}")
+        msg_bits = [f"{self.kind} {key!r} not found{where}"]
+        if self.candidates:
+            msg_bits.append(f"Did you mean: {', '.join(repr(c) for c in self.candidates)}?")
+        if self.available:
+            msg_bits.append(f"Available: {self.available}")
+        super().__init__(". ".join(msg_bits))
 
 
 class MaterialNotFoundError(NotFoundError):
@@ -893,46 +907,47 @@ class MatVisClient:
         self,
         category: str | None = None,
         *,
+        query: str | None = None,
+        name: str | None = None,
+        tag: str | None = None,
+        is_conductor: bool | None = None,
+        has_map: str | None = None,
+        transmission_range: tuple[float, float] | None = None,
+        dispersion_range: tuple[float, float] | None = None,
         roughness: float | None = None,
         metalness: float | None = None,
         roughness_range: tuple[float, float] | None = None,
         metalness_range: tuple[float, float] | None = None,
         source: str | None = None,
         tier: str = "1k",
-        tag: str | None = None,
-        score: bool = False,
+        release: str | None = None,
+        distance: bool = False,
         limit: int | None = None,
     ) -> list[dict]:
-        """Search materials by category and scalar ranges.
+        """Discover materials. See packaged-client docstring for full semantics.
 
-        Fetches index JSON for the given source (or all sources for the
-        tier) and filters locally. Returns matching index entries.
-
-        Args:
-            category: Filter by material category (e.g. "metal", "wood").
-            roughness: Scalar shorthand. Matches within ± ``_SCALAR_WIDEN``.
-                Mutually exclusive with ``roughness_range``.
-            metalness: Scalar shorthand. Same semantics as ``roughness``.
-            roughness_range: (min, max) roughness filter, inclusive.
-            metalness_range: (min, max) metalness filter, inclusive.
-            source: Limit search to one source. If None, searches all
-                    sources available for the given tier.
-            tier: Only return materials that have this tier available.
-            tag: Optional release tag override (see .at()).
-            score: When True and a scalar shorthand is passed, attach a
-                ``score`` field (absolute distance) and sort ascending.
-            limit: Cap the returned list length.
+        Standalone keeps the dict return shape (no Match class) — Match
+        is a packaged-only convenience; standalone consumers don't have
+        the import surface for it. Filter parity matches the packaged
+        client (#359).
         """
-        if tag is not None and tag != self._tag:
-            return self.at(tag).search(
+        if release is not None and release != self._tag:
+            return self.at(release).search(
                 category,
+                query=query,
+                name=name,
+                tag=tag,
+                is_conductor=is_conductor,
+                has_map=has_map,
+                transmission_range=transmission_range,
+                dispersion_range=dispersion_range,
                 roughness=roughness,
                 metalness=metalness,
                 roughness_range=roughness_range,
                 metalness_range=metalness_range,
                 source=source,
                 tier=tier,
-                score=score,
+                distance=distance,
                 limit=limit,
             )
         # Scalar + range on the same dimension is ambiguous — reject.
@@ -954,8 +969,6 @@ class MatVisClient:
         if category:
             valid = self.categories()  # discovered from manifest
             if valid and category not in valid:
-                # Soft-warn rather than raise — the honest answer to "find
-                # materials in a category that has none" is an empty list.
                 log.warning(
                     "search: category %r not in manifest %s; returning empty",
                     category,
@@ -964,6 +977,8 @@ class MatVisClient:
                 return []
 
         sources = [source] if source else self.sources(tier)
+        name_q = name.casefold() if name else None
+        tag_q = tag.casefold() if tag else None
         results: list[dict] = []
 
         for src in sources:
@@ -972,29 +987,59 @@ class MatVisClient:
                 pbr = mv.get("pbr") or {}
                 if category and mv.get("category") != category:
                     continue
+                if name_q and name_q not in (mv.get("name") or "").casefold():
+                    continue
+                if tag_q is not None:
+                    tags = mv.get("tags") or []
+                    if not any(tag_q in (t or "").casefold() for t in tags):
+                        continue
+                if is_conductor is not None and pbr.get("is_conductor") != is_conductor:
+                    continue
+                if has_map is not None and has_map not in (entry.get("maps") or []):
+                    continue
+                if transmission_range is not None and not _in_range(
+                    pbr.get("transmission"), *transmission_range
+                ):
+                    continue
+                if dispersion_range is not None and not _in_range(
+                    pbr.get("dispersion"), *dispersion_range
+                ):
+                    continue
                 if roughness_range and not _in_range(pbr.get("roughness"), *roughness_range):
                     continue
                 if metalness_range and not _in_range(pbr.get("metalness"), *metalness_range):
                     continue
-                # Scalar-only entries (e.g. physicallybased) advertise no
-                # textures — treat missing/empty ``available_tiers`` as
-                # tier-independent so they pass any tier filter (#167).
-                # Textured entries still get gated to the requested tier.
                 entry_tiers = entry.get("available_tiers")
                 if entry_tiers and tier not in entry_tiers:
                     continue
                 results.append(entry)
 
-        if score and (roughness is not None or metalness is not None):
+        if query:
+            # Standalone: pure-Python token-AND substring; no rapidfuzz
+            # path (the standalone is intentionally zero-dep). Stable
+            # id-sort within matched set.
+            tokens = [t.casefold() for t in query.split() if t]
+            filtered = []
+            for r in results:
+                mv = r.get("mat_vis") or {}
+                n = (mv.get("name") or "").casefold()
+                tg = " ".join((t or "").casefold() for t in (mv.get("tags") or []))
+                if all((tok in n) or (tok in tg) for tok in tokens):
+                    filtered.append(r)
+            filtered.sort(key=lambda r: r.get("id", ""))
+            results = filtered
+        elif distance and (roughness is not None or metalness is not None):
             for r in results:
                 pbr = (r.get("mat_vis") or {}).get("pbr") or {}
-                s = 0.0
+                d = 0.0
                 if roughness is not None and pbr.get("roughness") is not None:
-                    s += abs(pbr["roughness"] - roughness)
+                    d += abs(pbr["roughness"] - roughness)
                 if metalness is not None and pbr.get("metalness") is not None:
-                    s += abs(pbr["metalness"] - metalness)
-                r["score"] = s
-            results.sort(key=lambda r: r["score"])
+                    d += abs(pbr["metalness"] - metalness)
+                r["distance"] = d
+            results.sort(key=lambda r: r["distance"])
+        else:
+            results.sort(key=lambda r: r.get("id") or "")
 
         if limit is not None:
             results = results[:limit]
@@ -1179,18 +1224,52 @@ class MatVisClient:
 
     def asset(
         self,
-        source: str,
-        material_id: str,
-        tier: str = "1k",
+        ref=None,
+        material_id: str | None = None,
+        tier: str | None = None,
+        *,
+        source: str | None = None,
+        id: str | None = None,
     ) -> "VisAsset":
-        """Return a :class:`VisAsset` ergonomic wrapper for ``(source, material_id, tier)``.
+        """Return a :class:`VisAsset` for a material. Polymorphic dispatch (#359).
 
-        VisAsset bundles identity, lazy scalars, lazy textures, and adapter
-        methods (``.to_threejs() / .to_gltf() / .to_mtlx()``). Creation is
-        free — no network IO until ``.scalars`` / ``.textures`` / an adapter
-        method is accessed. Mat-vis#93.
+        Three input shapes:
+
+        - ``asset("ambientcg/Rock064")`` — string ``"source/id"`` ref.
+        - ``asset(source="ambientcg", id="Rock064")`` — explicit kwargs.
+        - ``asset("ambientcg", "Rock064", "1k")`` — legacy 3-positional.
+
+        (Standalone has no Match class; that input shape is packaged-only.)
         """
-        return VisAsset(self, source, material_id, tier)
+        s, mid, t = self._resolve_asset_triple(ref, material_id, tier, source, id)
+        return VisAsset(self, s, mid, t)
+
+    def _resolve_asset_triple(
+        self,
+        ref,
+        positional_mid: str | None,
+        positional_tier: str | None,
+        kw_source: str | None,
+        kw_id: str | None,
+    ) -> tuple[str, str, str]:
+        """Resolve polymorphic ``asset()`` input into ``(source, id, tier)``.
+
+        Standalone variant: no Match path (the standalone has no Match
+        class). String-ref / legacy-positional / kwargs only.
+        """
+        if isinstance(ref, str) and positional_mid is None and kw_source is None and kw_id is None:
+            if "/" not in ref:
+                raise ValueError(f"asset() string ref must be 'source/id', got {ref!r}")
+            s, mid = ref.split("/", 1)
+            return s, mid, positional_tier or "1k"
+        if isinstance(ref, str) and positional_mid is not None:
+            return ref, positional_mid, positional_tier or "1k"
+        if kw_source is not None and kw_id is not None:
+            return kw_source, kw_id, positional_tier or "1k"
+        raise TypeError(
+            "asset() requires a 'source/id' string, (source, id, tier) "
+            "positionals, or source=, id=, tier= kwargs"
+        )
 
     def _scalars_for(self, source: str, material_id: str) -> dict:
         """Look up PBR scalars for a material from the source index.
@@ -2121,28 +2200,39 @@ def get_client() -> MatVisClient:
 def search(
     *,
     category: str | None = None,
+    query: str | None = None,
+    name: str | None = None,
+    tag: str | None = None,
+    is_conductor: bool | None = None,
+    has_map: str | None = None,
+    transmission_range: tuple[float, float] | None = None,
+    dispersion_range: tuple[float, float] | None = None,
     roughness: float | None = None,
     metalness: float | None = None,
     source: str | None = None,
     tier: str = "1k",
-    tag: str | None = None,
+    release: str | None = None,
     limit: int = 20,
 ) -> list[dict]:
-    """Search the mat-vis index by category and scalar similarity.
+    """Standalone module-level search forwarder. See :meth:`MatVisClient.search`.
 
-    Thin forwarder to :meth:`MatVisClient.search` with ``score=True`` —
-    the scoring/sorting + default ``limit=20`` are the only module-level
-    convenience on top of the method. Every other argument is just passed
-    through.
+    Default: ``distance=True`` (scalar-similarity sort) + ``limit=20``.
     """
     return get_client().search(
         category,
+        query=query,
+        name=name,
+        tag=tag,
+        is_conductor=is_conductor,
+        has_map=has_map,
+        transmission_range=transmission_range,
+        dispersion_range=dispersion_range,
         roughness=roughness,
         metalness=metalness,
         source=source,
         tier=tier,
-        tag=tag,
-        score=True,
+        release=release,
+        distance=True,
         limit=limit,
     )
 

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -26,6 +26,11 @@ dependencies = []
 # when both metalness and roughness PNGs are present (it remains a
 # zero-dependency client by default).
 gltf = ["pillow>=10.0"]
+# #359: opt-in fuzzy ranking for ``client.search(query=...)``. Without
+# this extra, ``query=`` falls back to token-AND substring matching
+# (functional but coarser ranking). rapidfuzz is a small compiled wheel
+# (~250KB) — kept opt-in so the default install stays zero-dep.
+search = ["rapidfuzz>=3.0"]
 
 [project.scripts]
 mat-vis-client = "mat_vis_client.client:main"

--- a/clients/python/src/mat_vis_client/__init__.py
+++ b/clients/python/src/mat_vis_client/__init__.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any
 
 from mat_vis_client.adapters import export_mtlx, to_gltf, to_threejs
 from mat_vis_client.asset import VisAsset
@@ -48,11 +47,13 @@ from mat_vis_client.client import (
     __version__,
     _in_range,
 )
+from mat_vis_client.match import Match
 
 __all__ = [
     "AmbiguousMaterialError",
     "ChannelNotFoundError",
     "HTTPFetchError",
+    "Match",
     "MatVisClient",
     "MatVisError",
     "MaterialNotFoundError",
@@ -186,28 +187,41 @@ def get_manifest(release_tag: str | None = None) -> dict:
 def search(
     *,
     category: str | None = None,
+    query: str | None = None,
+    name: str | None = None,
+    tag: str | None = None,
+    is_conductor: bool | None = None,
+    has_map: str | None = None,
+    transmission_range: tuple[float, float] | None = None,
+    dispersion_range: tuple[float, float] | None = None,
     roughness: float | None = None,
     metalness: float | None = None,
     source: str | None = None,
     tier: str = "1k",
-    tag: str | None = None,
+    release: str | None = None,
     limit: int = 20,
-) -> list[dict[str, Any]]:
-    """Search the mat-vis index by category and scalar similarity.
+) -> list[Match]:
+    """Search the mat-vis index. Thin forwarder to :meth:`MatVisClient.search`
+    with ``distance=True`` (scalar-similarity sort) and a default ``limit=20``.
 
-    Thin forwarder to :meth:`MatVisClient.search` with ``score=True`` —
-    the scoring/sorting + default ``limit=20`` are the only module-level
-    convenience on top of the method. Every other argument is just passed
-    through.
+    Every other argument is passed through. See the method for the full
+    filter/query semantics.
     """
     return get_client().search(
         category,
+        query=query,
+        name=name,
+        tag=tag,
+        is_conductor=is_conductor,
+        has_map=has_map,
+        transmission_range=transmission_range,
+        dispersion_range=dispersion_range,
         roughness=roughness,
         metalness=metalness,
         source=source,
         tier=tier,
-        tag=tag,
-        score=True,
+        release=release,
+        distance=True,
         limit=limit,
     )
 

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -38,6 +38,7 @@ from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
+from mat_vis_client.match import Match
 from mat_vis_client.progress import ClientEvent
 
 if TYPE_CHECKING:
@@ -147,6 +148,52 @@ def _fmt_size(n: int) -> str:
 # Default soft cap: 5 GB (configurable via MAT_VIS_CACHE_MAX_SIZE).
 DEFAULT_CACHE_MAX_BYTES = _parse_size(os.environ.get("MAT_VIS_CACHE_MAX_SIZE", "5GB"))
 
+
+def _rank_by_query(matches: list["Match"], query: str) -> list["Match"]:
+    """Rank ``matches`` by fuzzy similarity to ``query``.
+
+    Tokenizes ``query`` on whitespace; tokens AND-narrow (every token
+    must appear in ``name`` or any ``tag``). When ``rapidfuzz`` is
+    installed (``mat-vis-client[search]`` extra), ranking uses
+    ``WRatio`` against ``name`` (weighted ×1.5) and the tag-joined
+    string. Without rapidfuzz, falls back to token-AND substring with
+    a stable id-sort within the matched set.
+    """
+    if not query.strip():
+        return matches
+    tokens = [t.casefold() for t in query.split() if t]
+
+    def _haystack(m: "Match") -> tuple[str, str]:
+        mv = m.mat_vis
+        return (mv.get("name") or "").casefold(), " ".join(
+            (t or "").casefold() for t in (mv.get("tags") or [])
+        )
+
+    # Token-AND prefilter: every token must appear in name OR tags.
+    filtered = []
+    for m in matches:
+        n, tg = _haystack(m)
+        if all((tok in n) or (tok in tg) for tok in tokens):
+            filtered.append(m)
+
+    try:
+        from rapidfuzz import fuzz  # type: ignore[import-not-found]
+    except ImportError:
+        # No fuzz library — stable id-sort within matched set.
+        filtered.sort(key=lambda m: m.id)
+        return filtered
+
+    # Score: max(WRatio(query, name) * 1.5, WRatio(query, tags))
+    scored: list[tuple[float, "Match"]] = []
+    for m in filtered:
+        n, tg = _haystack(m)
+        s_name = fuzz.WRatio(query, n) * 1.5 if n else 0.0
+        s_tags = fuzz.WRatio(query, tg) if tg else 0.0
+        scored.append((max(s_name, s_tags), m))
+    scored.sort(key=lambda pair: (-pair[0], pair[1].id))
+    return [m for _, m in scored]
+
+
 # Previously a hardcoded frozenset of 10 names. The client doesn't need a
 # static enum — categories are discoverable at runtime from rowmap filenames
 # in the release manifest. See MatVisClient.categories(). Kept as a
@@ -177,6 +224,9 @@ class NotFoundError(MatVisError):
 
     - ``key``: the missing name (e.g. ``"Rock999"``)
     - ``available``: sorted list of valid names at this level
+    - ``candidates``: top-3 fuzzy did-you-mean suggestions (#359). Empty
+      when ``available`` is small enough to render directly without
+      ranking, OR when no candidate scores above the cutoff.
     - ``context``: optional path qualifier (e.g. ``"ambientcg/1k"``)
     - ``kind``: class-level label ("material", "source", ...)
     """
@@ -188,13 +238,27 @@ class NotFoundError(MatVisError):
         key: str,
         available: list[str] | None = None,
         context: str = "",
+        candidates: list[str] | None = None,
     ) -> None:
         self.key = key
         self.available = list(available or [])
         self.context = context
+        # #359: did-you-mean suggestions. Computed by callers (typically
+        # via ``difflib.get_close_matches`` or ``rapidfuzz``) so the
+        # exception class stays dependency-free; we just hold the list.
+        # When the caller doesn't compute it, fall back to a small
+        # difflib pass against ``available`` so error messages still
+        # surface likely-typo hints automatically.
+        if candidates is None and available:
+            candidates = difflib.get_close_matches(key, list(available), n=3, cutoff=0.6)
+        self.candidates = list(candidates or [])
         where = f" in {context}" if context else ""
-        hint = f". Available: {self.available}" if self.available else ""
-        super().__init__(f"{self.kind} {key!r} not found{where}{hint}")
+        msg_bits = [f"{self.kind} {key!r} not found{where}"]
+        if self.candidates:
+            msg_bits.append(f"Did you mean: {', '.join(repr(c) for c in self.candidates)}?")
+        if self.available:
+            msg_bits.append(f"Available: {self.available}")
+        super().__init__(". ".join(msg_bits))
 
 
 class MaterialNotFoundError(NotFoundError):
@@ -1280,8 +1344,8 @@ class MatVisClient:
             return entry
         return {k: v for k, v in entry.items() if k != "upstream"}
 
-    def index(self, source: str) -> list[dict]:
-        """Fetch and cache the per-source catalog JSON.
+    def index(self, source: str) -> list[Match]:
+        """Fetch and cache the per-source catalog JSON. Returns ``list[Match]``.
 
         v0.6.0: resolves to ``<HF_BASE>/<revision>/<source>.json`` via
         the manifest. No GH-Raw fallback — the catalog lives in the
@@ -1291,8 +1355,12 @@ class MatVisClient:
         every entry — it's the verbatim upstream response, intentionally
         NOT part of the stable query surface. Use :meth:`upstream` to
         access it for a specific material.
+
+        #359: returns ``list[Match]`` (dict-subclass) for shape parity
+        with :meth:`search`. ``isinstance(m, dict)`` stays True so all
+        existing key-access patterns keep working.
         """
-        return [self._strip_upstream(e) for e in self._load_index_raw(source)]
+        return [Match(self._strip_upstream(e)) for e in self._load_index_raw(source)]
 
     def upstream(
         self,
@@ -1339,23 +1407,49 @@ class MatVisClient:
         self,
         category: str | None = None,
         *,
+        # text + structural filters (#359)
+        query: str | None = None,
+        name: str | None = None,
+        tag: str | None = None,
+        is_conductor: bool | None = None,
+        has_map: str | None = None,
+        transmission_range: tuple[float, float] | None = None,
+        dispersion_range: tuple[float, float] | None = None,
+        # scalar filters (existing)
         roughness: float | None = None,
         metalness: float | None = None,
         roughness_range: tuple[float, float] | None = None,
         metalness_range: tuple[float, float] | None = None,
+        # scoping
         source: str | None = None,
         tier: str = "1k",
-        tag: str | None = None,
-        score: bool = False,
+        release: str | None = None,
+        # tuning
+        distance: bool = False,
         limit: int | None = None,
-    ) -> list[dict]:
-        """Search materials by category and scalar ranges.
+    ) -> list[Match]:
+        """Discover materials by text + filters. Returns ``list[Match]``.
 
-        Fetches index JSON for the given source (or all sources for the
-        tier) and filters locally. Returns matching index entries.
+        The single discovery verb on the client (#359). With no ``query=``,
+        results are sorted by id; with ``query=``, ranked by fuzzy
+        similarity (rapidfuzz when ``mat-vis-client[search]`` is installed,
+        token-AND substring fallback otherwise). Structural filters
+        AND-narrow the candidate set first; ``query=`` ranks within.
 
         Args:
             category: Filter by material category (e.g. "metal", "wood").
+            query: Free-text fuzzy match across (name, tags). Tokens
+                AND-narrow; ranking uses rapidfuzz.WRatio with name >
+                tag weighting when the ``[search]`` extra is present.
+            name: Substring on ``mat_vis.name`` (case-insensitive).
+            tag: Substring on any tag in ``mat_vis.tags``.
+            is_conductor: Filter by Phase 1 procedural-PBR conductor
+                stamp (#316). Useful to discriminate procedural-walker
+                metals from convention metals.
+            has_map: Material has this map name in ``maps[]``
+                (e.g. ``"opacity"``, ``"displacement"``, ``"normal"``).
+            transmission_range: (min, max) on ``pbr.transmission`` (#340).
+            dispersion_range: (min, max) on ``pbr.dispersion`` (#340).
             roughness: Scalar shorthand. Matches within ± ``_SCALAR_WIDEN``.
                 Mutually exclusive with ``roughness_range``.
             metalness: Scalar shorthand. Same semantics as ``roughness``.
@@ -1364,21 +1458,30 @@ class MatVisClient:
             source: Limit search to one source. If None, searches all
                     sources available for the given tier.
             tier: Only return materials that have this tier available.
-            tag: Optional release tag override (see .at()).
-            score: When True and a scalar shorthand is passed, attach a
-                ``score`` field (absolute distance) and sort ascending.
+            release: Optional release tag override (see :meth:`.at`).
+                Renamed from ``tag=`` (#359, which now means material-tag).
+            distance: When True and a scalar shorthand is passed, attach
+                a ``"distance"`` field (absolute scalar distance) and
+                sort ascending. Renamed from ``score=`` (#359).
             limit: Cap the returned list length.
         """
-        if tag is not None and tag != self._tag:
-            return self.at(tag).search(
+        if release is not None and release != self._tag:
+            return self.at(release).search(
                 category,
+                query=query,
+                name=name,
+                tag=tag,
+                is_conductor=is_conductor,
+                has_map=has_map,
+                transmission_range=transmission_range,
+                dispersion_range=dispersion_range,
                 roughness=roughness,
                 metalness=metalness,
                 roughness_range=roughness_range,
                 metalness_range=metalness_range,
                 source=source,
                 tier=tier,
-                score=score,
+                distance=distance,
                 limit=limit,
             )
         # Scalar + range on the same dimension is ambiguous — reject.
@@ -1410,13 +1513,39 @@ class MatVisClient:
                 return []
 
         sources = [source] if source else self.sources(tier)
-        results: list[dict] = []
+        name_q = name.casefold() if name else None
+        tag_q = tag.casefold() if tag else None
+        results: list[Match] = []
 
         for src in sources:
             for entry in self.index(src):
                 mv = entry.get("mat_vis") or {}
                 pbr = mv.get("pbr") or {}
                 if category and mv.get("category") != category:
+                    continue
+                # name= substring (case-insensitive on mat_vis.name)
+                if name_q and name_q not in (mv.get("name") or "").casefold():
+                    continue
+                # tag= substring on any tag
+                if tag_q is not None:
+                    tags = mv.get("tags") or []
+                    if not any(tag_q in (t or "").casefold() for t in tags):
+                        continue
+                # is_conductor= exact bool
+                if is_conductor is not None and pbr.get("is_conductor") != is_conductor:
+                    continue
+                # has_map= membership
+                if has_map is not None and has_map not in (entry.get("maps") or []):
+                    continue
+                # transmission_range / dispersion_range — None is excluded
+                # (range filter implies "must have a value to compare")
+                if transmission_range is not None and not _in_range(
+                    pbr.get("transmission"), *transmission_range
+                ):
+                    continue
+                if dispersion_range is not None and not _in_range(
+                    pbr.get("dispersion"), *dispersion_range
+                ):
                     continue
                 if roughness_range and not _in_range(pbr.get("roughness"), *roughness_range):
                     continue
@@ -1425,22 +1554,30 @@ class MatVisClient:
                 # Scalar-only entries (e.g. physicallybased) advertise no
                 # textures — treat missing/empty ``available_tiers`` as
                 # tier-independent so they pass any tier filter (#167).
-                # Textured entries still get gated to the requested tier.
                 entry_tiers = entry.get("available_tiers")
                 if entry_tiers and tier not in entry_tiers:
                     continue
-                results.append(entry)
+                results.append(Match(entry))
 
-        if score and (roughness is not None or metalness is not None):
+        # query= fuzzy text ranking. Structural filters above have already
+        # AND-narrowed; this just sorts within. Pure-Python token-AND
+        # substring fallback when rapidfuzz isn't installed.
+        if query:
+            results = _rank_by_query(results, query)
+        elif distance and (roughness is not None or metalness is not None):
             for r in results:
-                pbr = (r.get("mat_vis") or {}).get("pbr") or {}
-                s = 0.0
+                pbr = r.pbr
+                d = 0.0
                 if roughness is not None and pbr.get("roughness") is not None:
-                    s += abs(pbr["roughness"] - roughness)
+                    d += abs(pbr["roughness"] - roughness)
                 if metalness is not None and pbr.get("metalness") is not None:
-                    s += abs(pbr["metalness"] - metalness)
-                r["score"] = s
-            results.sort(key=lambda r: r["score"])
+                    d += abs(pbr["metalness"] - metalness)
+                r["distance"] = d
+            results.sort(key=lambda r: r["distance"])
+        else:
+            # Stable id-sort default — predictable for both single-source
+            # and multi-source scans.
+            results.sort(key=lambda r: r.id)
 
         if limit is not None:
             results = results[:limit]
@@ -1673,19 +1810,74 @@ class MatVisClient:
 
     def asset(
         self,
-        source: str,
-        material_id: str,
-        tier: str = "1k",
+        ref: "Match | str | None" = None,
+        material_id: str | None = None,
+        tier: str | None = None,
+        *,
+        source: str | None = None,
+        id: str | None = None,
     ) -> "VisAsset":
-        """Return a :class:`VisAsset` ergonomic wrapper for ``(source, material_id, tier)``.
+        """Return a :class:`VisAsset` for a material. Polymorphic dispatch (#359).
+
+        Three input shapes:
+
+        - ``asset(match)`` — a :class:`Match` from ``search()``/``index()``;
+          identity comes from the Match (with ``tier=`` defaulted from its
+          ``available_tiers`` if not given).
+        - ``asset("ambientcg/Rock064")`` — a string ``"source/id"`` ref.
+          Malformed refs raise ``ValueError``.
+        - ``asset(source="ambientcg", id="Rock064")`` — explicit kwargs.
+        - ``asset("ambientcg", "Rock064", "1k")`` — legacy 3-positional
+          form (preserved so existing callers don't break).
 
         VisAsset bundles identity, lazy scalars, lazy textures, and adapter
-        methods (``.to_threejs() / .to_gltf() / .to_mtlx()``) that delegate
-        to the free-function primitive layer in :mod:`mat_vis_client.adapters`.
-        Creation is free — no network IO until ``.scalars`` / ``.textures``
-        / an adapter method is accessed. Mat-vis#93.
+        methods (``.to_threejs() / .to_gltf() / .to_mtlx()``). Creation
+        is free — no network IO until ``.scalars`` / ``.textures`` / an
+        adapter method is accessed. Mat-vis#93.
         """
-        return VisAsset(self, source, material_id, tier)
+        # Resolve the (source, material_id, tier) triple from whichever
+        # input shape the caller used.
+        s, mid, t = self._resolve_asset_triple(ref, material_id, tier, source, id)
+        return VisAsset(self, s, mid, t)
+
+    def _resolve_asset_triple(
+        self,
+        ref: "Match | str | None",
+        positional_mid: str | None,
+        positional_tier: str | None,
+        kw_source: str | None,
+        kw_id: str | None,
+    ) -> tuple[str, str, str]:
+        """Resolve the polymorphic ``asset()`` input into ``(source, id, tier)``.
+
+        Precedence: positional ref > positional source/material_id/tier
+        triple (legacy) > kwargs. Tier defaults to ``"1k"`` when nothing
+        else gives one.
+        """
+        # Match handle path.
+        if isinstance(ref, Match):
+            t = positional_tier or "1k"
+            # Match knows which tiers it's staged at — prefer one of
+            # those when the caller didn't ask for a specific tier.
+            if positional_tier is None and ref.tiers:
+                t = ref.tiers[0] if "1k" not in ref.tiers else "1k"
+            return ref.source, ref.id, t
+        # String ref path (must contain '/').
+        if isinstance(ref, str) and positional_mid is None and kw_source is None and kw_id is None:
+            if "/" not in ref:
+                raise ValueError(f"asset() string ref must be 'source/id', got {ref!r}")
+            s, mid = ref.split("/", 1)
+            return s, mid, positional_tier or "1k"
+        # Legacy 3-positional path: ``asset("source", "id", "1k")``.
+        if isinstance(ref, str) and positional_mid is not None:
+            return ref, positional_mid, positional_tier or "1k"
+        # Pure-kwarg path.
+        if kw_source is not None and kw_id is not None:
+            return kw_source, kw_id, positional_tier or "1k"
+        raise TypeError(
+            "asset() requires a Match, a 'source/id' string, "
+            "(source, id, tier) positionals, or source=, id=, tier= kwargs"
+        )
 
     def _scalars_for(self, source: str, material_id: str) -> dict:
         """Look up PBR scalars for a material from the source index.

--- a/clients/python/src/mat_vis_client/match.py
+++ b/clients/python/src/mat_vis_client/match.py
@@ -1,0 +1,130 @@
+"""``Match`` — the unified return type for ``search()`` and ``index()`` (#359).
+
+A dict-subclass: every existing ``entry["mat_vis"]["pbr"][...]`` access keeps
+working, ``isinstance(m, dict)`` stays True. The class adds:
+
+- A human-friendly ``__str__`` (one-line summary, not the raw dict dump).
+- Stable identity properties: ``id``, ``source``, ``ref`` (the ``"source/id"``
+  string handle for ``client.asset(ref)``).
+- Namespace pointers: ``mat_vis``, ``pbr``, ``physical``, ``attribution``,
+  ``dates``, ``upstream``, ``maps``, ``tiers``.
+
+The properties are deliberately a *small* surface — only identity and
+namespace pointers. No PBR field accessors (``m.roughness``, ``m.metalness``,
+etc.) because those would duplicate the substrate shape and bind ``Match``
+to PBR field churn (#316 + #340 added 8 fields in two months). Use
+``m.pbr["roughness"]`` for the actual scalars; the substrate dict shape is
+the source of truth.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class Match(dict):
+    """Substrate Layer-1 entry with smart presentation + identity props.
+
+    Inherits from ``dict``; all existing key-access patterns work. Adds
+    convenience properties for the *common* identity + namespace cases.
+    """
+
+    # ── identity ─────────────────────────────────────────────────
+
+    @property
+    def id(self) -> str:
+        return self.get("id", "")
+
+    @property
+    def source(self) -> str:
+        return self.get("source", "")
+
+    @property
+    def ref(self) -> str:
+        """Globally-unique fetch handle: ``"<source>/<id>"``.
+
+        Pass directly to :meth:`MatVisClient.asset` — accepts this string
+        form alongside the ``Match`` itself and explicit kwargs.
+        """
+        return f"{self.source}/{self.id}"
+
+    # ── tier coverage ────────────────────────────────────────────
+
+    @property
+    def tiers(self) -> list[str]:
+        """The tiers this material is staged at (``available_tiers``)."""
+        v = self.get("available_tiers")
+        return list(v) if v else []
+
+    # ── namespace pointers ───────────────────────────────────────
+    #
+    # These return the live nested dicts; mutation is the caller's
+    # problem (same as the existing ``entry["mat_vis"][...]`` contract).
+    # Each returns ``{}`` when the namespace is absent so chained access
+    # doesn't crash on partial entries (e.g. failed records).
+
+    @property
+    def mat_vis(self) -> dict[str, Any]:
+        return self.get("mat_vis") or {}
+
+    @property
+    def pbr(self) -> dict[str, Any]:
+        return self.mat_vis.get("pbr") or {}
+
+    @property
+    def physical(self) -> dict[str, Any]:
+        return self.mat_vis.get("physical") or {}
+
+    @property
+    def attribution(self) -> dict[str, Any]:
+        return self.mat_vis.get("attribution") or {}
+
+    @property
+    def dates(self) -> dict[str, Any]:
+        return self.mat_vis.get("dates") or {}
+
+    @property
+    def upstream(self) -> dict[str, Any] | None:
+        """Verbatim Layer-2 mirror (ADR-0011) — None when absent.
+
+        Unlike the other pointers (which return ``{}`` for missing
+        namespaces), ``upstream`` returns ``None`` because the *absence*
+        of an upstream block is itself meaningful: pre-Phase-C entries
+        and stripped views (default for :meth:`MatVisClient.search` /
+        :meth:`MatVisClient.index`) just don't have it.
+        """
+        v = self.get("upstream")
+        return v if isinstance(v, dict) else None
+
+    @property
+    def maps(self) -> list[str]:
+        v = self.get("maps")
+        return list(v) if v else []
+
+    # ── presentation ─────────────────────────────────────────────
+
+    def __str__(self) -> str:
+        """One-line human summary — ``ref + category + scalars + tiers``.
+
+        Example: ``ambientcg/Brass001  metal  r=0.10 m=1.00  tiers=[1k,2k]``
+
+        Falls back gracefully when fields are missing (failed records,
+        partial entries).
+        """
+        cat = self.mat_vis.get("category") or "?"
+        pbr = self.pbr
+        r = pbr.get("roughness")
+        m = pbr.get("metalness")
+
+        bits = [self.ref, cat]
+        if r is not None or m is not None:
+            r_str = f"r={r:.2f}" if r is not None else "r=?"
+            m_str = f"m={m:.2f}" if m is not None else "m=?"
+            bits.append(f"{r_str} {m_str}")
+        if self.tiers:
+            bits.append(f"tiers=[{','.join(self.tiers)}]")
+        return "  ".join(bits)
+
+    def __repr__(self) -> str:
+        # Distinct from dict's repr so REPL output stays tight.
+        return f"Match({self.ref!r})"

--- a/clients/python/tests/test_match_search_unified.py
+++ b/clients/python/tests/test_match_search_unified.py
@@ -1,0 +1,540 @@
+"""Match dict-subclass + unified search/asset surface (#359).
+
+The contract:
+
+- ``Match`` is a dict-subclass with smart ``__str__`` and stable identity
+  + namespace properties. ``isinstance(m, dict)`` stays True so all existing
+  ``entry["mat_vis"]["pbr"]["..."]`` access keeps working.
+- ``client.search()`` returns ``list[Match]``. New filters: ``query=`` (fuzzy
+  text), ``name=`` (substring), ``tag=`` (material-tag substring),
+  ``is_conductor=``, ``has_map=``, ``transmission_range=``, ``dispersion_range=``.
+- ``score=`` → ``distance=`` (hard rename, no alias).
+- ``client.index()`` returns ``list[Match]`` (consistent with search()).
+- ``client.asset()`` is polymorphic — accepts a ``Match``, a ``"source/id"``
+  string ref, or explicit ``source=, id=, tier=`` kwargs.
+- ``materials()`` is unchanged (returns ``list[str]``, protects bernhard's
+  downstream tests).
+- ``SourceNotFoundError`` gains fuzzy did-you-mean for typos like
+  ``ambient_cg`` → ``ambientcg``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from mat_vis_client import MatVisClient
+
+
+# ── Test fixtures ──────────────────────────────────────────────
+
+
+def _entry(
+    mid: str,
+    *,
+    name: str | None = None,
+    cat: str = "stone",
+    r: float | None = 0.5,
+    m: float | None = 0.0,
+    tags: list[str] | None = None,
+    is_conductor: bool | None = None,
+    transmission: float | None = None,
+    dispersion: float | None = None,
+    tiers: list[str] | None = None,
+    maps: list[str] | None = None,
+    source: str = "ambientcg",
+) -> dict:
+    return {
+        "id": mid,
+        "source": source,
+        "mat_vis": {
+            "name": name or mid,
+            "category": cat,
+            "tags": tags or [],
+            "description": None,
+            "physical": {"dimensions_m": None, "max_resolution_px": None},
+            "pbr": {
+                "color_rgb": None,
+                "roughness": r,
+                "metalness": m,
+                "ior": None,
+                "specular_f0": None,
+                "transmission": transmission,
+                "complex_ior": None,
+                "is_conductor": is_conductor,
+                "metalness_mean": None,
+                "metalness_source": None,
+                "clearcoat_roughness": None,
+                "specular_intensity": None,
+                "specular_color": None,
+                "thickness": None,
+                "dispersion": dispersion,
+            },
+            "attribution": {
+                "authors": [],
+                "license_spdx": "CC0-1.0",
+                "source_url": "",
+            },
+            "dates": {"published": None, "updated": None},
+            "upstream_id": mid,
+        },
+        "available_tiers": tiers if tiers is not None else ["1k"],
+        "maps": maps or ["color"],
+    }
+
+
+CORPUS = [
+    _entry("Rock064", cat="stone", r=0.78, m=0.0, tags=["rock", "rough"]),
+    _entry("Brass001", cat="metal", r=0.10, m=1.0, tags=["brass", "polished"], is_conductor=True),
+    _entry(
+        "BrassRusted",
+        name="Brass Rusted",
+        cat="metal",
+        r=0.45,
+        m=0.9,
+        tags=["brass", "rusted"],
+        is_conductor=True,
+    ),
+    _entry(
+        "Glass001",
+        cat="glass",
+        r=0.0,
+        m=0.0,
+        transmission=1.0,
+        dispersion=0.05,
+        maps=["color", "opacity"],
+    ),
+    _entry("Wood002", cat="wood", r=0.7, m=0.0, tags=["oak"]),
+]
+
+
+def _patch_search_deps(c: MatVisClient, corpus: list[dict] = CORPUS):
+    """Stack the three patches search() needs: sources(), index(), categories()."""
+    cats = frozenset(e["mat_vis"]["category"] for e in corpus)
+    return (
+        patch.object(c, "sources", return_value=["ambientcg"]),
+        patch.object(c, "index", return_value=corpus),
+        patch.object(c, "categories", return_value=cats),
+    )
+
+
+# ── Match class ────────────────────────────────────────────────
+
+
+def test_match_is_dict_subclass():
+    """Match inherits from dict — full subscript access stays."""
+    from mat_vis_client import Match
+
+    m = Match(CORPUS[0])
+    assert isinstance(m, dict)
+    assert isinstance(m, Match)
+    # Existing access pattern keeps working.
+    assert m["mat_vis"]["pbr"]["roughness"] == 0.78
+    assert m["id"] == "Rock064"
+
+
+def test_match_identity_properties():
+    """id / source / ref — the three identity props."""
+    from mat_vis_client import Match
+
+    m = Match(CORPUS[0])
+    assert m.id == "Rock064"
+    assert m.source == "ambientcg"
+    assert m.ref == "ambientcg/Rock064"
+
+
+def test_match_namespace_pointers():
+    """mat_vis / pbr / physical / attribution / dates / maps."""
+    from mat_vis_client import Match
+
+    m = Match(CORPUS[0])
+    assert m.mat_vis is m["mat_vis"]
+    assert m.pbr is m["mat_vis"]["pbr"]
+    assert m.physical is m["mat_vis"]["physical"]
+    assert m.attribution is m["mat_vis"]["attribution"]
+    assert m.dates is m["mat_vis"]["dates"]
+    assert m.maps == ["color"]
+
+
+def test_match_tiers_property():
+    from mat_vis_client import Match
+
+    m = Match(CORPUS[0])
+    assert m.tiers == ["1k"]
+
+
+def test_match_upstream_optional():
+    """upstream prop returns None when block absent (most entries)."""
+    from mat_vis_client import Match
+
+    m = Match(CORPUS[0])
+    assert m.upstream is None
+    with_upstream = dict(CORPUS[0])
+    with_upstream["upstream"] = {"raw": {"foo": "bar"}}
+    m2 = Match(with_upstream)
+    assert m2.upstream == {"raw": {"foo": "bar"}}
+
+
+def test_match_str_includes_ref_and_pbr_summary():
+    """__str__ is a one-line human summary, NOT the full dict dump."""
+    from mat_vis_client import Match
+
+    m = Match(CORPUS[1])  # Brass001
+    s = str(m)
+    # Must include ref (the canonical fetch handle) and a hint of category.
+    assert "ambientcg/Brass001" in s
+    assert "metal" in s
+    # Must NOT be the raw dict dump.
+    assert "{'id':" not in s
+
+
+def test_match_no_pbr_field_properties():
+    """Only identity + namespace pointers are properties.
+
+    No ``m.roughness`` / ``m.metalness`` / ``m.ior`` etc. — those would
+    duplicate substrate shape and bind Match to PBR field churn (#316,
+    #340 added 8 fields in two months). Use ``m.pbr["roughness"]``.
+    """
+    from mat_vis_client import Match
+
+    m = Match(CORPUS[0])
+    assert not hasattr(m, "roughness")
+    assert not hasattr(m, "metalness")
+    assert not hasattr(m, "ior")
+
+
+# ── search() returns list[Match] ───────────────────────────────
+
+
+def test_search_returns_list_of_match():
+    from mat_vis_client import MatVisClient, Match
+
+    c = MatVisClient()
+    p_sources, p_index, p_cats = _patch_search_deps(c)
+    with p_sources, p_index, p_cats:
+        results = c.search(source="ambientcg")
+    assert results, "expected non-empty result for unfiltered source"
+    for r in results:
+        assert isinstance(r, Match)
+        assert isinstance(r, dict)
+
+
+def test_search_no_query_stable_id_sort():
+    """Without query=, results sort by id ascending."""
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    p_sources, p_index, p_cats = _patch_search_deps(c)
+    with p_sources, p_index, p_cats:
+        results = c.search(source="ambientcg")
+    ids = [m.id for m in results]
+    assert ids == sorted(ids)
+
+
+# ── search() new structural filters ────────────────────────────
+
+
+def test_search_filter_by_name_substring():
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    p_sources, p_index, p_cats = _patch_search_deps(c)
+    with p_sources, p_index, p_cats:
+        results = c.search(source="ambientcg", name="brass")
+    ids = {m.id for m in results}
+    assert ids == {"Brass001", "BrassRusted"}
+
+
+def test_search_filter_by_tag_substring():
+    """tag= substring-matches any tag in mat_vis.tags."""
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    p_sources, p_index, p_cats = _patch_search_deps(c)
+    with p_sources, p_index, p_cats:
+        results = c.search(source="ambientcg", tag="rust")
+    ids = {m.id for m in results}
+    assert ids == {"BrassRusted"}
+
+
+# ── tag= ↔ release= rename ─────────────────────────────────────
+
+
+def test_search_release_kwarg_dispatches_to_at():
+    """release= scopes the call to a pinned revision via .at()."""
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+
+    class _FakePinned:
+        calls: list[dict] = []
+
+        def search(self, category=None, **kwargs):
+            _FakePinned.calls.append({"category": category, **kwargs})
+            return []
+
+    with patch.object(c, "at", return_value=_FakePinned()) as p_at:
+        out = c.search(source="ambientcg", release="v2026.04.99")
+    p_at.assert_called_once_with("v2026.04.99")
+    assert out == []
+
+
+def test_search_old_tag_release_override_kwarg_is_gone():
+    """tag= now means material-tag filter, NOT release-tag override.
+
+    Don't silently misroute. The intent is clear: tag is for material
+    tags now; use release= for release-tag scoping.
+    """
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    p_sources, p_index, p_cats = _patch_search_deps(c)
+    sentinel_called = []
+    with p_sources, p_index, p_cats:
+        with patch.object(c, "at", side_effect=lambda *a, **k: sentinel_called.append(a)):
+            results = c.search(source="ambientcg", tag="v2026.04.99")
+    # tag= treated as material-tag substring; no material has that tag → empty.
+    assert results == []
+    assert sentinel_called == []  # .at() was NOT called
+
+
+def test_search_filter_by_is_conductor():
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    p_sources, p_index, p_cats = _patch_search_deps(c)
+    with p_sources, p_index, p_cats:
+        results = c.search(source="ambientcg", is_conductor=True)
+    ids = {m.id for m in results}
+    assert ids == {"Brass001", "BrassRusted"}
+
+
+def test_search_filter_by_has_map():
+    """has_map='opacity' filters to materials whose maps[] includes 'opacity'."""
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    p_sources, p_index, p_cats = _patch_search_deps(c)
+    with p_sources, p_index, p_cats:
+        results = c.search(source="ambientcg", has_map="opacity")
+    ids = {m.id for m in results}
+    assert ids == {"Glass001"}
+
+
+def test_search_filter_by_transmission_range():
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    p_sources, p_index, p_cats = _patch_search_deps(c)
+    with p_sources, p_index, p_cats:
+        results = c.search(source="ambientcg", transmission_range=(0.5, 1.0))
+    ids = {m.id for m in results}
+    assert ids == {"Glass001"}
+
+
+def test_search_filter_by_dispersion_range():
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    p_sources, p_index, p_cats = _patch_search_deps(c)
+    with p_sources, p_index, p_cats:
+        results = c.search(source="ambientcg", dispersion_range=(0.0, 0.1))
+    ids = {m.id for m in results}
+    assert ids == {"Glass001"}
+
+
+# ── search() query= fuzzy text ─────────────────────────────────
+
+
+def test_search_query_substring_fallback():
+    """Without rapidfuzz, query= is a token-AND substring on (name, tags).
+
+    'brass' should match both Brass001 and BrassRusted (name match) and
+    rank by simple substring presence.
+    """
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    p_sources, p_index, p_cats = _patch_search_deps(c)
+    with p_sources, p_index, p_cats:
+        results = c.search(source="ambientcg", query="brass")
+    ids = {m.id for m in results}
+    assert ids == {"Brass001", "BrassRusted"}
+
+
+def test_search_query_token_AND_across_fields():
+    """query='rusted brass' tokens AND-narrow: must appear together."""
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    p_sources, p_index, p_cats = _patch_search_deps(c)
+    with p_sources, p_index, p_cats:
+        results = c.search(source="ambientcg", query="rusted brass")
+    # Only BrassRusted has both tokens (name has 'brass', tag has 'rusted').
+    ids = [m.id for m in results]
+    assert ids == ["BrassRusted"]
+
+
+def test_search_query_with_filters_AND_narrows():
+    """Structural filters AND-narrow before query= ranks within."""
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    p_sources, p_index, p_cats = _patch_search_deps(c)
+    with p_sources, p_index, p_cats:
+        results = c.search(source="ambientcg", category="metal", query="brass")
+    ids = {m.id for m in results}
+    assert ids == {"Brass001", "BrassRusted"}  # Wood002 / Rock064 / Glass001 excluded
+
+
+# ── score → distance rename ────────────────────────────────────
+
+
+def test_search_distance_attaches_when_scalar_passed():
+    """distance=True with a scalar attaches a 'distance' field; sorts ascending."""
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    p_sources, p_index, p_cats = _patch_search_deps(c)
+    with p_sources, p_index, p_cats:
+        results = c.search(source="ambientcg", category="metal", roughness=0.1, distance=True)
+    # Brass001 (0.10) must sort before BrassRusted (0.45) when distance=True.
+    ids = [m.id for m in results]
+    assert ids[0] == "Brass001"
+    for r in results:
+        assert "distance" in r
+
+
+def test_search_score_kwarg_is_gone():
+    """Hard rename: ``score=`` raises TypeError, no alias."""
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    p_sources, p_index, p_cats = _patch_search_deps(c)
+    with p_sources, p_index, p_cats:
+        with pytest.raises(TypeError):
+            c.search(source="ambientcg", roughness=0.5, score=True)
+
+
+# ── index() returns list[Match] ────────────────────────────────
+
+
+def test_index_returns_list_of_match():
+    """index() returns Match objects, just like search()."""
+    from mat_vis_client import MatVisClient, Match
+
+    c = MatVisClient()
+    with patch.object(c, "_load_index_raw", return_value=CORPUS):
+        results = c.index("ambientcg")
+    assert results
+    for r in results:
+        assert isinstance(r, Match)
+
+
+# ── asset() polymorphism ───────────────────────────────────────
+
+
+def test_asset_accepts_match_handle():
+    """asset(match) — Match carries source + id, no kwargs needed."""
+    from mat_vis_client import MatVisClient, Match
+
+    c = MatVisClient()
+    m = Match(CORPUS[0])
+    a = c.asset(m)
+    assert a.source == "ambientcg"
+    assert a.material_id == "Rock064"
+    assert a.tier == "1k"  # default
+
+
+def test_asset_accepts_string_ref():
+    """asset('source/id') — string handle form."""
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    a = c.asset("ambientcg/Rock064")
+    assert a.source == "ambientcg"
+    assert a.material_id == "Rock064"
+
+
+def test_asset_accepts_kwargs():
+    """asset(source=, id=, tier=) — explicit form."""
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    a = c.asset(source="ambientcg", id="Rock064", tier="2k")
+    assert a.source == "ambientcg"
+    assert a.material_id == "Rock064"
+    assert a.tier == "2k"
+
+
+def test_asset_legacy_positional_still_works():
+    """Three-positional form preserved (existing callers don't break)."""
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    a = c.asset("ambientcg", "Rock064", "1k")
+    assert a.source == "ambientcg"
+    assert a.material_id == "Rock064"
+    assert a.tier == "1k"
+
+
+def test_asset_match_with_explicit_tier_overrides_default():
+    """Match handle + explicit tier= kwarg → tier from kwarg wins."""
+    from mat_vis_client import MatVisClient, Match
+
+    c = MatVisClient()
+    m = Match(CORPUS[0])  # tiers=['1k']
+    a = c.asset(m, tier="2k")
+    assert a.tier == "2k"
+
+
+def test_asset_malformed_string_ref_raises_value_error():
+    """'ambientcg-Rock064' (no slash) is a syntax error, not lookup."""
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    with pytest.raises(ValueError, match="source/id"):
+        c.asset("ambientcg-Rock064")
+
+
+# ── source did-you-mean ────────────────────────────────────────
+
+
+def test_source_not_found_includes_did_you_mean():
+    """SourceNotFoundError fuzzy-suggests typos like ambient_cg → ambientcg."""
+    from mat_vis_client import MatVisClient, SourceNotFoundError
+
+    c = MatVisClient()
+    fake_manifest = {
+        "sources": {
+            "ambientcg": {"tiers": {"1k": {}}},
+            "polyhaven": {"tiers": {"1k": {}}},
+            "physicallybased": {"tiers": {"scalar": {}}},
+        }
+    }
+    with patch.object(MatVisClient, "manifest", fake_manifest):
+        with pytest.raises(SourceNotFoundError) as exc_info:
+            c.tiers("ambient_cg")
+    err = exc_info.value
+    assert "ambientcg" in str(err)
+    assert hasattr(err, "candidates")
+    assert "ambientcg" in err.candidates
+
+
+# ── materials() unchanged contract ─────────────────────────────
+
+
+def test_materials_still_returns_list_of_str():
+    """Bernhard's downstream tests rely on list[str]. Unchanged."""
+    from mat_vis_client import MatVisClient
+
+    c = MatVisClient()
+    fake_manifest = {"sources": {"ambientcg": {"tiers": {"1k": {}}}}}
+    with patch.object(MatVisClient, "manifest", fake_manifest):
+        with patch.object(c, "_load_index_raw", return_value=CORPUS):
+            ids = c.materials("ambientcg")
+    assert ids
+    assert all(isinstance(x, str) for x in ids)
+    # IDs only, not refs (source/id) — single-source call, source is implicit.
+    assert "ambientcg/" not in ids[0]

--- a/clients/python/tests/test_search_unified.py
+++ b/clients/python/tests/test_search_unified.py
@@ -111,20 +111,22 @@ def test_method_search_accepts_scalar_metalness():
     assert "Wood002" not in ids
 
 
-def test_method_search_score_option_sorts_by_distance():
-    """search(roughness=0.3, score=True) sorts by |r - 0.3|."""
+def test_method_search_distance_option_sorts_by_distance():
+    """search(roughness=0.3, distance=True) sorts by |r - 0.3| (#359 rename)."""
     from mat_vis_client import MatVisClient
 
     c = MatVisClient()
     with patch.object(c, "sources", return_value=["ambientcg"]):
         with patch.object(c, "index", return_value=MOCK_INDEX):
             with patch.object(c, "categories", return_value=frozenset(["metal", "wood"])):
-                results = c.search(category="metal", roughness=0.3, score=True)
-    # Metal032 (0.3, diff 0) comes before Metal050A (0.5, diff 0.2)
+                results = c.search(category="metal", roughness=0.3, distance=True)
+    # Metal032 (0.3, diff 0) comes before Metal050A (0.5, diff 0.2).
+    # Results are now list[Match] (#359), but the dict-subclass means
+    # ``r["material_id"]`` (the fixture key) still works.
     ids = [r["material_id"] for r in results]
     assert ids[0] == "Metal032"
     for r in results:
-        assert "score" in r
+        assert "distance" in r
 
 
 def test_method_search_rejects_both_scalar_and_range():
@@ -157,9 +159,9 @@ def test_module_search_forwards_to_client_method():
     with patch.object(client2, "sources", return_value=["ambientcg"]):
         with patch.object(client2, "index", return_value=MOCK_INDEX):
             with patch.object(client2, "categories", return_value=frozenset(["metal", "wood"])):
-                method_results = client2.search(category="metal", roughness=0.3, score=True)
+                method_results = client2.search(category="metal", roughness=0.3, distance=True)
 
-    # Module-level is equivalent to method-level with score=True
+    # Module-level is equivalent to method-level with distance=True (#359 rename).
     assert [r["material_id"] for r in mod_results] == [r["material_id"] for r in method_results]
 
 
@@ -288,18 +290,18 @@ def test_standalone_search_scalar_roughness_widens():
     assert "Metal050A" in ids
 
 
-def test_standalone_search_score_sorts_ascending_by_distance():
-    """Standalone: ``search(roughness=0.3, score=True)`` attaches + sorts by distance."""
+def test_standalone_search_distance_sorts_ascending_by_distance():
+    """Standalone: ``search(roughness=0.3, distance=True)`` attaches + sorts (#359)."""
     std = _load_standalone()
     c = std.MatVisClient()
     with patch.object(c, "sources", return_value=["ambientcg"]):
         with patch.object(c, "index", return_value=MOCK_INDEX):
             with patch.object(c, "categories", return_value=frozenset(["metal", "wood"])):
-                results = c.search(category="metal", roughness=0.3, score=True)
+                results = c.search(category="metal", roughness=0.3, distance=True)
     ids = [r["material_id"] for r in results]
     assert ids[0] == "Metal032"  # diff 0 comes first
     for r in results:
-        assert "score" in r
+        assert "distance" in r
 
 
 def test_standalone_search_limit_truncates():
@@ -313,12 +315,8 @@ def test_standalone_search_limit_truncates():
     assert len(results) == 1
 
 
-def test_standalone_search_tag_kwarg_accepted():
-    """Standalone: ``search(tag=...)`` dispatches to a pinned client without TypeError.
-
-    We don't assert on the pinned client's behaviour — only that the call
-    signature accepts the kwarg and forwards it through ``self.at(tag)``.
-    """
+def test_standalone_search_release_kwarg_accepted():
+    """Standalone: ``search(release=...)`` dispatches to a pinned client (#359 rename)."""
     std = _load_standalone()
     c = std.MatVisClient()
 
@@ -330,7 +328,7 @@ def test_standalone_search_tag_kwarg_accepted():
             return []
 
     with patch.object(c, "at", return_value=_FakePinned()):
-        out = c.search(category="metal", tag="v2026.04.1")
+        out = c.search(category="metal", release="v2026.04.1")
     assert out == []
     assert _FakePinned.calls and _FakePinned.calls[0]["category"] == "metal"
 
@@ -343,8 +341,8 @@ def test_standalone_search_rejects_both_scalar_and_range():
         c.search(roughness=0.3, roughness_range=(0.1, 0.5))
 
 
-def test_standalone_module_level_search_forwards_with_score_and_limit():
-    """Standalone's module-level ``search()`` applies score=True + default limit=20."""
+def test_standalone_module_level_search_forwards_with_distance_and_limit():
+    """Standalone's module-level ``search()`` applies distance=True + default limit=20 (#359)."""
     std = _load_standalone()
     # Reset the standalone's own singleton so the patch targets a fresh client.
     std._client = None
@@ -353,7 +351,7 @@ def test_standalone_module_level_search_forwards_with_score_and_limit():
         with patch.object(client, "index", return_value=MOCK_INDEX):
             with patch.object(client, "categories", return_value=frozenset(["metal", "wood"])):
                 mod_results = std.search(category="metal", roughness=0.3)
-    # score=True was applied, so results carry a 'score' field and are sorted.
+    # distance=True is applied, so results carry a 'distance' field and are sorted.
     assert mod_results
-    assert "score" in mod_results[0]
+    assert "distance" in mod_results[0]
     assert mod_results[0]["material_id"] == "Metal032"

--- a/uv.lock
+++ b/uv.lock
@@ -458,8 +458,11 @@ version = "0.6.4"
 source = { editable = "clients/python" }
 
 [package.metadata]
-requires-dist = [{ name = "pillow", marker = "extra == 'gltf'", specifier = ">=10.0" }]
-provides-extras = ["gltf"]
+requires-dist = [
+    { name = "pillow", marker = "extra == 'gltf'", specifier = ">=10.0" },
+    { name = "rapidfuzz", marker = "extra == 'search'", specifier = ">=3.0" },
+]
+provides-extras = ["gltf", "search"]
 
 [[package]]
 name = "materialx"


### PR DESCRIPTION
## Summary

Discovery surface was three return shapes for the same idea (`list[str]` from `materials`, `list[dict]` from `index`, `list[dict]` with different filters from `search`) and a fixed-arity `asset()`. Per #359 user-story redesign, this collapses to one return type, one polymorphic fetch, and reclaims the `tag=` kwarg for material tags.

**Single PR, no deprecation dance** — per the "ship full in one go" rule. `score` → `distance` and release-`tag` → `release` are hard renames with no aliases. The one exception is `materials()`, which stays as `list[str]` sugar to protect Bernhard's downstream tests.

## What's in this PR

### `Match` — dict-subclass return type

```python
class Match(dict):
    @property
    def id(self) -> str: ...
    @property
    def source(self) -> str: ...
    @property
    def ref(self) -> str: ...        # "source/id" — fetch handle
    @property
    def tiers(self) -> list[str]: ...
    # namespace pointers
    @property
    def mat_vis | pbr | physical | attribution | dates | upstream | maps
    def __str__(self) -> str:        # "ambientcg/Brass001  metal  r=0.10 m=1.00  tiers=[1k,2k]"
```

`isinstance(m, dict) is True` — every existing `entry["mat_vis"]["pbr"]["..."]` access keeps working. Properties are deliberately a small surface (only identity + namespace pointers) so Match isn't bound to PBR field churn (#316/#340 added 8 fields in two months).

### `search()` — `list[Match]` + new filters + fuzzy query

```python
client.search(
    query="rusty brass",                 # NEW — fuzzy via rapidfuzz [search] extra
    name="brass",                        # NEW — substring on mat_vis.name
    tag="rusted",                        # NEW — material-tag substring (was: release override)
    is_conductor=True,                   # NEW — #316 procedural-PBR
    has_map="opacity",                   # NEW — #340
    transmission_range=(0.5, 1.0),       # NEW — #340
    dispersion_range=(0.0, 0.3),         # NEW — #340
    distance=True,                       # RENAMED from score=
    release="v2026.04.99",               # RENAMED from tag= (release-override)
    # ...existing scalar/category/source/tier filters preserved
) -> list[Match]
```

Ranking: structural filters AND-narrow first; `query=` ranks within. With the new `mat-vis-client[search]` extra installed, `query=` uses `rapidfuzz.fuzz.WRatio` with name-weighted (×1.5) scoring. Without it, falls back to pure-Python token-AND substring with stable id-sort.

### `index()` — `list[Match]`

Same wrapper as search(). Existing `entry["..."]` access patterns keep working.

### `asset()` — polymorphic dispatch

```python
client.asset(match)                              # Match handle
client.asset("ambientcg/Rock064")                # string ref
client.asset(source="ambientcg", id="Rock064")   # kwargs
client.asset("ambientcg", "Rock064", "1k")       # legacy 3-positional (preserved)
```

Match handles default tier from the Match's `available_tiers` when not given. Malformed string refs raise `ValueError`.

### `materials()` — unchanged

Stays as `list[str]`, single-source. Per "protect known consumers" — Bernhard's tests rely on this shape; "no deprecation dance" doesn't mean breaking known consumers, it means avoiding deprecation flags + alias-version-skew.

### Errors — did-you-mean for `SourceNotFoundError`

`NotFoundError` now carries `candidates` (top-3 fuzzy suggestions auto-computed from `available` via `difflib.get_close_matches`). The material-id path already had this fully; sources/tiers now do too.

```
SourceNotFoundError: source 'ambient_cg' not found.
  Did you mean: 'ambientcg'?
  Available: ['ambientcg', 'gpuopen', 'physicallybased', 'polyhaven']
```

### Standalone parity

`mat_vis_client_standalone.py` mirrors all signature changes (minus the `Match` import, since the standalone is intentionally zero-dep). `tests/test_standalone_drift.py` confirms parity.

### `[search]` extra

```toml
[project.optional-dependencies]
search = ["rapidfuzz>=3.0"]
```

~250KB compiled wheel, opt-in. Default install stays zero-dep; `query=` works without it via the substring fallback.

## Test plan

- [x] 31 new tests in `tests/test_match_search_unified.py` covering Match shape, search filters, fuzzy `query=` (both rapidfuzz path and pure-Python fallback), `distance=` rename, asset() polymorphism, source did-you-mean, materials() unchanged
- [x] 4 existing tests migrated for `score`→`distance` and `tag`→`release` renames
- [x] Full client suite: 442 passed, 29 skipped, 2 xfailed
- [x] Full baker/top-level suite: 604 passed, 16 skipped
- [x] Standalone signature drift test passes
- [x] `[search]` extra: rapidfuzz installs cleanly, fuzzy ranking activates, all 31 new tests still pass

## References

- #359 — search()/index()/asset() unification spike
- #316 — Phase 1 procedural-PBR (`is_conductor`, `metalness_source`)
- #340 — Full MeshPhysicalMaterial PBR coverage (`thickness`, `dispersion`, `has_map="opacity"`)
- #311 — Bernhard's "materials are very much a visual selection" umbrella
- ADR-0011 — Layer-1 stable query surface
- ADR-0013 — adapter input-shape conventions