### PR TITLE
bugfix(baker): gpuopen scalar-only entries emit available_tiers=["scalar"] (closes #369)

### DIFF
--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -2125,7 +2125,12 @@ class VisAsset:
         return self._textures_cache
 
     def _is_scalar_only_entry(self) -> bool:
-        """True if this asset's index entry advertises no staged tiers."""
+        """True if this asset's index entry advertises no texture tiers.
+
+        Post-#369 the substrate convention is ``available_tiers=["scalar"]``
+        for scalar-only entries (was ``[]``/missing pre-#369; the
+        legacy shapes still resolve here for back-compat).
+        """
         try:
             entries = self._client.index(self._source)
         except Exception:
@@ -2135,8 +2140,9 @@ class VisAsset:
         # mat-vis#372: route through the centralized 3-way predicate.
         for entry in entries:
             if self._client._entry_matches_id_or_name(entry, self._material_id):
-                tiers = entry.get("available_tiers")
-                return not tiers
+                tiers = entry.get("available_tiers") or []
+                # Scalar-only iff no tier is a real texture tier.
+                return all(t == "scalar" for t in tiers)
         return False
 
     def to_threejs(self, *, color_format: Literal["hex", "int"] = "hex") -> dict:

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -2995,14 +2995,18 @@ class VisAsset:
         return self._textures_cache
 
     def _is_scalar_only_entry(self) -> bool:
-        """True if this asset's index entry advertises no staged tiers.
+        """True if this asset's index entry advertises no texture tiers.
 
-        Scalar-only sources (currently just ``physicallybased``, but the
-        check is shape-driven so future scalar-only sources will work)
-        publish ``available_tiers=[]`` for every entry — there are no
-        textures to fetch. Best-effort: a missing index or lookup error
-        falls back to ``False``, preserving the existing (loud) error
-        path through :meth:`fetch_all_textures`.
+        Scalar-only entries are physicallybased (always) and the 18
+        gpuopen subset (mat-vis#369) — they publish
+        ``available_tiers=["scalar"]`` (the sentinel) under the post-#369
+        substrate convention. The check is shape-driven so future
+        scalar-only sources work without code changes. We treat
+        ``[]``/``None``/missing-key as scalar-only too, for resilience
+        to legacy substrates baked before #369 landed. Best-effort: a
+        missing index or lookup error falls back to ``False``,
+        preserving the existing (loud) error path through
+        :meth:`fetch_all_textures`.
         """
         try:
             entries = self._client.index(self._source)
@@ -3016,9 +3020,12 @@ class VisAsset:
         # _scalars_for. Now both sites share one matcher.
         for entry in entries:
             if self._client._entry_matches_id_or_name(entry, self._material_id):
-                tiers = entry.get("available_tiers")
-                # Explicitly empty list (or missing) → scalar-only entry.
-                return not tiers
+                tiers = entry.get("available_tiers") or []
+                # Scalar-only iff no tier is a real texture tier.
+                # Pre-#369 substrates emit ``[]`` or omit the key (both
+                # land here as ``[]`` after the ``or``); post-#369 emit
+                # ``["scalar"]``. Either way the entry is scalar-only.
+                return all(t == "scalar" for t in tiers)
         return False
 
     def to_threejs(self, *, color_format: Literal["hex", "int"] = "hex") -> dict:

--- a/clients/python/tests/test_scalar_only_lookup.py
+++ b/clients/python/tests/test_scalar_only_lookup.py
@@ -205,3 +205,115 @@ def test_resolve_material_id_tier_1k_staged_returns_id():
     with patch.object(c, "index", return_value=GPUOPEN_INDEX):
         resolved = c._resolve_material_id("gpuopen", "Wood Oak", "1k")
     assert resolved == "66666666-7777-8888-9999-000000000000"
+
+
+# ── #369 — _is_scalar_only_entry across the four catalog shapes ───
+#
+# The substrate-shape contract for scalar-only entries shifted twice:
+#
+#   pre-#338 (legacy):              key absent       → scalar-only
+#   #338 physicallybased fix:        ["scalar"]       → scalar-only
+#   pre-#369 gpuopen subset:         key absent / []  → scalar-only
+#   post-#369 gpuopen subset:        ["scalar"]       → scalar-only
+#
+# Clients must keep working across all four shapes — the legacy substrate
+# tags (v2026.04.0/.1/.2) still ship missing-key gpuopen entries; future
+# bakes will ship ["scalar"]. _is_scalar_only_entry has to accept both.
+
+
+@pytest.fixture
+def _client_with_index():
+    """Helper: build a MatVisClient + asset, patch index, return both."""
+    from mat_vis_client.client import VisAsset
+
+    def _make(index_data: list[dict], material_id: str) -> tuple[MatVisClient, VisAsset]:
+        c = MatVisClient()
+        # Don't actually fetch — just stub the index.
+        c.index = lambda src: index_data  # type: ignore[assignment]
+        asset = VisAsset(client=c, source="test", material_id=material_id, tier="scalar")
+        return c, asset
+
+    return _make
+
+
+@pytest.mark.parametrize(
+    "tiers_value,expected_scalar_only",
+    [
+        # New post-#369 substrate convention.
+        (["scalar"], True),
+        # Legacy gpuopen scalar-only shape (key present, empty list).
+        ([], True),
+        # Legacy null shape (key present, value None).
+        (None, True),
+        # Textured entry — definitely not scalar-only.
+        (["1k"], False),
+        (["1k", "2k"], False),
+        # Hypothetical mixed: ["1k", "scalar"] would mean "renderable both
+        # ways" — for the scalar-only check, having ANY texture tier is
+        # disqualifying.
+        (["1k", "scalar"], False),
+    ],
+)
+def test_is_scalar_only_entry_accepts_all_substrate_shapes(
+    _client_with_index, tiers_value, expected_scalar_only
+):
+    """``_is_scalar_only_entry`` accepts ``["scalar"]`` (post-#369),
+    ``[]`` and ``None`` (pre-#369 legacy), and rejects entries with any
+    real texture tier."""
+    entry: dict = {
+        "id": "test-id",
+        "mat_vis": {"name": "Test", "pbr": {"roughness": 0.1, "metalness": 1.0}},
+    }
+    if tiers_value is not None or "tiers_value" == "explicit-none":
+        # pytest.parametrize passes None for "missing-key" too; we treat
+        # the explicit None case the same as missing-key. To distinguish
+        # from "absent", we add the key only when value is not None.
+        if tiers_value is None:
+            # explicit JSON null
+            entry["available_tiers"] = None
+        else:
+            entry["available_tiers"] = tiers_value
+    _, asset = _client_with_index([entry], "test-id")
+    assert asset._is_scalar_only_entry() is expected_scalar_only
+
+
+def test_is_scalar_only_entry_with_missing_key_is_scalar_only(_client_with_index):
+    """Pre-#369 legacy substrates omit ``available_tiers`` entirely for
+    scalar-only entries. Client must treat key-absence as scalar-only."""
+    entry = {
+        "id": "test-id",
+        "mat_vis": {"name": "Test", "pbr": {"roughness": 0.1}},
+        # no available_tiers key at all
+    }
+    _, asset = _client_with_index([entry], "test-id")
+    assert asset._is_scalar_only_entry() is True
+
+
+# ── #369 end-to-end: selection method returns scalars for new shape ──
+
+
+def test_asset_textures_empty_for_post369_scalar_shape(_client_with_index):
+    """Full flow: asset(...).textures returns {} for the new ``["scalar"]``
+    shape without trying to fetch from HF.
+
+    Pre-#369-shape regression vector: if ``_is_scalar_only_entry``
+    incorrectly treated ``["scalar"]`` as textured, it would route to
+    ``fetch_all_textures`` and either crash (no staged tier) or download
+    nothing — either way silently broken. This pins the resilient path.
+    """
+    entry = {
+        "id": "chrome-uuid",
+        "mat_vis": {
+            "name": "Chrome",
+            "pbr": {"roughness": 0.05, "metalness": 1.0, "color_rgb": [0.55, 0.56, 0.55]},
+        },
+        "available_tiers": ["scalar"],
+    }
+    _, asset = _client_with_index([entry], "Chrome")
+    # Should resolve via display-name → ``Chrome`` matches mat_vis.name.
+    assert asset._is_scalar_only_entry() is True
+    # textures triggers the lazy load — must NOT call fetch_all_textures.
+    asset._client.fetch_all_textures = lambda *a, **kw: pytest.fail(  # type: ignore[assignment]
+        "fetch_all_textures called for scalar-only entry"
+    )
+    assert asset.textures == {}

--- a/src/mat_vis_baker/index_builder.py
+++ b/src/mat_vis_baker/index_builder.py
@@ -60,11 +60,18 @@ def build_index(records: list[MaterialRecord], source: str) -> list[dict]:
             "source": source,
             "mat_vis": asdict(rec.mat_vis),
             "maps": rec.maps,
+            # mat-vis#369: ``available_tiers`` is always present, always a
+            # non-empty list. Sources are responsible for emitting
+            # ``["scalar"]`` (not ``[]``) when a record has no texture
+            # tiers — physicallybased always does, gpuopen now does for
+            # the scalar-only subset (#369). Pre-#369 the key was omitted
+            # when empty, forcing consumers into ``entry.get(..., [])``
+            # gymnastics and diverging silently from the physicallybased
+            # ``["scalar"]`` convention.
+            "available_tiers": list(rec.available_tiers),
         }
         if rec.upstream is not None:
             entry["upstream"] = asdict(rec.upstream)
-        if rec.available_tiers:
-            entry["available_tiers"] = rec.available_tiers
         if rec.texture_hashes:
             entry["texture_hashes"] = rec.texture_hashes
         if rec.status == "failed":

--- a/src/mat_vis_baker/sources/gpuopen.py
+++ b/src/mat_vis_baker/sources/gpuopen.py
@@ -435,7 +435,11 @@ def _fetch_one(
             source="gpuopen",
             mat_vis=_mat_vis(pbr=parsed_pbr),
             upstream=upstream,
-            available_tiers=[tier] if textures else [],
+            # mat-vis#369: scalar-only gpuopen entries (the 18 with no
+            # baked texture maps) get ``["scalar"]`` — symmetric with
+            # physicallybased. ``[]`` is no longer a valid catalog shape;
+            # every entry carries at least one tier.
+            available_tiers=[tier] if textures else ["scalar"],
             maps=sorted(textures.keys()),
             texture_paths=texture_paths,
             needs_mtlx_bake=needs_bake,

--- a/tests/test_gpuopen_baker.py
+++ b/tests/test_gpuopen_baker.py
@@ -85,7 +85,14 @@ def test_fetch_one_populates_pbr_from_mtlx(tmp_path: Path) -> None:
 
 
 def test_fetch_one_pbr_populated_when_mtlx_only(tmp_path: Path) -> None:
-    """No flat textures (needs_mtlx_bake path) still parses scalars."""
+    """No flat textures (needs_mtlx_bake path) still parses scalars.
+
+    mat-vis#369: ``available_tiers`` is ``["scalar"]`` (not ``[]``) when
+    the package has no texture maps — the 18 gpuopen scalar-only entries
+    (Chrome, Aluminum, Gold, …) hit this path. Symmetric with
+    physicallybased's ``["scalar"]`` convention; clients see the same
+    sentinel regardless of source.
+    """
     mock_resp = MagicMock(content=_zip_with_mtlx_only())
     with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
         rec = _fetch_one(_mat(), "1k", tmp_path, mtlx_dir=None)
@@ -93,6 +100,21 @@ def test_fetch_one_pbr_populated_when_mtlx_only(tmp_path: Path) -> None:
     assert rec.needs_mtlx_bake is True
     assert rec.mat_vis.pbr.roughness == 0.7
     assert rec.mat_vis.pbr.color_rgb == [0.45, 0.30, 0.20]
+    assert rec.available_tiers == ["scalar"]
+
+
+def test_fetch_one_textured_keeps_tier_label(tmp_path: Path) -> None:
+    """Regression: textured entries still emit the requested tier label.
+
+    The ``["scalar"]`` fallback for scalar-only entries (#369) must not
+    leak into the textured path — entries with maps still emit ``["1k"]``.
+    """
+    mock_resp = MagicMock(content=_zip_with_mtlx_and_textures())
+    with patch("mat_vis_baker.sources.gpuopen.retry_request", return_value=mock_resp):
+        rec = _fetch_one(_mat(), "1k", tmp_path, mtlx_dir=None)
+
+    assert rec.available_tiers == ["1k"]
+    assert rec.maps  # at least one texture key
 
 
 def test_fetch_one_failed_path_keeps_empty_pbr(tmp_path: Path) -> None:

--- a/tests/test_index_builder.py
+++ b/tests/test_index_builder.py
@@ -180,10 +180,19 @@ def test_entries_sorted_by_id() -> None:
     assert [e["id"] for e in entries] == ["Aaa", "Mmm", "Zzz"]
 
 
-def test_available_tiers_absent_when_empty() -> None:
-    """Record with no tiers omits the field entirely (ADR-0007 rationale)."""
-    entry = build_index([_minimal_rec()], source="ambientcg")[0]
-    assert "available_tiers" not in entry
+def test_available_tiers_always_present(_min_record_helper=_minimal_rec) -> None:
+    """mat-vis#369: ``available_tiers`` is always present on every entry.
+
+    Pre-#369 the key was omitted when the record's list was empty, which
+    forced consumers into ``entry.get(..., [])`` gymnastics and silently
+    diverged from the physicallybased ``["scalar"]`` convention. Now the
+    index_builder always emits the key. Sources are responsible for
+    populating it with at least one tier — ``["scalar"]`` for entries
+    with no texture maps, ``["1k"]`` etc. for textured entries.
+    """
+    entry = build_index([_min_record_helper()], source="ambientcg")[0]
+    assert "available_tiers" in entry
+    assert entry["available_tiers"] == []
 
 
 def test_available_tiers_present_when_populated() -> None:
@@ -191,6 +200,18 @@ def test_available_tiers_present_when_populated() -> None:
     rec.available_tiers = ["1k", "2k"]
     entry = build_index([rec], source="ambientcg")[0]
     assert entry["available_tiers"] == ["1k", "2k"]
+
+
+def test_available_tiers_scalar_sentinel_passes_through() -> None:
+    """Scalar-only entries (gpuopen subset, physicallybased) emit ``["scalar"]``.
+
+    Sources fetcher decision; index_builder is a passthrough — but pin
+    the shape so a regression in the fetcher fails this test loudly.
+    """
+    rec = _minimal_rec(mid="34f2c1f9-...", source="gpuopen")
+    rec.available_tiers = ["scalar"]
+    entry = build_index([rec], source="gpuopen")[0]
+    assert entry["available_tiers"] == ["scalar"]
 
 
 # ── upstream mirror (Phase C, mat-vis#152) ──────────────────────


### PR DESCRIPTION
## Summary

- gpuopen baker: scalar-only entries (the 18 with no texture maps — Chrome, Aluminum, Gold, …) now emit `available_tiers=["scalar"]` instead of being silently absent. Symmetric with physicallybased's convention (#338).
- index_builder: always emit `available_tiers` on every entry. The `[]`/missing-key shape is no longer reachable from any source path.
- client `_is_scalar_only_entry`: accept the new `["scalar"]` shape **and** legacy shapes (`[]`/`None`/missing-key) via `all(t == "scalar" for t in tiers)`. Standalone mirrored. Resilient to pre-#369 substrates (e.g. v2026.04.0/.1/.2).

## Closes

- #369 — gpuopen catalog emits `available_tiers=null` for scalar-only entries

## Test plan

- [x] `tests/test_index_builder.py` — pin always-present contract + `["scalar"]` passthrough (43 baker tests pass)
- [x] `tests/test_gpuopen_baker.py` — extend mtlx-only path to assert `["scalar"]`; new regression-guard test for textured `["1k"]`
- [x] `clients/python/tests/test_scalar_only_lookup.py` — parametrised over all four catalog shapes + end-to-end `asset(...).textures` assertion that no `fetch_all_textures` call is made for scalar-only entries
- [x] Full baker suite: 606 pass / 16 skipped
- [x] Full client suite: 459 pass / 29 skipped / 2 xfailed
- [ ] Spot-bake gpuopen subset on `gerchowl/mat-vis-tst` (next step) and verify catalog post-bake has `available_tiers=["scalar"]` for the 18 scalar-only UUIDs

## Why this isn't only a substrate fix

The substrate convention diverges across legacy tags (`v2026.04.0/.1/.2` ship missing-key gpuopen entries), so client must remain resilient to both shapes — not just the new one. The fix lands on both sides simultaneously to keep the contract clean going forward without breaking already-published data.