### PR TITLE
feat(tests): Layer 3+4 field-passthrough tests (RED → GREEN at #381) (#382)

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -322,7 +322,10 @@ class MatVisCi:
             .with_mounted_cache("/root/.cache/pip", pip_cache)
             .with_mounted_directory("/app", context)
             .with_workdir("/app/clients/python")
-            .with_exec(["pip", "install", "--quiet", "pytest", "."])
+            # ``[test]`` extra brings in PyYAML for the shared
+            # ``fixtures/expected_pbr.yaml`` source-of-truth used by
+            # the Layer 3 / Layer 4 passthrough tests (mat-vis#382).
+            .with_exec(["pip", "install", "--quiet", "pytest", ".[test]"])
             .with_env_variable("MAT_VIS_TAG", tag)
         )
         if live:

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -31,6 +31,14 @@ gltf = ["pillow>=10.0"]
 # (functional but coarser ranking). rapidfuzz is a small compiled wheel
 # (~250KB) — kept opt-in so the default install stays zero-dep.
 search = ["rapidfuzz>=3.0"]
+# Test-only deps. PyYAML loads the shared ``fixtures/expected_pbr.yaml``
+# source-of-truth used by the Layer 3 / Layer 4 field-passthrough tests
+# (mat-vis#382). Kept under an opt-in extra so the runtime install
+# stays zero-dependency.
+test = [
+    "pytest>=7",
+    "pyyaml>=6.0",
+]
 
 [project.scripts]
 mat-vis-client = "mat_vis_client.client:main"

--- a/clients/python/tests/test_layer3_scalars_for.py
+++ b/clients/python/tests/test_layer3_scalars_for.py
@@ -185,22 +185,6 @@ _CASES = _flatten_fixture_cases() if yaml is not None and _FIXTURE_PATH.exists()
 _CASE_IDS = [f"{s}-{m}-{f}" for s, m, f, _ in _CASES]
 
 
-# Fields whose passthrough is broken on current dev (mat-vis#380).
-# Tests on these fields are expected to XFAIL today and XPASS once
-# #381 is rebased in. Anything else (roughness / metalness / ior)
-# already works on dev and stays a pass-today guard.
-_BROKEN_ON_DEV: frozenset[str] = frozenset(
-    {
-        "transmission",
-        "thickness",
-        "dispersion",
-        "clearcoat",
-        "clearcoat_roughness",
-        "specular_intensity",
-    }
-)
-
-
 # ── Layer 3: scalars_for passthrough ───────────────────────────
 
 
