### PR TITLE
chore: drop personal names from docstrings (#377)

### DIFF
--- a/clients/python/src/mat_vis_client/__init__.py
+++ b/clients/python/src/mat_vis_client/__init__.py
@@ -100,7 +100,7 @@ def get_client() -> MatVisClient:
     reporter auto-detects whether stderr is a TTY:
 
     - **REPL / Jupyter** (stderr is TTY): pretty one-line progress per
-      cache-miss download — bernhard's #312 repro now produces visible
+      cache-miss download — mat-vis#312 repro now produces visible
       feedback without consumers configuring loggers.
     - **CI / scripts** (stderr not TTY): degrades to a silent
       ``log_reporter`` at INFO. Default root-logger level is WARNING,

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -794,8 +794,8 @@ class MatVisClient:
 
         Layout (mat-vis#355): ``<cache_dir>/<client-version>/<tag>/...``.
         The client-version segment ensures upgrades across major.minor
-        boundaries never read through a stale layout (the bug bernhard
-        hit twice; see #281, #283 retraction). The tag segment keeps
+        boundaries never read through a stale layout (the bug surfaced
+        twice; see #281, #283 retraction). The tag segment keeps
         per-release data isolated so a tag=v1 cache never serves bytes
         for a tag=v2 request.
 
@@ -1174,7 +1174,7 @@ class MatVisClient:
         tiers. Hides the ``"scalar"`` sentinel from consumers of
         scalar-only sources like physicallybased; ``materials("physicallybased")``
         just works without the user having to type
-        ``materials("physicallybased", "scalar")``. Bernhard's #281
+        ``materials("physicallybased", "scalar")``. The mat-vis#281
         instinct (``tier=None``) is the friendlier path for both
         scalar-only and "I just want the catalog" multi-tier cases.
 
@@ -1257,8 +1257,8 @@ class MatVisClient:
         (#258). One conditional GET per client lifecycle per source.
         Server responds 304 if the index hasn't moved (immutable on a
         pinned tag) and we serve the cached body. Pre-#355 this path
-        bypassed ETag entirely, which is why bernhard's two false-report
-        cycles (#281/#283) surfaced as cache staleness — the index
+        bypassed ETag entirely, which is why the two false-report
+        cycles (mat-vis#281/#283) surfaced as cache staleness — the index
         cache had no invalidation hook beyond manual ``rm -rf``.
 
         Guards the v2/v3 boundary: a v3 client pointed at a v2 catalog (e.g.
@@ -1274,7 +1274,7 @@ class MatVisClient:
             # cached etag (warm cache). Cold start (cached_etag is None)
             # routes through `_get_json`, preserving the pre-#355 fetch
             # surface that tests mock heavily and avoiding a 16-test-
-            # file rewrite. The warm path is what bernhard's #281/#283
+            # file rewrite. The warm path is what the mat-vis#281/#283
             # cycles needed; the cold path is unchanged behavior.
             if cached_etag is not None:
                 body, new_etag = _get_with_etag(url, etag=cached_etag)
@@ -1294,8 +1294,9 @@ class MatVisClient:
                 # require a HEAD probe; not worth the round-trip), so
                 # the warm-cache validation kicks in only after the
                 # second client lifecycle when an ETag is available.
-                # On a fresh process with NO cache, the next bernhard-
-                # class staleness incident still requires `cache clear`
+                # On a fresh process with NO cache, the next
+                # mat-vis#281/#283-class staleness incident still
+                # requires `cache clear`
                 # — but only ONCE. Subsequent fetches ETag-validate.
                 data = _get_json(url)
                 self._indexes[source] = data

--- a/clients/python/tests/test_adapters_color_format.py
+++ b/clients/python/tests/test_adapters_color_format.py
@@ -1,6 +1,6 @@
 """Tests for to_threejs ``color_format`` kwarg (ADR-0013 §Decision-2 / #298).
 
-py-mat #99 (Bernhard, build123d): emitting ``result["color"]`` as a
+py-mat#99 (build123d): emitting ``result["color"]`` as a
 hex int is opaque in the REPL, doesn't round-trip through JSON for
 non-Three.js consumers, and is un-Pythonic. ``color_format: Literal[
 "hex", "int"]`` exposes the choice; default is ``"hex"`` since 0.7.0.

--- a/clients/python/tests/test_cache_lifecycle_e2e.py
+++ b/clients/python/tests/test_cache_lifecycle_e2e.py
@@ -8,7 +8,7 @@ Two distinct scenarios — neither covered by the unit tests in
    spawn one client process that writes cache → exit → spawn
    another client process at the same ``cache_dir`` and assert
    the new client doesn't read through the prior version's
-   layout (the bernhard #281/#283 staleness class).
+   layout (the mat-vis#281/#283 staleness class).
 
    The HF round-trip is mocked at the URL level via a local
    ``http.server`` so the test runs in any environment without

--- a/clients/python/tests/test_download_progress.py
+++ b/clients/python/tests/test_download_progress.py
@@ -1,6 +1,6 @@
 """Download-progress logging on cache miss (#287).
 
-bernhard-42 reports that ``show()`` over several uncached materials
+mat-vis#287: ``show()`` over several uncached materials
 pauses for many seconds with no feedback (each baked-material fetch
 ~0.8-1s). Library users (build123d, Jupyter, etc.) need a hook to know
 the client is actually doing work, not hung.
@@ -119,7 +119,7 @@ def test_fetch_texture_silent_on_cache_hit(tmp_cache, caplog):
 def test_client_accepts_on_download_callback() -> None:
     """``MatVisClient`` should accept an ``on_download=`` callback that
     fires on each cache-miss download. Replaces the silent ``log.info``
-    from #287 (whose close was premature — see bernhard's #312).
+    from #287 (whose close was premature — see mat-vis#312).
 
     The callback is the proper user-facing surface: zero default behavior,
     consumers wire their UI (tqdm, rich, custom). See mat-vis#333 for the
@@ -129,7 +129,7 @@ def test_client_accepts_on_download_callback() -> None:
     Full behavioural test (callback fires per cache-miss with correct
     args) belongs in the fix PR.
 
-    bernhard's repro at https://github.com/MorePET/mat-vis/issues/312 —
+    Repro at https://github.com/MorePET/mat-vis/issues/312 —
     5 calls to ``Vis(...).to_threejs()`` over fresh cache produces zero
     output today.
     """
@@ -142,5 +142,5 @@ def test_client_accepts_on_download_callback() -> None:
         "MatVisClient.__init__ should accept an on_download= callback "
         "kwarg (mat-vis#333). Today only log.info fires — silent in "
         "default loggers (consumers' apps default to WARNING). "
-        "bernhard's #312 cascade: '5 downloads, zero feedback'."
+        "mat-vis#312 cascade: '5 downloads, zero feedback'."
     )

--- a/clients/python/tests/test_errors.py
+++ b/clients/python/tests/test_errors.py
@@ -444,8 +444,8 @@ def test_resolve_name_prefers_mat_vis_name_over_top_level():
 
 
 def test_unknown_material_error_lists_names_not_uuids_with_close_matches():
-    """When the user typos a name (the bernhard repro: ``"TH Large Red
-    Bricks"`` missing the colon), the surfaced ``available`` list and
+    """When the user typos a name (the mat-vis#286 repro: ``"TH Large
+    Red Bricks"`` missing the colon), the surfaced ``available`` list and
     the rendered message should contain human names — and prioritize
     a close-match suggestion (#286).
     """
@@ -535,7 +535,7 @@ def test_material_not_staged_error_lists_available_tiers() -> None:
     """``MaterialNotStagedError`` includes an ``Available tiers: [...]``
     line so the user knows which tiers ARE staged.
 
-    bernhard mat-vis#311 sub-bullet "Unclear error messages":
+    mat-vis#311 sub-bullet "Unclear error messages":
     expectation was ``... is not staged for tier '3k'.
     Available tiers: ['1k', '2k', ...]``. Pre-#332 the message said
     "Needs a re-bake" (actionable only for maintainers).
@@ -555,7 +555,7 @@ def test_material_not_staged_error_lists_available_tiers() -> None:
     assert "Available tiers:" in msg
     assert "1k" in msg and "2k" in msg
     # Original "Needs a re-bake" wording is replaced when alternatives
-    # exist — bernhard's complaint was that line was non-actionable.
+    # exist — the mat-vis#311 complaint was that line was non-actionable.
     assert "Needs a re-bake" not in msg
 
 

--- a/clients/python/tests/test_match_search_unified.py
+++ b/clients/python/tests/test_match_search_unified.py
@@ -12,7 +12,7 @@ The contract:
 - ``client.index()`` returns ``list[Match]`` (consistent with search()).
 - ``client.asset()`` is polymorphic — accepts a ``Match``, a ``"source/id"``
   string ref, or explicit ``source=, id=, tier=`` kwargs.
-- ``materials()`` is unchanged (returns ``list[str]``, protects bernhard's
+- ``materials()`` is unchanged (returns ``list[str]``, protects
   downstream tests).
 - ``SourceNotFoundError`` gains fuzzy did-you-mean for typos like
   ``ambient_cg`` → ``ambientcg``.
@@ -526,7 +526,7 @@ def test_source_not_found_includes_did_you_mean():
 
 
 def test_materials_still_returns_list_of_str():
-    """Bernhard's downstream tests rely on list[str]. Unchanged."""
+    """Downstream tests rely on list[str]. Unchanged."""
     from mat_vis_client import MatVisClient
 
     c = MatVisClient()

--- a/clients/python/tests/test_materials_named.py
+++ b/clients/python/tests/test_materials_named.py
@@ -1,6 +1,6 @@
 """Red test for mat-vis#330: materials_named() output ergonomics.
 
-bernhard-42's mat-vis#311 sub-bullet "Consistently support material names":
+mat-vis#311 sub-bullet "Consistently support material names":
 ``client.materials("ambientcg", "1k")`` returns IDs (UUIDs for gpuopen,
 slugs for ambientcg/polyhaven). The catalog already carries human-readable
 names in ``entry.mat_vis.name``; ``materials()`` just doesn't surface them.
@@ -32,14 +32,14 @@ def test_materials_named_method_exists() -> None:
     HF tree to assert returned values). This test is the forcing
     function: the API surface must exist before the fix can claim closed.
 
-    bernhard's repro at https://github.com/MorePET/mat-vis/issues/311 —
+    Repro at https://github.com/MorePET/mat-vis/issues/311 —
     "Consistently support material names" section.
     """
     from mat_vis_client import MatVisClient
 
     assert hasattr(MatVisClient, "materials_named"), (
         "MatVisClient.materials_named is missing — see mat-vis#330. "
-        "Bernhard wants {id: display_name} dict alongside the existing "
+        "mat-vis#330 wants {id: display_name} dict alongside the existing "
         "materials() method so consumers can render material names in UI "
         "without a second round-trip through the catalog."
     )

--- a/clients/python/tests/test_progress_and_cache.py
+++ b/clients/python/tests/test_progress_and_cache.py
@@ -259,15 +259,15 @@ class TestCacheClearStaleOnly:
 
 
 class TestGetClientDefaults:
-    """Independent reviewer of #358 caught: bernhard reaches mat-vis
-    via pymat's singleton, never wiring on_event= himself, so the
-    silent-by-default behavior left him exactly as broken as before
-    #287's silent log.info. Pin the post-fix behavior here so a
-    future refactor can't quietly remove it."""
+    """Independent reviewer of #358 caught: the reporter of mat-vis#312
+    reaches mat-vis via pymat's singleton, never wiring on_event=
+    themselves, so the silent-by-default behavior left them exactly as
+    broken as before #287's silent log.info. Pin the post-fix behavior
+    here so a future refactor can't quietly remove it."""
 
     def test_get_client_singleton_wires_tty_reporter_by_default(self, monkeypatch):
         """get_client() must produce a client with on_event set —
-        otherwise bernhard's #312 repro stays broken even after #358."""
+        otherwise mat-vis#312 repro stays broken even after #358."""
         # Reset singleton so the test runs with a fresh init.
         import mat_vis_client
 
@@ -277,7 +277,7 @@ class TestGetClientDefaults:
         c = mat_vis_client.get_client()
         assert c._on_event is not None, (
             "get_client() must wire on_event= by default — silent default leaves "
-            "bernhard's #312 repro broken (his pymat singleton path can't see events)"
+            "mat-vis#312 repro broken (the pymat singleton path can't see events)"
         )
 
     def test_mat_vis_no_progress_env_var_opts_out(self, monkeypatch):
@@ -309,8 +309,8 @@ class TestLegacyLayoutAlsoLogsWarning:
         (orphan / "marker").write_text("x" * 1024)
 
         with caplog.at_level(logging.WARNING, logger="mat-vis-client"):
-            # No on_event= — the silent-default path bernhard hits
-            # via pymat's singleton.
+            # No on_event= — the silent-default path that mat-vis#312
+            # hits via pymat's singleton.
             MatVisClient(cache_dir=tmp_path, tag="v2026.04.2")
 
         # The WARN line includes the layout count + cache_dir in the

--- a/clients/python/tests/test_scalar_only_lookup.py
+++ b/clients/python/tests/test_scalar_only_lookup.py
@@ -1,7 +1,7 @@
 """Scalar-only path bug fixes (mat-vis#368, mat-vis#370).
 
 Two bugs surfaced in the scalar-only render path (pymat
-``test_visual_regression.py::BERNHARD_SCALAR_ONLY``: the case rendered as
+``test_visual_regression.py::SCALAR_ONLY``: the case rendered as
 default-grey because both lookups failed silently for the typical
 display-name input).
 

--- a/src/mat_vis_baker/sources/physicallybased.py
+++ b/src/mat_vis_baker/sources/physicallybased.py
@@ -199,7 +199,7 @@ def fetch(*, session: requests.Session | None = None) -> list[MaterialRecord]:
             # tiers.scalar.complete=True for physicallybased). Was [];
             # client.materials("physicallybased", "scalar") returned
             # empty for every dispatcher because `tier in []` matches
-            # nothing — see Bernhard's #313 cascade.
+            # nothing — see mat-vis#313 cascade.
             available_tiers=["scalar"],
             maps=[],
         )

--- a/tests/test_physicallybased_available_tiers.py
+++ b/tests/test_physicallybased_available_tiers.py
@@ -1,6 +1,6 @@
 """Test for mat-vis#331: physicallybased catalog ships available_tiers=["scalar"].
 
-bernhard-42's mat-vis#311 + #313: ``client.materials("physicallybased", "scalar")``
+mat-vis#311 + #313: ``client.materials("physicallybased", "scalar")``
 returned empty even though 86 materials exist in the catalog. Root cause was in
 the fetcher (``sources/physicallybased.py:197``) which hardcoded
 ``available_tiers=[]`` instead of ``available_tiers=["scalar"]``.
@@ -9,7 +9,7 @@ Was a strict-xfail forcing function until the fix landed; now a regular
 green test pinning the contract for the future.
 
 See https://github.com/MorePET/mat-vis/issues/331 (closed by this fix) and
-#313 for bernhard's user-visible repro that this unblocks in combination
+#313 for the user-visible repro that this unblocks in combination
 with mat#222.
 """
 


### PR DESCRIPTION
## Summary

- Replace `bernhard*` mentions in docstrings/comments with neutral references that point to the load-bearing issue numbers (`mat-vis#NNN` / `py-mat#NNN`).
- Code-only — no symbol/file/class/method renames. The audit candidate `test_bernhards_downstream_tests_rely_on_list_str` did not exist (the actual method is already named `test_materials_still_returns_list_of_str`); only the docstring was edited.
- 12 files touched, 24 mention rewrites total (audit estimated ~6 — undercount because several files had multiple hits).

## Scope (out)

Whitelisted per ADR provenance / historical-record / upstream-attribution policy:
- `CHANGELOG.md` (historical record)
- `docs/issues/`, `docs/pull-requests/` (archived mirrors)
- `docs/decisions/0013-adapter-color-input-and-scalar-coverage.md` (ADR provenance)

Verified: no `bernhard*` mentions remain outside the whitelist.

Closes #377.

## Test plan

- [x] `cd clients/python && uv run pytest --tb=short -q` → 451 passed, 29 skipped, 2 xfailed
- [x] `uv run pytest --tb=short -q` (repo root) → 604 passed, 16 skipped
- [x] Pre-commit hooks pass