### PR TITLE
refactor(client): centralize id/name lookup predicate (closes #372, #367)

### DIFF
--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -1054,6 +1054,25 @@ class MatVisClient:
 
         return unicodedata.normalize("NFKC", s).strip().casefold()
 
+    @staticmethod
+    def _entry_matches_id_or_name(entry: dict, query: str) -> bool:
+        """Three-way name-aware match for catalog lookups (mat-vis#372).
+
+        Standalone counterpart of the packaged client's predicate. Used
+        by ``_scalars_for`` and ``VisAsset._is_scalar_only_entry`` so
+        both share one matcher and can't drift.
+        """
+        if not isinstance(entry, dict):
+            return False
+        eid = entry.get("id", "")
+        name = (entry.get("mat_vis") or {}).get("name", "")
+        nq = MatVisClient._normalize_name(query)
+        return (
+            eid == query
+            or (eid and MatVisClient._normalize_name(eid) == nq)
+            or (name and MatVisClient._normalize_name(name) == nq)
+        )
+
     def _resolve_material_id(self, source: str, material_id: str, tier: str) -> str:
         """Resolve ``material_id`` to its canonical catalog id.
 
@@ -1297,18 +1316,10 @@ class MatVisClient:
         """
         scalars: dict = {}
         try:
-            norm_query = self._normalize_name(material_id)
             for entry in self.index(source):
-                entry_id = entry.get("id", "")
-                envelope = entry.get("mat_vis") or {}
-                entry_name = envelope.get("name") or ""
-                if not (
-                    entry_id == material_id
-                    or (entry_id and self._normalize_name(entry_id) == norm_query)
-                    or (entry_name and self._normalize_name(entry_name) == norm_query)
-                ):
+                if not self._entry_matches_id_or_name(entry, material_id):
                     continue
-                pbr = envelope.get("pbr") or {}
+                pbr = (entry.get("mat_vis") or {}).get("pbr") or {}
                 for k in ("roughness", "metalness", "ior"):
                     v = pbr.get(k)
                     if v is not None:
@@ -1914,15 +1925,9 @@ class VisAsset:
             return False
         if not isinstance(entries, list):
             return False
-        norm = self._client._normalize_name(self._material_id)
+        # mat-vis#372: route through the centralized 3-way predicate.
         for entry in entries:
-            if not isinstance(entry, dict):
-                continue
-            if (
-                entry.get("id") == self._material_id
-                or self._client._normalize_name((entry.get("mat_vis") or {}).get("name") or "")
-                == norm
-            ):
+            if self._client._entry_matches_id_or_name(entry, self._material_id):
                 tiers = entry.get("available_tiers")
                 return not tiers
         return False

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -1592,6 +1592,32 @@ class MatVisClient:
 
         return unicodedata.normalize("NFKC", s).strip().casefold()
 
+    @staticmethod
+    def _entry_matches_id_or_name(entry: dict, query: str) -> bool:
+        """Three-way name-aware match for catalog lookups (mat-vis#372).
+
+        Centralizes the asymmetry-prone substrate lookup used by
+        :meth:`_scalars_for` and :class:`VisAsset._is_scalar_only_entry`:
+        callers may receive a canonical UUID/slug, a normalized lowercase
+        id, or a display name like ``"Aluminum Brushed"``. All three
+        must match the same entry, or scalar-only sources silently lose
+        scalars when callers pass display names (#367/#368).
+
+        :meth:`_resolve_material_id` keeps its own logic — it builds
+        by-id + by-name lists for ambiguity detection and raises typed
+        errors, a different responsibility.
+        """
+        if not isinstance(entry, dict):
+            return False
+        eid = entry.get("id", "")
+        name = (entry.get("mat_vis") or {}).get("name", "")
+        nq = MatVisClient._normalize_name(query)
+        return (
+            eid == query
+            or (eid and MatVisClient._normalize_name(eid) == nq)
+            or (name and MatVisClient._normalize_name(name) == nq)
+        )
+
     def _resolve_material_id(self, source: str, material_id: str, tier: str) -> str:
         """Resolve ``material_id`` to its canonical catalog id.
 
@@ -1917,18 +1943,10 @@ class MatVisClient:
         """
         scalars: dict = {}
         try:
-            norm_query = self._normalize_name(material_id)
             for entry in self.index(source):
-                entry_id = entry.get("id", "")
-                envelope = entry.get("mat_vis") or {}
-                entry_name = envelope.get("name") or ""
-                if not (
-                    entry_id == material_id
-                    or (entry_id and self._normalize_name(entry_id) == norm_query)
-                    or (entry_name and self._normalize_name(entry_name) == norm_query)
-                ):
+                if not self._entry_matches_id_or_name(entry, material_id):
                     continue
-                pbr = envelope.get("pbr") or {}
+                pbr = (entry.get("mat_vis") or {}).get("pbr") or {}
                 for k in ("roughness", "metalness", "ior"):
                     v = pbr.get(k)
                     if v is not None:
@@ -2697,15 +2715,12 @@ class VisAsset:
             return False
         if not isinstance(entries, list):
             return False
-        norm = self._client._normalize_name(self._material_id)
+        # mat-vis#372: route through the centralized 3-way predicate.
+        # Previously a bespoke 2-way match here (exact id / norm name)
+        # missed the norm-id leg — silent #367-class drift relative to
+        # _scalars_for. Now both sites share one matcher.
         for entry in entries:
-            if not isinstance(entry, dict):
-                continue
-            if (
-                entry.get("id") == self._material_id
-                or self._client._normalize_name((entry.get("mat_vis") or {}).get("name") or "")
-                == norm
-            ):
+            if self._client._entry_matches_id_or_name(entry, self._material_id):
                 tiers = entry.get("available_tiers")
                 # Explicitly empty list (or missing) → scalar-only entry.
                 return not tiers


### PR DESCRIPTION
## Summary

- Extract \`_entry_matches_id_or_name\` static predicate on \`MatVisClient\` — three-way name-aware match (canonical id exact / normalized id / normalized name).
- Refactor \`_scalars_for\` and \`VisAsset._is_scalar_only_entry\` to use it (silently strengthens the latter from a 2-way match — fixes a latent #367-class drift).
- Mirror in standalone single-file client; drift test keeps the surface in sync.
- \`_resolve_material_id\` left untouched — different responsibility (by_id + by_name lists for ambiguity detection + typed errors).

Built on top of #371's #368/#370 fix.

## Why

Before this PR, three substrate-lookup call sites had subtly different versions of the same matching logic:

| Site | Pattern | Strength |
|---|---|---|
| \`_scalars_for\` | inline 3-way (after #371) | strong |
| \`VisAsset._is_scalar_only_entry\` | inline 2-way (no norm-id leg) | weaker |
| \`_resolve_material_id\` | by_id+by_name w/ ambiguity | separate |

The 2-way version in \`_is_scalar_only_entry\` would silently miss \`VisAsset(source="physicallybased", material_id="Aluminum")\` because the substrate id is \`"aluminum"\` (lowercase) — exact match fails, the entry name might happen to be \`"Aluminum"\` (so name match works for *this* case), but the next physicallybased material whose name doesn't exactly equal the call site's casing would silently miss again.

Centralizing prevents drift: any new substrate lookup site uses one matcher.

## Test plan

- [x] Full client suite: 451 passed, 29 skipped, 2 xfailed
- [x] Full baker suite: 604 passed, 16 skipped
- [x] Live verification against \`gerchowl/mat-vis-tst@v2026.04.99-tst-full\`: \`_scalars_for('gpuopen', 'Aluminum Brushed')\` and the lowercase variant + UUID all return identical scalars
- [x] Standalone drift test passes