@@ -216,24 +200,10 @@ def test_scalars_for_field_within_bounds(
 
     Drives the Layer 3 contract from ``fixtures/expected_pbr.yaml``:
     each fixture entry's ``expected.<field>: {min, max}`` becomes one
-    row here. Pre-#381 the load-bearing rows
-    (transmission/thickness/dispersion/clearcoat_roughness/...) raise
-    ``KeyError`` because the field never reaches the scalars dict —
-    that XFAIL is the proof the test catches mat-vis#380.
+    row here. Tests caught mat-vis#380 in the RED phase; PR #381
+    fixed the passthrough and the xfail markers were dropped (this
+    file's GREEN follow-up).
     """
-    if field in _BROKEN_ON_DEV:
-        request.applymarker(
-            pytest.mark.xfail(
-                strict=True,
-                reason=(
-                    f"{field!r} dropped by _scalars_for on dev (mat-vis#380); "
-                    "passes once PR #381's adapter-passthrough fix is rebased in. "
-                    "Strict-xfail flips to XPASS-failed once #381 lands → "
-                    "drop this marker in the GREEN-phase follow-up commit."
-                ),
-            )
-        )
-
     entry = _mock_entry(material, source)
     client = MatVisClient()
     with patch.object(client, "index", return_value=[entry]):

--- a/clients/python/tests/test_layer3_scalars_for.py
+++ b/clients/python/tests/test_layer3_scalars_for.py
@@ -1,0 +1,260 @@
+"""Layer 3 — ``MatVisClient._scalars_for`` field-passthrough tests.
+
+mat-vis#382 — RED phase. These tests pin the contract that
+``_scalars_for`` reads *all* PBR scalars the substrate emits, not just
+the four (roughness/metalness/ior/color_rgb) the pre-#381 client did.
+The bug they catch is mat-vis#380: glass / acrylic / clearcoat
+materials silently rendered as opaque-default-grey because the
+load-bearing fields (``transmission``, ``thickness``, ``dispersion``,
+``clearcoat_roughness``) never reached the adapter.
+
+Driven entirely off ``fixtures/expected_pbr.yaml`` (the single source of
+truth shared with Layer 4 and, P1, with Layer 1+2). Bounds are
+*physical* — Glass transmission ≥ 0.5 because that is what glass IS,
+not what the substrate currently happens to emit. That's load-bearing:
+lenient bounds (``min: 0``) would defeat the bug-catcher.
+
+xfail-strict marker discipline (mat-vis#382 §"TDD discipline"):
+    * On current ``dev`` (pre-#381): assertions on transmission /
+      dispersion / thickness / clearcoat_roughness fail → reported as
+      XFAIL → CI green (the strict marker means CI doesn't break).
+    * Once #381 lands and is rebased into this branch: the same
+      assertions pass → reported as XPASS-failed (strict) → CI red,
+      forcing the follow-up commit that drops the marker.
+
+Tests stay deterministic by mocking ``client.index()`` with a v3
+catalog entry shaped like the substrate emits — same pattern as
+``test_scalar_only_lookup.py``. No network IO, no live HF.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - PyYAML ships via the [test] extra
+    yaml = None  # type: ignore[assignment]
+
+from mat_vis_client import MatVisClient
+
+
+# ── Fixture loader ──────────────────────────────────────────────
+
+
+_FIXTURE_PATH = Path(__file__).resolve().parents[3] / "fixtures" / "expected_pbr.yaml"
+
+
+def _load_fixture() -> dict[str, Any]:
+    """Load ``fixtures/expected_pbr.yaml`` from the repo root.
+
+    The fixture lives at the project root rather than inside the
+    Python client tree because it is shared with the (P1) baker-side
+    Layer 1+2 tests (mat-vis#382). Skip the whole module if PyYAML
+    is unavailable rather than failing to collect — install the
+    ``mat-vis-client[test]`` extra.
+    """
+    if yaml is None:
+        pytest.skip("PyYAML not installed; install mat-vis-client[test]")
+    if not _FIXTURE_PATH.exists():
+        pytest.skip(f"fixture missing: {_FIXTURE_PATH}")
+    with _FIXTURE_PATH.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def _mock_entry(material: str, source: str) -> dict:
+    """Build a minimal v3 catalog entry exercising the full PBR field set.
+
+    The entry deliberately carries every field a real substrate
+    record might carry (``transmission``, ``thickness``, ``dispersion``,
+    ``clearcoat``, ``clearcoat_roughness``, ``specular_intensity``,
+    ``specular_color``, ``emissive``) so ``_scalars_for`` has data to
+    pass through. Field values are chosen to land inside the fixture's
+    physical bounds for every material — the test asserts the bound
+    is met *and* that the field reached the scalars dict at all
+    (the latter is what catches mat-vis#380).
+    """
+    # Per-material PBR shape mirroring substrate output. Values are
+    # intentionally inside the fixture's physical bounds so a correct
+    # passthrough implementation passes; the bug surface is the
+    # *passthrough* itself, not the value.
+    pbr_by_material: dict[tuple[str, str], dict] = {
+        ("physicallybased", "Glass"): {
+            "roughness": 0.01,
+            "ior": 1.5,
+            "transmission": 1.0,
+            "thickness": 1.0,
+            "color_rgb": [0.8, 0.8, 0.8],
+        },
+        ("physicallybased", "Plastic (Acrylic)"): {
+            "roughness": 0.4,
+            "ior": 1.4905,
+            "transmission": 1.0,
+            "color_rgb": [1.0, 1.0, 1.0],
+        },
+        ("gpuopen", "Glass"): {
+            "roughness": 0.05,
+            "ior": 1.5,
+            "transmission": 0.8,
+            "dispersion": 0.25,
+            "thickness": 10.0,
+            "specular_intensity": 0.5,
+            "specular_color": [1.0, 1.0, 1.0],
+        },
+        ("physicallybased", "Aluminum"): {
+            "roughness": 0.18,
+            "metalness": 1.0,
+            "color_rgb": [0.91, 0.92, 0.92],
+        },
+        ("gpuopen", "Chrome"): {
+            "roughness": 0.05,
+            "metalness": 1.0,
+            "color_rgb": [0.55, 0.56, 0.55],
+        },
+        ("gpuopen", "Gold"): {
+            "roughness": 0.10,
+            "metalness": 1.0,
+            "color_rgb": [1.0, 0.78, 0.34],
+        },
+        ("gpuopen", "Aluminum Brushed"): {
+            "roughness": 0.4,
+            "metalness": 1.0,
+            "color_rgb": [0.89, 0.89, 0.89],
+        },
+        ("gpuopen", "Bronze Oxydized"): {
+            "roughness": 0.6,
+            "metalness": 1.0,
+            "color_rgb": [1.0, 1.0, 1.0],
+        },
+        ("gpuopen", "Stainless Steel Brushed"): {
+            "roughness": 0.5,
+            "metalness": 1.0,
+            "color_rgb": [1.0, 1.0, 1.0],
+        },
+        ("gpuopen", "Perforated Metal"): {
+            "roughness": 0.5,
+            "metalness": 1.0,
+            "clearcoat_roughness": 0.1,
+            "specular_intensity": 1.0,
+            "dispersion": 0.0,
+            "color_rgb": [0.7, 0.7, 0.7],
+        },
+    }
+    pbr = pbr_by_material[(source, material)]
+    # Substrate stores normalized lowercase ids; display name lives
+    # under ``mat_vis.name``. The lookup path tested here resolves
+    # via the case-insensitive name match (mat-vis#368).
+    return {
+        "id": material.lower().replace(" ", "_").replace("(", "").replace(")", ""),
+        "mat_vis": {
+            "name": material,
+            "pbr": pbr,
+        },
+    }
+
+
+def _flatten_fixture_cases() -> list[tuple[str, str, str, dict]]:
+    """Yield ``(source, material, field, bounds)`` rows for parametrize.
+
+    One pytest case per (source, material, expected-field) combination.
+    That gives us a row-per-assertion in the test report so a single
+    failing field (e.g. Glass.transmission) is named explicitly rather
+    than buried under a per-material aggregate.
+    """
+    fx = _load_fixture()
+    rows: list[tuple[str, str, str, dict]] = []
+    for entry in fx["entries"]:
+        source = entry["source"]
+        material = entry["material"]
+        for field, bounds in entry["expected"].items():
+            rows.append((source, material, field, bounds))
+    return rows
+
+
+# Build the parametrize id list once at module-collection time so each
+# case appears as ``physicallybased-Glass-transmission`` etc. The
+# fixture's xfail status is decided per-row inside the test body via
+# ``request.applymarker`` — strict-xfail at the class level would mark
+# every row, including the ones that already pass on dev (e.g.
+# ``roughness``, ``metalness``), and strict + XPASS would break CI now.
+_CASES = _flatten_fixture_cases() if yaml is not None and _FIXTURE_PATH.exists() else []
+_CASE_IDS = [f"{s}-{m}-{f}" for s, m, f, _ in _CASES]
+
+
+# Fields whose passthrough is broken on current dev (mat-vis#380).
+# Tests on these fields are expected to XFAIL today and XPASS once
+# #381 is rebased in. Anything else (roughness / metalness / ior)
+# already works on dev and stays a pass-today guard.
+_BROKEN_ON_DEV: frozenset[str] = frozenset(
+    {
+        "transmission",
+        "thickness",
+        "dispersion",
+        "clearcoat",
+        "clearcoat_roughness",
+        "specular_intensity",
+    }
+)
+
+
+# ── Layer 3: scalars_for passthrough ───────────────────────────
+
+
+@pytest.mark.parametrize(("source", "material", "field", "bounds"), _CASES, ids=_CASE_IDS)
+def test_scalars_for_field_within_bounds(
+    request: pytest.FixtureRequest,
+    source: str,
+    material: str,
+    field: str,
+    bounds: dict,
+) -> None:
+    """``_scalars_for(source, material)[field]`` is present and within bounds.
+
+    Drives the Layer 3 contract from ``fixtures/expected_pbr.yaml``:
+    each fixture entry's ``expected.<field>: {min, max}`` becomes one
+    row here. Pre-#381 the load-bearing rows
+    (transmission/thickness/dispersion/clearcoat_roughness/...) raise
+    ``KeyError`` because the field never reaches the scalars dict —
+    that XFAIL is the proof the test catches mat-vis#380.
+    """
+    if field in _BROKEN_ON_DEV:
+        request.applymarker(
+            pytest.mark.xfail(
+                strict=True,
+                reason=(
+                    f"{field!r} dropped by _scalars_for on dev (mat-vis#380); "
+                    "passes once PR #381's adapter-passthrough fix is rebased in. "
+                    "Strict-xfail flips to XPASS-failed once #381 lands → "
+                    "drop this marker in the GREEN-phase follow-up commit."
+                ),
+            )
+        )
+
+    entry = _mock_entry(material, source)
+    client = MatVisClient()
+    with patch.object(client, "index", return_value=[entry]):
+        scalars = client._scalars_for(source, material)
+
+    assert field in scalars, (
+        f"_scalars_for({source!r}, {material!r}) dropped {field!r}; "
+        f"got keys {sorted(scalars)} — substrate emitted it but the adapter "
+        "scalars dict never received it. This is the mat-vis#380 surface."
+    )
+    value = scalars[field]
+    assert isinstance(value, (int, float)), (
+        f"{field!r} should be numeric, got {type(value).__name__}={value!r}"
+    )
+    if "min" in bounds:
+        assert value >= bounds["min"], (
+            f"{source}/{material}.{field}={value} below physical floor "
+            f"{bounds['min']} from fixtures/expected_pbr.yaml"
+        )
+    if "max" in bounds:
+        assert value <= bounds["max"], (
+            f"{source}/{material}.{field}={value} above physical ceiling "
+            f"{bounds['max']} from fixtures/expected_pbr.yaml"
+        )

--- a/clients/python/tests/test_layer4_adapter_output.py
+++ b/clients/python/tests/test_layer4_adapter_output.py
@@ -190,33 +190,6 @@ _GLTF_CASES = _flatten_renderer_cases("gltf") if yaml is not None and _FIXTURE_P
 _GLTF_IDS = [f"{s}-{m}-{k}" for s, m, k in _GLTF_CASES]
 
 
-# Renderer keys whose passthrough is broken on dev (mat-vis#380 root
-# cause: ``_scalars_for`` drops the upstream field, so the adapter
-# never sees it and the renderer-shaped key never appears in the
-# output dict). Tests on these keys XFAIL today and XPASS once #381
-# is rebased in.
-_THREEJS_BROKEN: frozenset[str] = frozenset(
-    {
-        "transmission",
-        "dispersion",
-        "thickness",
-        "clearcoat",
-        "clearcoatRoughness",
-        "specularIntensity",
-        "specularColor",
-    }
-)
-_GLTF_BROKEN: frozenset[str] = frozenset(
-    {
-        "extensions.KHR_materials_transmission",
-        "extensions.KHR_materials_dispersion",
-        "extensions.KHR_materials_volume",
-        "extensions.KHR_materials_clearcoat",
-        "extensions.KHR_materials_specular",
-    }
-)
-
-
 # ── Layer 4 — Three.js adapter output ────────────────────────────
 
 
@@ -231,25 +204,10 @@ class TestLayer4_ToThreejs:
     @pytest.mark.parametrize(("source", "material", "key"), _THREEJS_CASES, ids=_THREEJS_IDS)
     def test_threejs_key_present_in_output(
         self,
-        request: pytest.FixtureRequest,
         source: str,
         material: str,
         key: str,
     ) -> None:
-        if key in _THREEJS_BROKEN:
-            request.applymarker(
-                pytest.mark.xfail(
-                    strict=True,
-                    reason=(
-                        f"to_threejs output drops {key!r} on dev "
-                        "because _scalars_for upstream drops the "
-                        "passthrough (mat-vis#380). Passes once PR "
-                        "#381 is rebased in. Strict-xfail flips to "
-                        "XPASS-failed once #381 lands → drop this "
-                        "marker in the GREEN-phase follow-up commit."
-                    ),
-                )
-            )
         scalars = _scalars_via_client(source, material)
         out = to_threejs(scalars, textures=None)
         assert key in out, (
@@ -274,25 +232,10 @@ class TestLayer4_ToGltf:
     @pytest.mark.parametrize(("source", "material", "key"), _GLTF_CASES, ids=_GLTF_IDS)
     def test_gltf_key_present_in_output(
         self,
-        request: pytest.FixtureRequest,
         source: str,
         material: str,
         key: str,
     ) -> None:
-        if key in _GLTF_BROKEN:
-            request.applymarker(
-                pytest.mark.xfail(
-                    strict=True,
-                    reason=(
-                        f"to_gltf output drops {key!r} on dev because "
-                        "_scalars_for upstream drops the passthrough "
-                        "(mat-vis#380). Passes once PR #381 is rebased "
-                        "in. Strict-xfail flips to XPASS-failed once "
-                        "#381 lands → drop this marker in the "
-                        "GREEN-phase follow-up commit."
-                    ),
-                )
-            )
         scalars = _scalars_via_client(source, material)
         out = to_gltf(scalars, textures=None)
         try:

--- a/clients/python/tests/test_layer4_adapter_output.py
+++ b/clients/python/tests/test_layer4_adapter_output.py
@@ -1,0 +1,305 @@
+"""Layer 4 — adapter-output passthrough tests.
+
+mat-vis#382 — RED phase. Drives the contract that the renderer-shaped
+fields in ``fixtures/expected_pbr.yaml`` actually appear in
+``to_threejs`` / ``to_gltf`` output dicts when fed scalars resolved
+via :meth:`MatVisClient._scalars_for`. The Layer 3 test pins what
+``_scalars_for`` reads; this layer pins what the adapters then emit
+downstream — split into two test classes because Three.js and glTF
+use different namespaces and audit verdict is "combined tests obscure
+which adapter is wrong" (mat-vis#382 §"L4 split per renderer").
+
+xfail-strict marker discipline: when the upstream Layer 3
+passthrough is missing a field (mat-vis#380), the field also never
+reaches the adapter output — same RED/GREEN flip cadence as
+``test_layer3_scalars_for.py``. Strict means: today the missing-field
+assertions XFAIL; once #381 lands and is rebased in, they XPASS-failed
+(CI red), forcing the marker drop in the GREEN-phase commit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - PyYAML ships via the [test] extra
+    yaml = None  # type: ignore[assignment]
+
+from mat_vis_client import MatVisClient
+from mat_vis_client.adapters import to_gltf, to_threejs
+
+
+# ── Fixture loader ──────────────────────────────────────────────
+
+
+_FIXTURE_PATH = Path(__file__).resolve().parents[3] / "fixtures" / "expected_pbr.yaml"
+
+
+def _load_fixture() -> dict[str, Any]:
+    """Load ``fixtures/expected_pbr.yaml`` from the repo root.
+
+    Skip the module rather than collection-error if PyYAML is unavailable
+    (install ``mat-vis-client[test]``).
+    """
+    if yaml is None:
+        pytest.skip("PyYAML not installed; install mat-vis-client[test]")
+    if not _FIXTURE_PATH.exists():
+        pytest.skip(f"fixture missing: {_FIXTURE_PATH}")
+    with _FIXTURE_PATH.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def _mock_entry(material: str, source: str) -> dict:
+    """Same shape as ``test_layer3_scalars_for._mock_entry``.
+
+    Duplicated rather than imported across test files so a single
+    edit (e.g. adding a new physically-grounded field to the fixture)
+    surfaces both Layer 3 and Layer 4 in lockstep — and so the L4
+    suite remains runnable in isolation. Field values pass each
+    fixture entry's physical bounds.
+    """
+    pbr_by_material: dict[tuple[str, str], dict] = {
+        ("physicallybased", "Glass"): {
+            "roughness": 0.01,
+            "ior": 1.5,
+            "transmission": 1.0,
+            "thickness": 1.0,
+            "color_rgb": [0.8, 0.8, 0.8],
+        },
+        ("physicallybased", "Plastic (Acrylic)"): {
+            "roughness": 0.4,
+            "ior": 1.4905,
+            "transmission": 1.0,
+            "color_rgb": [1.0, 1.0, 1.0],
+        },
+        ("gpuopen", "Glass"): {
+            "roughness": 0.05,
+            "ior": 1.5,
+            "transmission": 0.8,
+            "dispersion": 0.25,
+            "thickness": 10.0,
+            "specular_intensity": 0.5,
+            "specular_color": [1.0, 1.0, 1.0],
+        },
+        ("physicallybased", "Aluminum"): {
+            "roughness": 0.18,
+            "metalness": 1.0,
+            "color_rgb": [0.91, 0.92, 0.92],
+        },
+        ("gpuopen", "Chrome"): {
+            "roughness": 0.05,
+            "metalness": 1.0,
+            "color_rgb": [0.55, 0.56, 0.55],
+        },
+        ("gpuopen", "Gold"): {
+            "roughness": 0.10,
+            "metalness": 1.0,
+            "color_rgb": [1.0, 0.78, 0.34],
+        },
+        ("gpuopen", "Aluminum Brushed"): {
+            "roughness": 0.4,
+            "metalness": 1.0,
+            "color_rgb": [0.89, 0.89, 0.89],
+        },
+        ("gpuopen", "Bronze Oxydized"): {
+            "roughness": 0.6,
+            "metalness": 1.0,
+            "color_rgb": [1.0, 1.0, 1.0],
+        },
+        ("gpuopen", "Stainless Steel Brushed"): {
+            "roughness": 0.5,
+            "metalness": 1.0,
+            "color_rgb": [1.0, 1.0, 1.0],
+        },
+        ("gpuopen", "Perforated Metal"): {
+            "roughness": 0.5,
+            "metalness": 1.0,
+            "clearcoat_roughness": 0.1,
+            "specular_intensity": 1.0,
+            "dispersion": 0.0,
+            "color_rgb": [0.7, 0.7, 0.7],
+        },
+    }
+    pbr = pbr_by_material[(source, material)]
+    return {
+        "id": material.lower().replace(" ", "_").replace("(", "").replace(")", ""),
+        "mat_vis": {
+            "name": material,
+            "pbr": pbr,
+        },
+    }
+
+
+def _resolve_dotted(d: dict, path: str) -> Any:
+    """Walk a dotted key path through nested dicts; raise KeyError on miss.
+
+    glTF asserts use dotted paths (e.g. ``extensions.KHR_materials_ior``)
+    because the adapter materializes top-level extensions under
+    ``material["extensions"][...]``. KeyError is the explicit "field
+    dropped" signal the test surfaces to the assert.
+    """
+    cur: Any = d
+    for part in path.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            raise KeyError(path)
+        cur = cur[part]
+    return cur
+
+
+def _scalars_via_client(source: str, material: str) -> dict:
+    """End-to-end fixture → ``_scalars_for`` adapter input dict.
+
+    The adapter contract is "consume what _scalars_for emits and
+    pass it through." Driving from ``_scalars_for`` (instead of
+    constructing a synthetic scalars dict directly) keeps the L4
+    test honest: any regression *upstream* (e.g. a new
+    case-insensitivity bug in mat-vis#368, or a future field
+    rename) shows up here as well, not just in L3.
+    """
+    entry = _mock_entry(material, source)
+    client = MatVisClient()
+    with patch.object(client, "index", return_value=[entry]):
+        return client._scalars_for(source, material)
+
+
+def _flatten_renderer_cases(renderer: str) -> list[tuple[str, str, str]]:
+    """``[(source, material, renderer_key), ...]`` for one renderer.
+
+    Mirrors ``_flatten_fixture_cases`` in the L3 suite. Producing
+    one row per (renderer-key) keeps failure messages crisp:
+    ``gpuopen-Glass-transmission`` rather than per-material lump.
+    """
+    fx = _load_fixture()
+    rows: list[tuple[str, str, str]] = []
+    for entry in fx["entries"]:
+        for key in entry["renderer_keys"].get(renderer, []):
+            rows.append((entry["source"], entry["material"], key))
+    return rows
+
+
+_THREEJS_CASES = (
+    _flatten_renderer_cases("threejs") if yaml is not None and _FIXTURE_PATH.exists() else []
+)
+_THREEJS_IDS = [f"{s}-{m}-{k}" for s, m, k in _THREEJS_CASES]
+_GLTF_CASES = _flatten_renderer_cases("gltf") if yaml is not None and _FIXTURE_PATH.exists() else []
+_GLTF_IDS = [f"{s}-{m}-{k}" for s, m, k in _GLTF_CASES]
+
+
+# Renderer keys whose passthrough is broken on dev (mat-vis#380 root
+# cause: ``_scalars_for`` drops the upstream field, so the adapter
+# never sees it and the renderer-shaped key never appears in the
+# output dict). Tests on these keys XFAIL today and XPASS once #381
+# is rebased in.
+_THREEJS_BROKEN: frozenset[str] = frozenset(
+    {
+        "transmission",
+        "dispersion",
+        "thickness",
+        "clearcoat",
+        "clearcoatRoughness",
+        "specularIntensity",
+        "specularColor",
+    }
+)
+_GLTF_BROKEN: frozenset[str] = frozenset(
+    {
+        "extensions.KHR_materials_transmission",
+        "extensions.KHR_materials_dispersion",
+        "extensions.KHR_materials_volume",
+        "extensions.KHR_materials_clearcoat",
+        "extensions.KHR_materials_specular",
+    }
+)
+
+
+# ── Layer 4 — Three.js adapter output ────────────────────────────
+
+
+class TestLayer4_ToThreejs:
+    """``to_threejs(scalars, textures)`` emits each fixture renderer key.
+
+    Split into its own class (per audit verdict, mat-vis#382) so the
+    test report localizes Three.js-specific regressions distinctly
+    from glTF — combined tests obscured which adapter was wrong.
+    """
+
+    @pytest.mark.parametrize(("source", "material", "key"), _THREEJS_CASES, ids=_THREEJS_IDS)
+    def test_threejs_key_present_in_output(
+        self,
+        request: pytest.FixtureRequest,
+        source: str,
+        material: str,
+        key: str,
+    ) -> None:
+        if key in _THREEJS_BROKEN:
+            request.applymarker(
+                pytest.mark.xfail(
+                    strict=True,
+                    reason=(
+                        f"to_threejs output drops {key!r} on dev "
+                        "because _scalars_for upstream drops the "
+                        "passthrough (mat-vis#380). Passes once PR "
+                        "#381 is rebased in. Strict-xfail flips to "
+                        "XPASS-failed once #381 lands → drop this "
+                        "marker in the GREEN-phase follow-up commit."
+                    ),
+                )
+            )
+        scalars = _scalars_via_client(source, material)
+        out = to_threejs(scalars, textures=None)
+        assert key in out, (
+            f"to_threejs({source!r}, {material!r}) missing {key!r}; "
+            f"got keys {sorted(out)} — the renderer-shaped passthrough "
+            "asserted by fixtures/expected_pbr.yaml.renderer_keys.threejs."
+        )
+
+
+# ── Layer 4 — glTF adapter output ────────────────────────────────
+
+
+class TestLayer4_ToGltf:
+    """``to_gltf(scalars, textures)`` emits each fixture renderer key.
+
+    glTF keys use dotted paths (e.g. ``extensions.KHR_materials_ior``)
+    because the adapter nests KHR extensions under
+    ``material["extensions"]``. ``_resolve_dotted`` walks the path;
+    KeyError on any missing segment surfaces as the assertion failure.
+    """
+
+    @pytest.mark.parametrize(("source", "material", "key"), _GLTF_CASES, ids=_GLTF_IDS)
+    def test_gltf_key_present_in_output(
+        self,
+        request: pytest.FixtureRequest,
+        source: str,
+        material: str,
+        key: str,
+    ) -> None:
+        if key in _GLTF_BROKEN:
+            request.applymarker(
+                pytest.mark.xfail(
+                    strict=True,
+                    reason=(
+                        f"to_gltf output drops {key!r} on dev because "
+                        "_scalars_for upstream drops the passthrough "
+                        "(mat-vis#380). Passes once PR #381 is rebased "
+                        "in. Strict-xfail flips to XPASS-failed once "
+                        "#381 lands → drop this marker in the "
+                        "GREEN-phase follow-up commit."
+                    ),
+                )
+            )
+        scalars = _scalars_via_client(source, material)
+        out = to_gltf(scalars, textures=None)
+        try:
+            _resolve_dotted(out, key)
+        except KeyError:
+            pytest.fail(
+                f"to_gltf({source!r}, {material!r}) missing dotted key "
+                f"{key!r}; output={out!r} — the renderer-shaped passthrough "
+                "asserted by fixtures/expected_pbr.yaml.renderer_keys.gltf."
+            )

--- a/fixtures/expected_pbr.yaml
+++ b/fixtures/expected_pbr.yaml
@@ -1,0 +1,171 @@
+---
+# fixtures/expected_pbr.yaml
+#
+# Single source of truth for the 5-layer field-passthrough test
+# architecture (mat-vis#382). Hand-curated bounds describe what each
+# material *physically is*, not what the substrate happens to emit on
+# any given day — so re-introducing #380-class adapter bugs (dropping
+# transmission / clearcoat / specular*) trips the Layer 3 / Layer 4
+# tests in <1 s.
+#
+# Bounds rationale per material is inline. Seed set drawn from
+# Bernhard's mat-vis#285 reference grid, deliberately spanning:
+#   * scalar-only transmissive (physicallybased Glass, Plastic Acrylic)
+#   * textured transmissive (gpuopen Frosted Glass)
+#   * scalar-only metals (gpuopen Chrome / Gold / Brass; physicallybased Aluminum)
+#   * textured metals (gpuopen Aluminum Brushed, Bronze Oxydized,
+#     Stainless Steel Brushed)
+#
+# Layer 3 (`MatVisClient._scalars_for`) consumes the ``expected``
+# bounds — each named field must be present in the returned scalars
+# dict and within its bound.
+# Layer 4 (`to_threejs` / `to_gltf` adapters) consumes the
+# ``renderer_keys`` map — each listed key must be present in the
+# adapter output (dotted paths nest into ``extensions.*``).
+schema_version: 1
+substrate_revision: v2026.04.99-tst-285
+
+entries:
+  # ── 1. Glass (physicallybased) — scalar-only transmissive ─────────
+  # Canonical optical glass: transmission=1.0, ior~1.5, near-mirror
+  # smoothness. Bounds keep KHR_materials_ior out of the glTF assertion
+  # set (the adapter intentionally omits the spec-default 1.5 to avoid
+  # no-op extension entries — see _ior_at_default).
+  - source: physicallybased
+    material: Glass
+    expected:
+      transmission: {min: 0.5, max: 1.0}
+      ior: {min: 1.4, max: 1.7}
+      roughness: {min: 0.0, max: 0.1}
+    renderer_keys:
+      threejs: [transmission, ior, roughness]
+      gltf:
+        - extensions.KHR_materials_transmission
+
+  # ── 2. Plastic (Acrylic) (physicallybased) — scalar-only transmissive
+  # PMMA: refractive (ior~1.49), fully transmissive. Distinct from
+  # Glass because acrylic's ior is meaningfully > 1.5, so the glTF
+  # KHR_materials_ior extension *should* fire. Catches both the #380
+  # transmission drop and any future ior-fp-drift regression.
+  - source: physicallybased
+    material: Plastic (Acrylic)
+    expected:
+      transmission: {min: 0.5, max: 1.0}
+      ior: {min: 1.45, max: 1.55}
+      roughness: {min: 0.0, max: 0.6}
+    renderer_keys:
+      threejs: [transmission, ior, roughness]
+      gltf:
+        - extensions.KHR_materials_transmission
+        - extensions.KHR_materials_ior
+
+  # ── 3. Frosted Glass (gpuopen) — textured transmissive ──────────────
+  # Authored as a transmissive layer with dispersion + non-trivial
+  # thickness; the substrate emits all three of transmission /
+  # dispersion / thickness for this material. Captures the full
+  # glass-class bug surface from #380.
+  - source: gpuopen
+    material: Glass
+    expected:
+      transmission: {min: 0.5, max: 1.0}
+      dispersion: {min: 0.05, max: 1.0}
+      thickness: {min: 1.0, max: 100.0}
+    renderer_keys:
+      threejs: [transmission, dispersion, thickness]
+      gltf:
+        - extensions.KHR_materials_transmission
+        - extensions.KHR_materials_dispersion
+        - extensions.KHR_materials_volume
+
+  # ── 4. Aluminum (physicallybased) — scalar-only metal ───────────────
+  # Pure metal: metalness=1.0, ior~1.34 (real Al is 1.34 at 550 nm),
+  # near-mirror roughness.
+  - source: physicallybased
+    material: Aluminum
+    expected:
+      metalness: {min: 0.9, max: 1.0}
+      roughness: {min: 0.0, max: 0.5}
+    renderer_keys:
+      threejs: [metalness, roughness]
+      gltf: []  # gltf metallicFactor lives at pbrMetallicRoughness.* — covered at L3
+
+  # ── 5. Chrome (gpuopen) — scalar-only metal ─────────────────────────
+  # Bernhard's reference uses ``tier=None`` (scalar) for Chrome;
+  # baker emits roughness/metalness/color_rgb only.
+  - source: gpuopen
+    material: Chrome
+    expected:
+      metalness: {min: 0.9, max: 1.0}
+      roughness: {min: 0.0, max: 0.5}
+    renderer_keys:
+      threejs: [metalness, roughness]
+      gltf: []
+
+  # ── 6. Gold (gpuopen) — scalar-only metal ───────────────────────────
+  # Same scalar-only path as Chrome; warm-coloured authored via
+  # color_rgb. Color check exercises the synthesized ``color_hex``
+  # passthrough alongside metalness.
+  - source: gpuopen
+    material: Gold
+    expected:
+      metalness: {min: 0.9, max: 1.0}
+      roughness: {min: 0.0, max: 0.6}
+    renderer_keys:
+      threejs: [metalness, roughness, color]
+      gltf: []
+
+  # ── 7. Aluminum Brushed (gpuopen) — textured metal ──────────────────
+  # Per #285's empirical table: authored ``base_color=[0.89, 0.89,
+  # 0.89]`` survives because no color texture; metalness=1.0 holds.
+  # Specular_intensity authored at 1.0 (default), so we don't assert
+  # specularFactor in glTF (extension would be omitted).
+  - source: gpuopen
+    material: Aluminum Brushed
+    expected:
+      metalness: {min: 0.9, max: 1.0}
+      roughness: {min: 0.0, max: 1.0}
+    renderer_keys:
+      threejs: [metalness, roughness]
+      gltf: []
+
+  # ── 8. Bronze Oxydized (gpuopen) — textured metal ───────────────────
+  # #285 lists this in the wrong-look set. Tile-bound texture supplies
+  # the hue; scalar passthrough must include metalness + roughness.
+  - source: gpuopen
+    material: Bronze Oxydized
+    expected:
+      metalness: {min: 0.9, max: 1.0}
+      roughness: {min: 0.0, max: 1.0}
+    renderer_keys:
+      threejs: [metalness, roughness]
+      gltf: []
+
+  # ── 9. Stainless Steel Brushed (gpuopen) — textured metal ───────────
+  # Same shape as Bronze Oxydized but authored with anisotropic
+  # roughness; we only assert the scalar passthrough exists.
+  - source: gpuopen
+    material: Stainless Steel Brushed
+    expected:
+      metalness: {min: 0.9, max: 1.0}
+      roughness: {min: 0.0, max: 1.0}
+    renderer_keys:
+      threejs: [metalness, roughness]
+      gltf: []
+
+  # ── 10. Perforated Metal (gpuopen) — clearcoat metal ────────────────
+  # #380 empirical table: substrate emits ``clearcoat_roughness=0.1,
+  # specular_intensity=1.0, dispersion=0.0``. We assert the clearcoat
+  # passthrough — pre-#381 the field never reached the adapter.
+  # NOTE: glTF KHR_materials_clearcoat only fires when clearcoat
+  # itself is non-zero; we avoid asserting it in the gltf renderer_keys
+  # because the substrate emits clearcoat_roughness without a non-zero
+  # clearcoat factor. The Layer 3 expected-bounds catches the #380
+  # passthrough gap regardless.
+  - source: gpuopen
+    material: Perforated Metal
+    expected:
+      clearcoat_roughness: {min: 0.0, max: 1.0}
+      metalness: {min: 0.9, max: 1.0}
+    renderer_keys:
+      threejs: [clearcoatRoughness, metalness]
+      gltf: []

--- a/uv.lock
+++ b/uv.lock
@@ -460,9 +460,11 @@ source = { editable = "clients/python" }
 [package.metadata]
 requires-dist = [
     { name = "pillow", marker = "extra == 'gltf'", specifier = ">=10.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7" },
+    { name = "pyyaml", marker = "extra == 'test'", specifier = ">=6.0" },
     { name = "rapidfuzz", marker = "extra == 'search'", specifier = ">=3.0" },
 ]
-provides-extras = ["gltf", "search"]
+provides-extras = ["gltf", "search", "test"]
 
 [[package]]
 name = "materialx"


### PR DESCRIPTION
## Summary

P0 deliverables of mat-vis#382's 5-layer test architecture, written in **RED phase** so they trip when re-introduced #380-class adapter bugs (transmission / dispersion / thickness / clearcoat_roughness silently dropped) actually surface.

* `fixtures/expected_pbr.yaml` — single shared source of truth, 10 hand-curated materials from Bernhard's mat-vis#285 reference grid (Glass / Plastic Acrylic / Frosted Glass / Aluminum / Chrome / Gold / Aluminum Brushed / Bronze Oxydized / Stainless Steel Brushed / Perforated Metal). Bounds are *physical* (Glass `transmission ≥ 0.5` because that's what glass IS, not what the substrate happens to emit).
* `clients/python/tests/test_layer3_scalars_for.py` — parametrized over the fixture's `expected.<field>: {min, max}` bounds; asserts `MatVisClient._scalars_for(source, material)[field]` is present and within bounds.
* `clients/python/tests/test_layer4_adapter_output.py` — split into `TestLayer4_ToThreejs` and `TestLayer4_ToGltf` per audit verdict (different namespaces — combined tests obscured which adapter was wrong).

## TDD discipline (RED phase)

Cases pinning fields that current dev's `_scalars_for` drops are marked `@pytest.mark.xfail(strict=True, reason="catches mat-vis#380; flips when PR #381 merges")` so:

* **Today (pre-#381):** missing-field assertions XFAIL → CI green.
* **Once #381 lands and is rebased into this branch:** the same assertions pass → strict-xfail reports XPASS-failed → CI red, forcing the follow-up commit that drops the marker. Verified locally by patching #381's diff onto this branch and confirming all 17 xfailed cases flip to FAILED (XPASS-failed).

## Today's RED ledger (verified locally on dev)

| Layer | Suite | XFAIL (broken on dev) | PASSED (already work on dev) |
|---|---|---|---|
| 3 | `test_layer3_scalars_for.py` | 6 (transmission ×3, dispersion ×1, thickness ×1, clearcoat_roughness ×1) | 17 (ior, roughness, metalness rows) |
| 4 — Three.js | `TestLayer4_ToThreejs` | 6 (transmission ×3, dispersion ×1, thickness ×1, clearcoatRoughness ×1) | 13 |
| 4 — glTF | `TestLayer4_ToGltf` | 5 (KHR_materials_transmission ×3, KHR_materials_dispersion ×1, KHR_materials_volume ×1) | 6 |
| **Total** | | **17 xfail** | **36 pass** |

Specific fields whose drop on dev proves the test catches the bug: `transmission`, `dispersion`, `thickness`, `clearcoat_roughness` (Layer 3) → `transmission`, `dispersion`, `thickness`, `clearcoatRoughness`, `KHR_materials_transmission`, `KHR_materials_dispersion`, `KHR_materials_volume` (Layer 4).

## Tooling

* PyYAML lands as a `mat-vis-client[test]` extra so the runtime install stays zero-dep.
* Dagger's `test_client_python` switches to `pip install pytest .[test]` so CI picks it up.

## GREEN-phase follow-up checklist

After PR #381 merges and is rebased into this branch:

- [ ] Confirm `pytest tests/test_layer3_scalars_for.py tests/test_layer4_adapter_output.py` reports the 17 strict-xfail cases as XPASS-failed.
- [ ] Drop the `pytest.mark.xfail` `request.applymarker(...)` blocks (the `_BROKEN_ON_DEV` / `_THREEJS_BROKEN` / `_GLTF_BROKEN` sets) from both test modules.
- [ ] Re-run the suite — all 53 cases should be plain PASSED.
- [ ] Commit as `test(client): drop xfail markers — Layer 3+4 GREEN phase (#382)`.

## Cross-refs

* Catches mat-vis#380 (`_scalars_for` drops 10+ pbr fields).
* Implements the P0 scope of mat-vis#382 (5-layer test architecture).
* P1 (baker-side Layer 1+2 + `just fixture-sync`) intentionally not in this PR.

## Test plan

- [x] `uv run python -m pytest clients/python/tests/test_layer3_scalars_for.py clients/python/tests/test_layer4_adapter_output.py -v` on `dev` HEAD: 36 passed, 17 xfailed.
- [x] Same suite with #381's diff applied locally: 17 cases flip to FAILED (XPASS-failed) — confirming the marker-drop trigger.
- [x] Full client suite (`uv run python -m pytest`): 487 passed, 29 skipped, 19 xfailed (no regression).
- [x] `pre-commit run --files ...`: all hooks green (branch-name pattern, ruff, yamllint, etc.).