### PR TITLE
fix(client-standalone): tree-URL honors HF env override (refs #384)

### DIFF
--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -42,12 +42,27 @@ PYPI_API = "https://pypi.org/pypi/mat-vis-client/json"
 
 # v0.6.0 (ADR-0007): HF Datasets is the canonical substrate. URLs are
 # built as ``{HF_BASE}/<tag>/<path>``. No "latest" alias on HF — tag
-# is effectively required. ``MAT_VIS_HF_BASE`` overrides the default.
-HF_DATASET = "gerchowl/mat-vis"
+# is effectively required.
+#
+# Override precedence (high → low):
+#   1. ``MAT_VIS_HF_BASE``    — full resolve URL prefix (legacy, back-compat).
+#                               Only routes resolve URLs; the tree-listing
+#                               API still derives from ``HF_DATASET`` below
+#                               unless the dataset coord matches. Prefer
+#                               (2) for new code.
+#   2. ``MAT_VIS_HF_DATASET`` — dataset coordinate (e.g. ``gerchowl/mat-vis-tst``).
+#                               Routes BOTH resolve URLs AND the tree-listing
+#                               API to the same dataset (#384).
+#   3. Default                — production ``gerchowl/mat-vis``.
+HF_DATASET = os.environ.get("MAT_VIS_HF_DATASET", "gerchowl/mat-vis")
 HF_BASE = os.environ.get(
     "MAT_VIS_HF_BASE",
     f"https://huggingface.co/datasets/{HF_DATASET}/resolve",
 )
+# Tree-listing API endpoint. Derived from ``HF_DATASET`` so the
+# ``MAT_VIS_HF_DATASET`` override routes the manifest-from-tree
+# discovery path to the same dataset as resolve URLs (#384).
+HF_TREE_API = f"https://huggingface.co/api/datasets/{HF_DATASET}/tree"
 # Default tag when the caller doesn't pin one (#242). The dataset's
 # `main` branch is an empty baseline — every release lives on a
 # CalVer branch. Bump when a new prod release ships under the
@@ -515,7 +530,7 @@ class MatVisClient:
         ``<src>/<tier>/.tier_complete`` sentinels mark complete tiers.
         """
         rev = self._tag or DEFAULT_TAG
-        tree_url = f"https://huggingface.co/api/datasets/{HF_DATASET}/tree/{rev}?recursive=true"
+        tree_url = f"{HF_TREE_API}/{rev}?recursive=true"
         tree = _get_json(tree_url)
         paths = [e["path"] for e in tree if e.get("type") == "file"]
 

--- a/clients/python/tests/test_standalone_hf_env.py
+++ b/clients/python/tests/test_standalone_hf_env.py
@@ -1,0 +1,125 @@
+"""Standalone client: HF env-override coherence (refs #384).
+
+Regression: the standalone's ``_build_manifest_from_tree`` used to
+hardcode the dataset coordinate in the tree-listing URL, so
+``MAT_VIS_HF_BASE`` redirected resolve URLs but left the manifest
+discovery path pointing at prod ``gerchowl/mat-vis``. After #384 a
+single ``MAT_VIS_HF_DATASET`` env var routes BOTH paths.
+
+These tests intercept the constructed URL by re-importing the
+standalone module under different env settings (the env is only read
+at module load time) — no network calls.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_STANDALONE = _REPO_ROOT / "clients" / "python" / "mat_vis_client_standalone.py"
+
+
+def _load_standalone(unique_name: str):
+    """Side-load a fresh copy of the standalone module.
+
+    Each test gets its own module name so the env-var snapshot taken
+    at import time is fresh — module caching would otherwise stick.
+    """
+    spec = importlib.util.spec_from_file_location(unique_name, _STANDALONE)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _with_env(env: dict[str, str | None]):
+    """Context-manager-ish helper: snapshot keys, set, yield, restore."""
+    prev: dict[str, str | None] = {k: os.environ.get(k) for k in env}
+
+    def _apply(values: dict[str, str | None]) -> None:
+        for k, v in values.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    _apply(env)
+    return prev, _apply
+
+
+def test_default_dataset_is_production():
+    """No env vars set → both resolve and tree URLs point at prod."""
+    prev, apply = _with_env({"MAT_VIS_HF_DATASET": None, "MAT_VIS_HF_BASE": None})
+    try:
+        std = _load_standalone("_standalone_hf_env_default")
+        assert std.HF_DATASET == "gerchowl/mat-vis"
+        assert "gerchowl/mat-vis/resolve" in std.HF_BASE
+        assert std.HF_TREE_API == "https://huggingface.co/api/datasets/gerchowl/mat-vis/tree"
+    finally:
+        apply(prev)
+
+
+def test_hf_dataset_env_routes_tree_url():
+    """``MAT_VIS_HF_DATASET=gerchowl/mat-vis-tst`` → tree URL contains -tst."""
+    prev, apply = _with_env({"MAT_VIS_HF_DATASET": "gerchowl/mat-vis-tst", "MAT_VIS_HF_BASE": None})
+    try:
+        std = _load_standalone("_standalone_hf_env_dataset")
+        assert std.HF_DATASET == "gerchowl/mat-vis-tst"
+        # Both paths route to the test dataset.
+        assert "mat-vis-tst" in std.HF_BASE
+        assert "mat-vis" in std.HF_BASE  # sanity (substring of mat-vis-tst too)
+        assert std.HF_TREE_API == "https://huggingface.co/api/datasets/gerchowl/mat-vis-tst/tree"
+        # The bug we're fixing: ensure the prod coord doesn't leak
+        # into the tree URL.
+        assert "datasets/gerchowl/mat-vis/tree" not in std.HF_TREE_API
+    finally:
+        apply(prev)
+
+
+def test_hf_base_env_back_compat_still_works():
+    """Legacy ``MAT_VIS_HF_BASE`` alone still overrides resolve URLs.
+
+    Tree URL falls back to default (prod) when only HF_BASE is set —
+    that's the documented legacy behavior. Callers wanting coherent
+    routing should use ``MAT_VIS_HF_DATASET``.
+    """
+    prev, apply = _with_env(
+        {
+            "MAT_VIS_HF_DATASET": None,
+            "MAT_VIS_HF_BASE": "https://example.test/datasets/foo/bar/resolve",
+        }
+    )
+    try:
+        std = _load_standalone("_standalone_hf_env_legacy_base")
+        assert std.HF_BASE == "https://example.test/datasets/foo/bar/resolve"
+        # Legacy behavior preserved: tree URL still derives from HF_DATASET.
+        assert std.HF_DATASET == "gerchowl/mat-vis"
+    finally:
+        apply(prev)
+
+
+def test_tree_url_used_in_manifest_build_honors_env():
+    """End-to-end: ``_build_manifest_from_tree`` issues the env-routed URL."""
+    prev, apply = _with_env({"MAT_VIS_HF_DATASET": "gerchowl/mat-vis-tst", "MAT_VIS_HF_BASE": None})
+    try:
+        std = _load_standalone("_standalone_hf_env_e2e")
+        captured: dict[str, str] = {}
+
+        def _fake_get_json(url: str):
+            captured["url"] = url
+            return []  # empty tree → empty sources dict
+
+        with patch.object(std, "_get_json", _fake_get_json):
+            client = std.MatVisClient(tag="v2026.04.2")
+            client._build_manifest_from_tree()
+
+        assert "url" in captured, "tree URL was never requested"
+        assert "gerchowl/mat-vis-tst/tree" in captured["url"], (
+            f"tree URL did not honor MAT_VIS_HF_DATASET: {captured['url']!r}"
+        )
+    finally:
+        apply(prev)


### PR DESCRIPTION
## Summary

- Standalone client's `_build_manifest_from_tree` (line 518) hardcoded the prod dataset coord in the HF tree-listing URL, bypassing the `MAT_VIS_HF_BASE` env override that already routed resolve URLs. So tests pointing at `gerchowl/mat-vis-tst` got mock textures from -tst but a manifest discovered from prod — a silent split-brain when verifying on the test repo.
- Adds a new `MAT_VIS_HF_DATASET` env var (dataset coordinate, e.g. `gerchowl/mat-vis-tst`) that routes BOTH resolve URLs and the tree-listing API to the same dataset. Single env var, coherent client.
- Legacy `MAT_VIS_HF_BASE` behavior is preserved unchanged for back-compat. Precedence: `MAT_VIS_HF_BASE` (full URL, legacy) > `MAT_VIS_HF_DATASET` (dataset coord, new) > default `gerchowl/mat-vis`.
- Introduces `HF_TREE_API` module-level constant derived from `HF_DATASET` so the tree URL is built from the same single source of truth as the resolve base — no more inline f-string with the raw `HF_DATASET`.
- Pure stdlib; no new deps. The constructor-arg refactor (`MatVisClient(repo=…)`) called out in #384 stays out of scope here.

## Out of scope

- The packaged client at `clients/python/src/mat_vis_client/client.py` does not have this bug (verified — it has no tree-listing call site).

## Test plan

- [x] New `clients/python/tests/test_standalone_hf_env.py` (4 tests):
  - default → both URLs point at prod
  - `MAT_VIS_HF_DATASET=gerchowl/mat-vis-tst` → `HF_TREE_API` contains `mat-vis-tst`
  - legacy `MAT_VIS_HF_BASE`-only still works (resolve overridden, tree falls back to prod default)
  - end-to-end: `_build_manifest_from_tree` actually issues the env-routed URL (intercepted via `_get_json` patch — no network)
- [x] Full standalone-client suite green: 527 passed, 29 skipped, 2 xfailed
- [x] Cross-client drift suite green: `test_standalone_drift.py` (4) + `test_version_sync.py` (7) all pass — public surface stays in sync with the packaged client