### PR TITLE
fix(client): scalar-only path — case-insensitive lookup + tier='scalar' sentinel (#368, #370)

### DIFF
--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -1060,6 +1060,10 @@ class MatVisClient:
         Per-file substrate (#186 / ADR-0012): "is this material staged
         for the requested tier?" comes from the v3 catalog entry's
         ``available_tiers`` field, not a separate rowmap.
+
+        Special case ``tier="scalar"`` (mat-vis#370): scalar-only sources
+        carry no texture tiers — ``"scalar"`` is the sentinel, not a
+        missing bake. Skip the ``available_tiers`` check in that case.
         """
         try:
             idx = self.index(source)
@@ -1090,6 +1094,10 @@ class MatVisClient:
                 by_name.append(entry)
 
         def _is_staged(entry: dict) -> bool:
+            # mat-vis#370: tier="scalar" is the scalar-only sentinel —
+            # treat as always-staged.
+            if tier == "scalar":
+                return True
             return tier in (entry.get("available_tiers") or [])
 
         if by_id is not None:
@@ -1279,15 +1287,28 @@ class MatVisClient:
         (``to_threejs`` / ``to_gltf`` / ``to_mtlx``) which still consume
         the hex shape.
 
+        Lookup is name-aware (mat-vis#368): match canonical id exactly,
+        OR casefold-normalized id, OR casefold-normalized
+        ``mat_vis.name``. Substrate stores lowercase ids; callers
+        routinely pass display names like ``"Aluminum"``.
+
         Silent on failure — returns ``{}`` if the index is unavailable or
         the material isn't found.
         """
         scalars: dict = {}
         try:
+            norm_query = self._normalize_name(material_id)
             for entry in self.index(source):
-                if entry["id"] != material_id:
+                entry_id = entry.get("id", "")
+                envelope = entry.get("mat_vis") or {}
+                entry_name = envelope.get("name") or ""
+                if not (
+                    entry_id == material_id
+                    or (entry_id and self._normalize_name(entry_id) == norm_query)
+                    or (entry_name and self._normalize_name(entry_name) == norm_query)
+                ):
                     continue
-                pbr = (entry.get("mat_vis") or {}).get("pbr") or {}
+                pbr = envelope.get("pbr") or {}
                 for k in ("roughness", "metalness", "ior"):
                     v = pbr.get(k)
                     if v is not None:

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -1610,6 +1610,14 @@ class MatVisClient:
            b. 1 match, tier staged → return id.
            c. 1 match, tier not staged → :class:`MaterialNotStagedError`.
         4. Nothing matches → :class:`UnknownMaterialError`.
+
+        Special case ``tier="scalar"`` (mat-vis#370): scalar-only sources
+        (physicallybased + the 18-entry gpuopen scalar-only subset) carry
+        no texture tiers — ``"scalar"`` is the convention sentinel
+        (cf. pymat ``TIERS_SCALAR = ["scalar"]``), not a missing bake. We
+        skip the ``available_tiers`` membership check in that case so
+        every entry counts as "staged". Without this, scalar-only callers
+        always raised :class:`MaterialNotStagedError`.
         """
         try:
             idx = self.index(source)
@@ -1640,6 +1648,11 @@ class MatVisClient:
                 by_name.append(entry)
 
         def _is_staged(entry: dict) -> bool:
+            # mat-vis#370: tier="scalar" is the scalar-only sentinel —
+            # treat as always-staged so scalar-only callers don't trip
+            # MaterialNotStagedError.
+            if tier == "scalar":
+                return True
             return tier in (entry.get("available_tiers") or [])
 
         if by_id is not None:
@@ -1889,16 +1902,33 @@ class MatVisClient:
         ``to_threejs`` / ``to_gltf`` / ``to_mtlx`` adapters which still
         consume the hex shape.
 
+        Lookup is name-aware (mat-vis#368): substrate stores normalized
+        lowercase ids, but callers (pymat, downstream tests) routinely
+        pass display names like ``"Aluminum"`` or ``"Plastic (Acrylic)"``.
+        Match against the canonical ``id`` exact, the casefold-normalized
+        ``id``, or the casefold-normalized ``mat_vis.name``. Without this,
+        scalar-only sources (physicallybased + the gpuopen scalar-only
+        subset) silently rendered as default-grey because every PBR scalar
+        was dropped.
+
         Silent on failure — returns ``{}`` if the index is unavailable or
         the material isn't found. Used by :class:`MtlxSource` to fill in
         shader scalar inputs when a texture channel is absent.
         """
         scalars: dict = {}
         try:
+            norm_query = self._normalize_name(material_id)
             for entry in self.index(source):
-                if entry["id"] != material_id:
+                entry_id = entry.get("id", "")
+                envelope = entry.get("mat_vis") or {}
+                entry_name = envelope.get("name") or ""
+                if not (
+                    entry_id == material_id
+                    or (entry_id and self._normalize_name(entry_id) == norm_query)
+                    or (entry_name and self._normalize_name(entry_name) == norm_query)
+                ):
                     continue
-                pbr = (entry.get("mat_vis") or {}).get("pbr") or {}
+                pbr = envelope.get("pbr") or {}
                 for k in ("roughness", "metalness", "ior"):
                     v = pbr.get(k)
                     if v is not None:

--- a/clients/python/tests/test_scalar_only_lookup.py
+++ b/clients/python/tests/test_scalar_only_lookup.py
@@ -1,0 +1,207 @@
+"""Scalar-only path bug fixes (mat-vis#368, mat-vis#370).
+
+Two bugs surfaced in the scalar-only render path (pymat
+``test_visual_regression.py::BERNHARD_SCALAR_ONLY``: the case rendered as
+default-grey because both lookups failed silently for the typical
+display-name input).
+
+Bug A (mat-vis#368): ``MatVisClient._scalars_for`` did a
+case-sensitive ``entry["id"] != material_id`` comparison. Substrate
+stores normalized lowercase ids (``"aluminum"``); callers pass
+capitalised display names (``"Aluminum"``). Result: silent ``{}``,
+every PBR scalar dropped.
+
+Bug B (mat-vis#370): ``_resolve_material_id`` raised
+:class:`MaterialNotStagedError` when ``tier="scalar"`` was passed for
+scalar-only sources. ``"scalar"`` is the convention sentinel for
+scalar-only callers (cf. pymat ``TIERS_SCALAR = ["scalar"]``), not a
+missing bake — the resolver should accept it.
+
+These tests pin both behaviours with mocked indexes so no network IO
+happens.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from mat_vis_client import MaterialNotStagedError, MatVisClient
+
+
+# ── Test fixtures ──────────────────────────────────────────────
+
+
+def _scalar_entry(
+    mid: str,
+    *,
+    name: str | None = None,
+    r: float = 0.5,
+    m: float = 0.0,
+    ior: float | None = None,
+    color_rgb: list[float] | None = None,
+    tiers: list[str] | None = None,
+) -> dict:
+    """Minimal v3 catalog entry with PBR scalars under ``mat_vis.pbr``.
+
+    Mirrors the substrate shape: lowercase canonical ``id``, display
+    ``name`` under ``mat_vis``, optional ``available_tiers`` (omitted
+    entirely for scalar-only sources).
+    """
+    entry: dict = {
+        "id": mid,
+        "mat_vis": {
+            "name": name or mid,
+            "pbr": {
+                "roughness": r,
+                "metalness": m,
+                "ior": ior,
+                "color_rgb": color_rgb,
+            },
+        },
+    }
+    if tiers is not None:
+        entry["available_tiers"] = tiers
+    return entry
+
+
+# physicallybased: scalar-only, no available_tiers, lowercase ids,
+# Title-Case display names. Mirrors the actual prod shape.
+PB_INDEX = [
+    _scalar_entry(
+        "aluminum",
+        name="Aluminum",
+        r=0.18,
+        m=1.0,
+        color_rgb=[0.91, 0.92, 0.92],
+    ),
+    _scalar_entry(
+        "plastic-acrylic",
+        name="Plastic (Acrylic)",
+        r=0.4,
+        m=0.0,
+        ior=1.49,
+        color_rgb=[1.0, 1.0, 1.0],
+    ),
+]
+
+# gpuopen: mixed — most entries have texture tiers, a scalar-only subset
+# (18 entries) carries no available_tiers. Use UUID-shaped ids to mirror
+# prod.
+CHROME_UUID = "11111111-2222-3333-4444-555555555555"
+GPUOPEN_INDEX = [
+    _scalar_entry(
+        CHROME_UUID,
+        name="Chrome",
+        r=0.05,
+        m=1.0,
+        color_rgb=[0.55, 0.56, 0.55],
+    ),
+    _scalar_entry(
+        "66666666-7777-8888-9999-000000000000",
+        name="Wood Oak",
+        r=0.7,
+        m=0.0,
+        color_rgb=[0.4, 0.3, 0.2],
+        tiers=["1k", "2k"],
+    ),
+]
+
+
+# ── Bug A — case-insensitive _scalars_for (mat-vis#368) ────────
+
+
+def test_scalars_for_case_insensitive_id():
+    """``_scalars_for("physicallybased", "Aluminum")`` returns the full PBR.
+
+    Pre-fix: case-sensitive ``entry["id"] != material_id`` returned ``{}``.
+    """
+    c = MatVisClient()
+    with patch.object(c, "index", return_value=PB_INDEX):
+        got = c._scalars_for("physicallybased", "Aluminum")
+    assert got["roughness"] == 0.18
+    assert got["metalness"] == 1.0
+    assert got["color_hex"] == "#E8EBEB"
+
+
+def test_scalars_for_lowercase_id_still_works():
+    """Lowercase canonical id still resolves (regression guard)."""
+    c = MatVisClient()
+    with patch.object(c, "index", return_value=PB_INDEX):
+        got = c._scalars_for("physicallybased", "aluminum")
+    assert got["roughness"] == 0.18
+    assert got["metalness"] == 1.0
+
+
+def test_scalars_for_display_name_lookup():
+    """Display name with punctuation/spaces resolves via mat_vis.name.
+
+    ``"Plastic (Acrylic)"`` doesn't match the canonical
+    ``"plastic-acrylic"`` id at all — only the name path can find it.
+    """
+    c = MatVisClient()
+    with patch.object(c, "index", return_value=PB_INDEX):
+        got = c._scalars_for("physicallybased", "Plastic (Acrylic)")
+    assert got["roughness"] == 0.4
+    assert got["ior"] == pytest.approx(1.49)
+
+
+def test_scalars_for_unknown_returns_empty():
+    """Silent-on-miss contract is preserved (no exception, just ``{}``)."""
+    c = MatVisClient()
+    with patch.object(c, "index", return_value=PB_INDEX):
+        assert c._scalars_for("physicallybased", "Nonexistent") == {}
+
+
+# ── Bug B — tier="scalar" sentinel (mat-vis#370) ───────────────
+
+
+def test_resolve_material_id_tier_scalar_for_scalar_only_source():
+    """``tier="scalar"`` on a scalar-only source returns the canonical id.
+
+    Pre-fix: physicallybased entries have no ``available_tiers``, so
+    ``"scalar" not in []`` always raised
+    :class:`MaterialNotStagedError`. ``"scalar"`` is the sentinel
+    (cf. pymat ``TIERS_SCALAR = ["scalar"]``), not a real tier.
+    """
+    c = MatVisClient()
+    with patch.object(c, "index", return_value=PB_INDEX):
+        resolved = c._resolve_material_id("physicallybased", "Aluminum", "scalar")
+    assert resolved == "aluminum"
+
+
+def test_resolve_material_id_tier_scalar_for_gpuopen_subset():
+    """gpuopen scalar-only entries (18 in prod) accept ``tier="scalar"``."""
+    c = MatVisClient()
+    with patch.object(c, "index", return_value=GPUOPEN_INDEX):
+        resolved = c._resolve_material_id("gpuopen", "Chrome", "scalar")
+    assert resolved == CHROME_UUID
+
+
+def test_resolve_material_id_tier_scalar_direct_id():
+    """Direct lowercase id with tier="scalar" also resolves."""
+    c = MatVisClient()
+    with patch.object(c, "index", return_value=PB_INDEX):
+        resolved = c._resolve_material_id("physicallybased", "aluminum", "scalar")
+    assert resolved == "aluminum"
+
+
+def test_resolve_material_id_tier_1k_still_enforces_staging():
+    """Regression: existing tier="1k" callers still raise on missing bake.
+
+    The scalar-sentinel fix must not break the ordinary
+    ``MaterialNotStagedError`` path for real texture tiers.
+    """
+    c = MatVisClient()
+    with patch.object(c, "index", return_value=PB_INDEX):
+        with pytest.raises(MaterialNotStagedError):
+            c._resolve_material_id("physicallybased", "Aluminum", "1k")
+
+
+def test_resolve_material_id_tier_1k_staged_returns_id():
+    """Regression: existing tier="1k" callers with a staged entry still work."""
+    c = MatVisClient()
+    with patch.object(c, "index", return_value=GPUOPEN_INDEX):
+        resolved = c._resolve_material_id("gpuopen", "Wood Oak", "1k")
+    assert resolved == "66666666-7777-8888-9999-000000000000"


### PR DESCRIPTION
## Summary

Fixes two related bugs in `MatVisClient` that broke the scalar-only render path. The surface symptom was pymat's `tests/test_visual_regression.py::BERNHARD_SCALAR_ONLY` case rendering as default-grey, because every PBR scalar was silently dropped for the typical display-name input.

### Bug A — #368: `_scalars_for` was case-sensitive

`MatVisClient._scalars_for(source, material_id)` compared `entry["id"] != material_id` directly. Substrate stores normalized lowercase ids (`"aluminum"`); callers (pymat, downstream tests) routinely pass capitalised display names (`"Aluminum"`, `"Plastic (Acrylic)"`). Result: silent `{}` return — every PBR scalar dropped, every scalar-only material rendered as default grey.

**Fix:** match against the canonical `id` exactly, OR casefold-normalized `id`, OR casefold-normalized `mat_vis.name`. Reuses the existing `_normalize_name` helper (NFKC + casefold).

### Bug B — #370: `_resolve_material_id` raised for `tier="scalar"`

`_resolve_material_id` raised `MaterialNotStagedError` when `tier="scalar"` was passed for scalar-only sources (physicallybased + the 18 gpuopen scalar-only entries). `"scalar"` is the convention sentinel for scalar-only callers (cf. pymat `TIERS_SCALAR = ["scalar"]`), not a missing bake — the resolver should accept it.

**Fix:** special-case `tier == "scalar"` inside the inner `_is_staged` predicate so the `available_tiers` membership check is skipped; every entry counts as staged for the sentinel tier. Direct-id, single-name-match, and disambiguation paths all continue to work.

### Standalone mirror

Both fixes mirrored to `clients/python/mat_vis_client_standalone.py`. The `tests/test_standalone_drift.py` suite stays green.

## Tests

Added 9 unit tests in `clients/python/tests/test_scalar_only_lookup.py`, all using mocked `index()` returns (no network):

- `_scalars_for("physicallybased", "Aluminum")` returns full PBR
- Lowercase canonical id still works (regression)
- Display-name lookup with punctuation: `"Plastic (Acrylic)"` resolves
- Silent-on-miss contract preserved (`{}` for unknowns)
- `_resolve_material_id("physicallybased", "Aluminum", "scalar")` returns `"aluminum"`
- `_resolve_material_id("gpuopen", "Chrome", "scalar")` returns the UUID
- Direct lowercase id with `tier="scalar"` also resolves
- Regression: `tier="1k"` still raises `MaterialNotStagedError` on missing bake
- Regression: `tier="1k"` + staged entry still returns canonical id

Suite: **442 → 451 passing** in `clients/python` (29 skipped, 2 xfailed unchanged).

## Out of scope

- #369 (substrate-side `available_tiers: null`) — that's a baker-layer concern, separate work.

## Test plan

- [x] `cd clients/python && uv run pytest --tb=short -q` — 451 passing
- [x] `uv run pytest tests/test_standalone_drift.py` — drift test green
- [x] Repo-root `uv run pytest tests/` — 604 passing
- [ ] Downstream verification in pymat: `BERNHARD_SCALAR_ONLY` visual regression should now render with the actual PBR scalars instead of default grey.