### PR TITLE
feat(client): adapter field passthrough — to_threejs/to_gltf (closes #380)

### DIFF
--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -1298,13 +1298,39 @@ class MatVisClient:
             "positionals, or source=, id=, tier= kwargs"
         )
 
+    # mat-vis#380: full-PBR passthrough. Adapter side already routes
+    # every key listed here to the correct MeshPhysicalMaterial /
+    # KHR-extension property; the gap was purely on the read side.
+    _PBR_SCALAR_PASSTHROUGH: tuple[str, ...] = (
+        "roughness",
+        "metalness",
+        "ior",
+        "transmission",
+        "thickness",
+        "dispersion",
+        "clearcoat",
+        "clearcoat_roughness",
+        "specular_intensity",
+        "emissive",
+    )
+
     def _scalars_for(self, source: str, material_id: str) -> dict:
         """Look up PBR scalars for a material from the source index.
 
-        v3 (ADR-0011): reads ``mat_vis.pbr.*`` and synthesizes a
-        ``color_hex`` string from ``pbr.color_rgb`` for the adapters
-        (``to_threejs`` / ``to_gltf`` / ``to_mtlx``) which still consume
-        the hex shape.
+        v3 (ADR-0011): reads ``mat_vis.pbr.*`` and forwards every field
+        the adapters can consume so glass-class / coated / authored-
+        specular materials reach the renderer with their distinguishing
+        scalars instead of silently rendering as opaque-default-grey.
+        mat-vis#380.
+
+        Synthesizes a ``color_hex`` string from ``pbr.color_rgb`` and
+        forwards ``pbr.specular_color`` (linear RGB) as
+        ``specular_color_linear`` so the adapters'
+        ``_resolve_specular_color`` path picks it up without redoing
+        the colorspace boundary.
+
+        Dumb-adapter contract (ADR-0013 / mat-vis#290): copy verbatim,
+        don't inject defaults, don't normalize.
 
         Lookup is name-aware (mat-vis#368): match canonical id exactly,
         OR casefold-normalized id, OR casefold-normalized
@@ -1320,7 +1346,7 @@ class MatVisClient:
                 if not self._entry_matches_id_or_name(entry, material_id):
                     continue
                 pbr = (entry.get("mat_vis") or {}).get("pbr") or {}
-                for k in ("roughness", "metalness", "ior"):
+                for k in self._PBR_SCALAR_PASSTHROUGH:
                     v = pbr.get(k)
                     if v is not None:
                         scalars[k] = v
@@ -1332,6 +1358,9 @@ class MatVisClient:
                         int(round(g * 255)),
                         int(round(b * 255)),
                     )
+                spec_rgb = pbr.get("specular_color")
+                if isinstance(spec_rgb, list) and len(spec_rgb) >= 3:
+                    scalars["specular_color_linear"] = list(spec_rgb[:3])
                 break
         except Exception:
             pass

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -1919,24 +1919,52 @@ class MatVisClient:
             "(source, id, tier) positionals, or source=, id=, tier= kwargs"
         )
 
+    # Plain float/int passthrough fields read verbatim from
+    # ``mat_vis.pbr.*`` into the adapter scalars dict. Adapter-side
+    # (``to_threejs`` / ``to_gltf``) already routes each of these to the
+    # correct MeshPhysicalMaterial / KHR-extension key — the gap was
+    # purely on the read side. mat-vis#380.
+    _PBR_SCALAR_PASSTHROUGH: tuple[str, ...] = (
+        "roughness",
+        "metalness",
+        "ior",
+        "transmission",
+        "thickness",
+        "dispersion",
+        "clearcoat",
+        "clearcoat_roughness",
+        "specular_intensity",
+        "emissive",
+    )
+
     def _scalars_for(self, source: str, material_id: str) -> dict:
         """Look up PBR scalars for a material from the source index.
 
-        Reads ``mat_vis.pbr.*`` (v3 catalog shape, ADR-0011). Returns a
-        flat dict keyed by the adapter interface's scalar names
-        (``roughness`` / ``metalness`` / ``ior`` / ``color_hex``) —
-        ``color_hex`` is synthesized from ``pbr.color_rgb`` for the
-        ``to_threejs`` / ``to_gltf`` / ``to_mtlx`` adapters which still
-        consume the hex shape.
+        Reads ``mat_vis.pbr.*`` (v3 catalog shape, ADR-0011) and passes
+        through every PBR field the adapters can consume so glass-class
+        materials (``transmission``, ``thickness``, ``dispersion``),
+        coated materials (``clearcoat`` / ``clearcoat_roughness``), and
+        gpuopen-style authored specular (``specular_intensity`` /
+        ``specular_color``) actually reach the renderer instead of
+        silently rendering as opaque-default-grey. mat-vis#380.
+
+        Returns a flat dict keyed by the adapter interface's scalar
+        names. ``color_hex`` is synthesized from ``pbr.color_rgb`` for
+        ``to_threejs`` / ``to_gltf`` / ``to_mtlx``; ``specular_color``
+        (linear RGB per :class:`PBRBlock`) is forwarded as
+        ``specular_color_linear`` so the shared
+        :func:`adapters._resolve_specular_color` path picks it up
+        without re-doing the de-gamma boundary.
+
+        Dumb-adapter contract (ADR-0013 / mat-vis#290): copy what's in
+        the substrate verbatim, do not inject defaults, do not normalize.
+        The baker already materialized neutral-multiplier conventions.
 
         Lookup is name-aware (mat-vis#368): substrate stores normalized
         lowercase ids, but callers (pymat, downstream tests) routinely
         pass display names like ``"Aluminum"`` or ``"Plastic (Acrylic)"``.
         Match against the canonical ``id`` exact, the casefold-normalized
-        ``id``, or the casefold-normalized ``mat_vis.name``. Without this,
-        scalar-only sources (physicallybased + the gpuopen scalar-only
-        subset) silently rendered as default-grey because every PBR scalar
-        was dropped.
+        ``id``, or the casefold-normalized ``mat_vis.name``.
 
         Silent on failure — returns ``{}`` if the index is unavailable or
         the material isn't found. Used by :class:`MtlxSource` to fill in
@@ -1948,7 +1976,7 @@ class MatVisClient:
                 if not self._entry_matches_id_or_name(entry, material_id):
                     continue
                 pbr = (entry.get("mat_vis") or {}).get("pbr") or {}
-                for k in ("roughness", "metalness", "ior"):
+                for k in self._PBR_SCALAR_PASSTHROUGH:
                     v = pbr.get(k)
                     if v is not None:
                         scalars[k] = v
@@ -1960,6 +1988,12 @@ class MatVisClient:
                         int(round(g * 255)),
                         int(round(b * 255)),
                     )
+                # specular_color is authored in linear RGB by the baker
+                # (cf. ``PBRBlock.specular_color``); forward as the
+                # ``specular_color_linear`` alias the adapters read.
+                spec_rgb = pbr.get("specular_color")
+                if isinstance(spec_rgb, list) and len(spec_rgb) >= 3:
+                    scalars["specular_color_linear"] = list(spec_rgb[:3])
                 break
         except Exception:
             pass

--- a/clients/python/tests/test_adapter_field_passthrough.py
+++ b/clients/python/tests/test_adapter_field_passthrough.py
@@ -1,0 +1,287 @@
+"""Adapter field passthrough — full PBR coverage from substrate to adapter (mat-vis#380).
+
+Pre-fix: ``MatVisClient._scalars_for`` only read 4 of the 14+ pbr fields
+the substrate emits (``roughness`` / ``metalness`` / ``ior`` /
+``color_rgb``). The adapter passes through what it gets, so glass-class,
+coated, and authored-specular materials silently rendered as opaque
+default-grey because their distinguishing scalars never reached
+Three.js / glTF.
+
+These tests pin the read-side contract: every scalar field the
+substrate emits under ``mat_vis.pbr`` that the adapters can consume
+must reach the adapter in a form ``to_threejs`` / ``to_gltf`` already
+recognize. Dumb-adapter contract (ADR-0013 / mat-vis#290) — values
+flow verbatim.
+
+Mocked indexes — no network IO.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from mat_vis_client import MatVisClient
+from mat_vis_client.adapters import to_gltf, to_threejs
+
+
+# ── Fixtures ───────────────────────────────────────────────────
+
+
+def _entry(mid: str, *, name: str | None = None, **pbr_overrides) -> dict:
+    """v3 catalog entry with full-PBR overrides under ``mat_vis.pbr``.
+
+    Mirrors the substrate shape: lowercase canonical ``id``, display
+    ``name`` under ``mat_vis``. Pass any pbr fields as kwargs.
+    """
+    pbr: dict = {
+        "color_rgb": None,
+        "roughness": None,
+        "metalness": None,
+        "ior": None,
+        "specular_f0": None,
+        "transmission": None,
+        "complex_ior": None,
+    }
+    pbr.update(pbr_overrides)
+    return {
+        "id": mid,
+        "mat_vis": {
+            "name": name or mid,
+            "pbr": pbr,
+        },
+    }
+
+
+# Frosted glass — exercises the transmission / dispersion / thickness /
+# specular_intensity / specular_color stack the issue called out as
+# load-bearing for the fingerprint regression.
+GLASS_INDEX = [
+    _entry(
+        "frosted-glass",
+        name="Frosted Glass",
+        roughness=0.4,
+        metalness=0.0,
+        ior=1.5,
+        transmission=0.8,
+        thickness=10.0,
+        dispersion=0.25,
+        specular_intensity=0.5,
+        specular_color=[1.0, 1.0, 1.0],
+        color_rgb=[0.95, 0.95, 0.95],
+    ),
+]
+
+# Clearcoated paint — exercises the clearcoat / clearcoat_roughness path.
+COATED_INDEX = [
+    _entry(
+        "varnished-wood",
+        name="Varnished Wood",
+        roughness=0.6,
+        metalness=0.0,
+        clearcoat=1.0,
+        clearcoat_roughness=0.1,
+        color_rgb=[0.4, 0.25, 0.1],
+    ),
+]
+
+# Emissive — exercises the RGB-list emissive passthrough.
+EMISSIVE_INDEX = [
+    _entry(
+        "led-strip",
+        name="LED Strip",
+        roughness=0.5,
+        metalness=0.0,
+        emissive=[0.0, 1.0, 0.5],
+        color_rgb=[0.1, 0.1, 0.1],
+    ),
+]
+
+
+# ── Read-side: _scalars_for forwards each new field ────────────
+
+
+class TestScalarsForFullPbrPassthrough:
+    """Pin the read-side contract — _scalars_for must surface every
+    PBR field the adapter knows how to render."""
+
+    def test_transmission_passes_through(self):
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=GLASS_INDEX):
+            scalars = c._scalars_for("physicallybased", "Frosted Glass")
+        assert scalars["transmission"] == pytest.approx(0.8)
+
+    def test_thickness_passes_through(self):
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=GLASS_INDEX):
+            scalars = c._scalars_for("physicallybased", "Frosted Glass")
+        assert scalars["thickness"] == pytest.approx(10.0)
+
+    def test_dispersion_passes_through(self):
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=GLASS_INDEX):
+            scalars = c._scalars_for("physicallybased", "Frosted Glass")
+        assert scalars["dispersion"] == pytest.approx(0.25)
+
+    def test_specular_intensity_passes_through(self):
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=GLASS_INDEX):
+            scalars = c._scalars_for("physicallybased", "Frosted Glass")
+        assert scalars["specular_intensity"] == pytest.approx(0.5)
+
+    def test_specular_color_forwarded_as_linear(self):
+        """Substrate authors specular_color in linear RGB (PBRBlock
+        docstring); _scalars_for forwards it under the
+        ``specular_color_linear`` alias the adapters' resolver consumes,
+        avoiding a re-de-gamma at the boundary."""
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=GLASS_INDEX):
+            scalars = c._scalars_for("physicallybased", "Frosted Glass")
+        assert scalars["specular_color_linear"] == [1.0, 1.0, 1.0]
+        # Raw key not passed through under the substrate name (would be
+        # ambiguous w.r.t. colorspace under the adapter resolver).
+        assert "specular_color" not in scalars
+
+    def test_clearcoat_passes_through(self):
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=COATED_INDEX):
+            scalars = c._scalars_for("physicallybased", "Varnished Wood")
+        assert scalars["clearcoat"] == pytest.approx(1.0)
+
+    def test_clearcoat_roughness_passes_through(self):
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=COATED_INDEX):
+            scalars = c._scalars_for("physicallybased", "Varnished Wood")
+        assert scalars["clearcoat_roughness"] == pytest.approx(0.1)
+
+    def test_emissive_passes_through_as_list(self):
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=EMISSIVE_INDEX):
+            scalars = c._scalars_for("physicallybased", "LED Strip")
+        assert scalars["emissive"] == [0.0, 1.0, 0.5]
+
+    def test_existing_4_field_contract_preserved(self):
+        """Regression guard — the original
+        roughness/metalness/ior/color_hex fields still round-trip
+        unchanged under the new code path."""
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=GLASS_INDEX):
+            scalars = c._scalars_for("physicallybased", "Frosted Glass")
+        assert scalars["roughness"] == pytest.approx(0.4)
+        assert scalars["metalness"] == pytest.approx(0.0)
+        assert scalars["ior"] == pytest.approx(1.5)
+        # color_rgb [0.95, 0.95, 0.95] -> #F2F2F2
+        assert scalars["color_hex"] == "#F2F2F2"
+
+    def test_none_fields_omitted(self):
+        """Dumb-adapter contract — missing fields stay missing, no
+        defaults injected. Pre-fix this behaviour was implicit; pin it."""
+        opaque = [_entry("aluminum", name="Aluminum", roughness=0.18, metalness=1.0)]
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=opaque):
+            scalars = c._scalars_for("physicallybased", "Aluminum")
+        for k in (
+            "transmission",
+            "thickness",
+            "dispersion",
+            "clearcoat",
+            "clearcoat_roughness",
+            "specular_intensity",
+            "specular_color_linear",
+            "emissive",
+        ):
+            assert k not in scalars, f"{k!r} should not be injected when substrate is None"
+
+
+# ── End-to-end: scalars → to_threejs / to_gltf ─────────────────
+
+
+class TestEndToEndThreejs:
+    """End-to-end: substrate index → _scalars_for → to_threejs emits
+    the MeshPhysicalMaterial keys downstream Three.js renderers need."""
+
+    def test_glass_emits_transmission_thickness_dispersion(self):
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=GLASS_INDEX):
+            scalars = c._scalars_for("physicallybased", "Frosted Glass")
+        result = to_threejs(scalars)
+        assert result["transmission"] == pytest.approx(0.8)
+        assert result["thickness"] == pytest.approx(10.0)
+        assert result["dispersion"] == pytest.approx(0.25)
+        assert result["specularIntensity"] == pytest.approx(0.5)
+        # specular_color_linear [1,1,1] re-encodes to sRGB white.
+        assert result["specularColor"] == "#ffffff"
+
+    def test_coated_emits_clearcoat(self):
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=COATED_INDEX):
+            scalars = c._scalars_for("physicallybased", "Varnished Wood")
+        result = to_threejs(scalars)
+        assert result["clearcoat"] == pytest.approx(1.0)
+        assert result["clearcoatRoughness"] == pytest.approx(0.1)
+
+    def test_emissive_emits_three_tuple(self):
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=EMISSIVE_INDEX):
+            scalars = c._scalars_for("physicallybased", "LED Strip")
+        result = to_threejs(scalars)
+        assert result["emissive"] == [0.0, 1.0, 0.5]
+
+
+class TestEndToEndGltf:
+    """End-to-end: substrate index → _scalars_for → to_gltf emits the
+    KHR extension blocks downstream glTF 2.0 consumers need."""
+
+    def test_glass_emits_transmission_extension(self):
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=GLASS_INDEX):
+            scalars = c._scalars_for("physicallybased", "Frosted Glass")
+        result = to_gltf(scalars)
+        ext = result["extensions"]
+        assert ext["KHR_materials_transmission"] == {"transmissionFactor": 0.8}
+
+    def test_glass_emits_volume_thickness_extension(self):
+        """KHR_materials_volume.thicknessFactor only ships when transmission > 0."""
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=GLASS_INDEX):
+            scalars = c._scalars_for("physicallybased", "Frosted Glass")
+        result = to_gltf(scalars)
+        ext = result["extensions"]
+        assert ext["KHR_materials_volume"] == {"thicknessFactor": 10.0}
+
+    def test_glass_emits_dispersion_extension(self):
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=GLASS_INDEX):
+            scalars = c._scalars_for("physicallybased", "Frosted Glass")
+        result = to_gltf(scalars)
+        ext = result["extensions"]
+        assert ext["KHR_materials_dispersion"] == {"dispersion": 0.25}
+
+    def test_glass_emits_specular_extension(self):
+        """specular_intensity=0.5 is non-default; specular_color [1,1,1]
+        is the spec default and must be omitted from the extension."""
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=GLASS_INDEX):
+            scalars = c._scalars_for("physicallybased", "Frosted Glass")
+        result = to_gltf(scalars)
+        ext = result["extensions"]
+        assert ext["KHR_materials_specular"] == {"specularFactor": 0.5}
+
+    def test_coated_emits_clearcoat_extension(self):
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=COATED_INDEX):
+            scalars = c._scalars_for("physicallybased", "Varnished Wood")
+        result = to_gltf(scalars)
+        ext = result["extensions"]
+        assert ext["KHR_materials_clearcoat"] == {
+            "clearcoatFactor": 1.0,
+            "clearcoatRoughnessFactor": 0.1,
+        }
+
+    def test_emissive_emits_factor(self):
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=EMISSIVE_INDEX):
+            scalars = c._scalars_for("physicallybased", "LED Strip")
+        result = to_gltf(scalars)
+        assert result["emissiveFactor"] == [0.0, 1.0, 0.5]


### PR DESCRIPTION
## Summary

- `MatVisClient._scalars_for` only forwarded 4 of the 14+ pbr fields the substrate emits, so glass-class (`transmission`/`thickness`/`dispersion`), coated (`clearcoat`/`clearcoat_roughness`), and authored-specular (`specular_intensity`/`specular_color`) materials silently rendered as opaque-default-grey through `to_threejs` / `to_gltf`.
- The adapters already routed every one of these to the correct `MeshPhysicalMaterial` / `KHR_materials_*` key (transmission, dispersion, clearcoat, volume, specular extensions, emissive). The gap was purely on the read side. No adapter changes were needed.
- Extended `_scalars_for` to forward the full PBR set verbatim, respecting the dumb-adapter contract (ADR-0013 / #290 — substrate values flow through, no defaults injected, no normalization).
- `specular_color` is forwarded under the `specular_color_linear` alias the adapter resolver consumes, so the linear-RGB boundary stays correct.
- Mirrored to `mat_vis_client_standalone.py`; drift-parity tests still green.

## Test plan

- [x] New `tests/test_adapter_field_passthrough.py` (19 tests) — pin read-side passthrough for each new field plus end-to-end `to_threejs` / `to_gltf` emission, including the dumb-adapter no-default-injection guard.
- [x] `clients/python` suite — 473 passed, 29 skipped, 2 xfailed (no regressions).
- [x] Repo-root suite — 604 passed, 16 skipped.
- [x] Standalone drift tests green.
- [x] Pre-commit hooks (ruff + branch-name) passed.
- [ ] Optional: re-bake `gerchowl/mat-vis-tst@v2026.04.99-tst-285` 25-grid through `bake/preview/utils/check_thumbs.py`; expect fingerprint matches to drop from 22 toward ~4 (genuine diffuse-white ambiguity cases).

Closes #380. Companion to pymat#100 from the mat-vis side.