### PR TITLE
feat(client): repo+tag override via constructor + MAT_VIS_DATASET env (#384)

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -103,6 +103,24 @@ mat-vis-client prefetch ambientcg 1k
 | `MAT_VIS_BACKOFF_BASE` | `1.0` | Exponential backoff base (seconds) |
 | `MAT_VIS_NO_UPDATE_CHECK` | — | Disable the once-a-day PyPI update check |
 | `MAT_VIS_UPDATE_CHECK` | — | Force update check even when stderr is not a TTY |
+| `MAT_VIS_DATASET` | — | `<repo>@<tag>` — combined dataset coord + tag override (mat-vis#384). |
+| `MAT_VIS_HF_DATASET` | — | Dataset coord (e.g. `gerchowl/mat-vis-tst`). Pair with `MAT_VIS_TAG`. |
+| `MAT_VIS_TAG` | — | Release tag (split-form companion to `MAT_VIS_HF_DATASET`). |
+| `MAT_VIS_HF_BASE` | — | Legacy: full resolve-URL prefix. Preserved for back-compat. |
+
+### Repo + tag override
+
+`MatVisClient` supports five layered ways to point at a non-default
+dataset (precedence high → low):
+
+1. Constructor kwargs: `MatVisClient(repo="gerchowl/mat-vis-tst", tag="v2026.04.99")`.
+2. `MAT_VIS_DATASET=gerchowl/mat-vis-tst@v2026.04.99` — combined env var.
+3. `MAT_VIS_HF_DATASET=gerchowl/mat-vis-tst` (+ optional `MAT_VIS_TAG=...`).
+4. `MAT_VIS_HF_BASE=https://...` — legacy full-URL form.
+5. Default `gerchowl/mat-vis` @ pinned `DEFAULT_TAG`.
+
+Cache is namespaced on `(repo, tag)` so two clients pointed at
+different repos with the same tag never collide on disk.
 
 ## Rate limits
 

--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -42,7 +42,15 @@ PYPI_API = "https://pypi.org/pypi/mat-vis-client/json"
 
 # v0.6.0 (ADR-0007): HF Datasets is the canonical substrate. URLs are
 # built as ``{HF_BASE}/<tag>/<path>``. No "latest" alias on HF — tag
-# is effectively required. ``MAT_VIS_HF_BASE`` overrides the default.
+# is effectively required.
+#
+# Repo + tag override precedence (highest first, mat-vis#384):
+#   1. Constructor kwargs ``MatVisClient(repo=..., tag=...)``.
+#   2. ``MAT_VIS_DATASET=<repo>@<tag>`` — combined env var.
+#   3. ``MAT_VIS_HF_DATASET=<repo>`` (PR #388) + ``MAT_VIS_TAG=<tag>``
+#      (or fall back to ``DEFAULT_TAG``).
+#   4. ``MAT_VIS_HF_BASE=<full-url>`` — legacy back-compat.
+#   5. Default ``gerchowl/mat-vis`` @ ``DEFAULT_TAG``.
 HF_DATASET = "gerchowl/mat-vis"
 HF_BASE = os.environ.get(
     "MAT_VIS_HF_BASE",
@@ -53,6 +61,56 @@ HF_BASE = os.environ.get(
 # CalVer branch. Bump when a new prod release ships under the
 # per-file substrate (#186 / ADR-0012). Explicit ``tag=...`` wins.
 DEFAULT_TAG = "v2026.04.2"
+
+
+def _resolve_repo_and_tag(
+    *,
+    repo_kwarg: str | None,
+    tag_kwarg: str | None,
+) -> tuple[str, str, str | None]:
+    """Resolve ``(repo, tag, base_url_override)`` per mat-vis#384.
+
+    Mirror of the packaged client's helper — kept in lockstep so the
+    standalone honors the same precedence chain.
+    """
+    if repo_kwarg is not None and tag_kwarg is not None:
+        return repo_kwarg, tag_kwarg, None
+
+    combined = os.environ.get("MAT_VIS_DATASET")
+    env_repo: str | None = None
+    env_tag: str | None = None
+    if combined and "@" in combined:
+        env_repo, env_tag = combined.rsplit("@", 1)
+        env_repo = env_repo or None
+        env_tag = env_tag or None
+
+    if env_repo is None:
+        env_repo = os.environ.get("MAT_VIS_HF_DATASET")
+    if env_tag is None:
+        env_tag = os.environ.get("MAT_VIS_TAG")
+
+    repo = repo_kwarg or env_repo
+    tag = tag_kwarg or env_tag
+
+    base_override: str | None = None
+    if repo is None:
+        legacy_base = os.environ.get("MAT_VIS_HF_BASE")
+        if legacy_base:
+            base_override = legacy_base
+            import re as _re
+
+            m = _re.search(r"/datasets/([^/]+/[^/]+)/resolve", legacy_base)
+            if m:
+                repo = m.group(1)
+
+    if repo is None:
+        repo = HF_DATASET
+    if tag is None:
+        tag = DEFAULT_TAG
+
+    return repo, tag, base_override
+
+
 DEFAULT_CACHE_DIR = Path(os.environ.get("MAT_VIS_CACHE", Path.home() / ".cache" / "mat-vis"))
 # Version is kept in sync with clients/python/pyproject.toml by
 # scripts/sync-standalone-version.py (run via pre-commit). Do not
@@ -443,6 +501,7 @@ class MatVisClient:
         manifest_url: str | None = None,
         cache_dir: Path | None = None,
         tag: str | None = None,
+        repo: str | None = None,
         cache: bool = True,
         on_event=None,
     ):
@@ -454,7 +513,12 @@ class MatVisClient:
         self._tier_complete: dict[tuple[str, str], bool] = {}
         self._indexes: dict[str, list[dict]] = {}
         self._alt_clients: dict[str, "MatVisClient"] = {}
-        self._tag = tag
+        # mat-vis#384: layered repo + tag resolution.
+        self._repo, self._tag, _base_override = _resolve_repo_and_tag(
+            repo_kwarg=repo,
+            tag_kwarg=tag,
+        )
+        self._base = _base_override or f"https://huggingface.co/datasets/{self._repo}/resolve"
         # mat-vis#312 + #355: signature parity with the packaged
         # client. The standalone doesn't fire events (no progress
         # module bundled), but the kwarg must exist so consumers that
@@ -468,13 +532,16 @@ class MatVisClient:
             # v0.6.0: HF substrate only. No "latest" alias on HF —
             # falls back to ``DEFAULT_TAG`` (#242) so out-of-the-box use
             # returns real data instead of the empty `main` baseline.
-            rev = tag or DEFAULT_TAG
-            self._manifest_url = f"{HF_BASE}/{rev}/release-manifest.json"
+            self._manifest_url = f"{self._base}/{self._tag}/release-manifest.json"
 
     @property
     def _cache_scope(self) -> Path:
-        """Tag-scoped cache subdirectory (v1 / v2 never collide)."""
-        return self._cache_dir / (self._tag or "latest")
+        """Repo-scoped + tag-scoped cache subdirectory (mat-vis#384).
+
+        Layout: ``<cache_dir>/<repo-slug>/<tag>/...``. Pre-#384
+        ``<cache_dir>/<tag>/`` layouts become one-shot orphans.
+        """
+        return self._cache_dir / self._repo.replace("/", "__") / (self._tag or "latest")
 
     def at(self, tag: str) -> "MatVisClient":
         """Return a client pinned to ``tag``, sharing this one's cache."""
@@ -484,6 +551,8 @@ class MatVisClient:
             self._alt_clients[tag] = MatVisClient(
                 cache_dir=self._cache_dir,
                 tag=tag,
+                # mat-vis#384: forward resolved repo so .at() preserves routing.
+                repo=self._repo,
                 cache=self._cache,
                 on_event=self._on_event,
             )
@@ -515,7 +584,11 @@ class MatVisClient:
         ``<src>/<tier>/.tier_complete`` sentinels mark complete tiers.
         """
         rev = self._tag or DEFAULT_TAG
-        tree_url = f"https://huggingface.co/api/datasets/{HF_DATASET}/tree/{rev}?recursive=true"
+        # mat-vis#384: route the tree-listing API through the resolved
+        # repo so a kwarg or env-var override actually moves the
+        # manifest discovery off the prod dataset (closes the bug
+        # called out in PR #388).
+        tree_url = f"https://huggingface.co/api/datasets/{self._repo}/tree/{rev}?recursive=true"
         tree = _get_json(tree_url)
         paths = [e["path"] for e in tree if e.get("type") == "file"]
 
@@ -711,7 +784,8 @@ class MatVisClient:
         return self._tag or self.manifest.get("release_tag", DEFAULT_TAG)
 
     def _hf_url(self, path: str) -> str:
-        return f"{HF_BASE}/{self._revision()}/{path}"
+        # mat-vis#384: composes from ``self._base`` (resolved at init).
+        return f"{self._base}/{self._revision()}/{path}"
 
     def sources(self, tier: str | None = None) -> list[str]:
         """List sources. With ``tier`` set, restricts to sources that

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -50,8 +50,23 @@ PYPI_API = "https://pypi.org/pypi/mat-vis-client/json"
 
 # v0.6.0 (ADR-0007): HF Datasets is the canonical substrate. URLs are
 # built as ``{HF_BASE}/<tag>/<path>``. There is no "latest" alias on HF
-# — callers must pin a revision (tag or branch). `MAT_VIS_HF_BASE`
-# overrides the default for tests / private mirrors.
+# — callers must pin a revision (tag or branch).
+#
+# Repo + tag override precedence (highest first, mat-vis#384):
+#
+#   1. Constructor kwargs ``MatVisClient(repo=..., tag=...)``.
+#   2. ``MAT_VIS_DATASET=<repo>@<tag>`` — combined env var, single
+#      string. Last ``@`` separates repo from tag so org/repo names
+#      with internal ``@`` (rare) round-trip cleanly.
+#   3. ``MAT_VIS_HF_DATASET=<repo>`` (PR #388) + ``MAT_VIS_TAG=<tag>``
+#      (or fall back to ``DEFAULT_TAG``) — split env-var form.
+#   4. ``MAT_VIS_HF_BASE=<full-url>`` — legacy back-compat. Full
+#      resolve-URL prefix; preserved verbatim so private mirrors with
+#      non-HF URL shapes keep working.
+#   5. Default: ``gerchowl/mat-vis`` @ ``DEFAULT_TAG``.
+#
+# All five layers are unit-tested in
+# ``tests/test_client_repo_resolution.py``.
 HF_DATASET = "gerchowl/mat-vis"
 HF_BASE = os.environ.get(
     "MAT_VIS_HF_BASE",
@@ -64,6 +79,84 @@ HF_BASE = os.environ.get(
 # under the per-file substrate (#186 / ADR-0012). The explicit
 # ``tag=...`` override still wins for callers that need it.
 DEFAULT_TAG = "v2026.04.2"
+
+
+def _resolve_repo_and_tag(
+    *,
+    repo_kwarg: str | None,
+    tag_kwarg: str | None,
+) -> tuple[str, str, str | None]:
+    """Resolve the effective ``(repo, tag, base_url_override)`` triple.
+
+    Walks the precedence chain documented above (mat-vis#384). Pure
+    function — no side effects, easy to unit-test.
+
+    Returns:
+        ``(repo, tag, base_url_override)``.
+
+        - ``repo``: dataset coordinate (e.g. ``gerchowl/mat-vis``).
+        - ``tag``: revision (CalVer release tag or branch).
+        - ``base_url_override``: when ``MAT_VIS_HF_BASE`` is the only
+          override active, the full legacy URL prefix. Callers should
+          use it verbatim to compose URLs (preserves private-mirror
+          shapes that don't match ``huggingface.co/datasets/<repo>``).
+          ``None`` when any higher-precedence layer is in effect.
+    """
+    # Layer 1: constructor kwargs win outright.
+    if repo_kwarg is not None and tag_kwarg is not None:
+        return repo_kwarg, tag_kwarg, None
+
+    # Layer 2: ``MAT_VIS_DATASET=repo@tag`` (combined). Last ``@``
+    # splits — defensive against repo names containing ``@`` (unusual
+    # but legal for branch-style refs).
+    combined = os.environ.get("MAT_VIS_DATASET")
+    env_repo: str | None = None
+    env_tag: str | None = None
+    if combined and "@" in combined:
+        env_repo, env_tag = combined.rsplit("@", 1)
+        env_repo = env_repo or None
+        env_tag = env_tag or None
+
+    # Layer 3: split form. ``MAT_VIS_HF_DATASET`` already exists in
+    # the standalone (PR #388); use it here too. Falls back to
+    # ``MAT_VIS_TAG`` then ``DEFAULT_TAG``.
+    if env_repo is None:
+        env_repo = os.environ.get("MAT_VIS_HF_DATASET")
+    if env_tag is None:
+        env_tag = os.environ.get("MAT_VIS_TAG")
+
+    # Constructor kwargs always win over their respective env layers.
+    repo = repo_kwarg or env_repo
+    tag = tag_kwarg or env_tag
+
+    # Layer 4: legacy ``MAT_VIS_HF_BASE``. Only honored when nothing
+    # higher set the repo, AND the env var is actually present (not
+    # just the module-level default). Pre-existing tests rely on the
+    # full URL being preserved (private mirrors).
+    base_override: str | None = None
+    if repo is None:
+        legacy_base = os.environ.get("MAT_VIS_HF_BASE")
+        if legacy_base:
+            base_override = legacy_base
+            # Best-effort repo extraction for cache namespacing.
+            # Pattern: ``https://<host>/datasets/<owner>/<name>/resolve``.
+            # Falls through to the default if the URL doesn't match —
+            # the override URL is still used verbatim for I/O.
+            import re as _re
+
+            m = _re.search(r"/datasets/([^/]+/[^/]+)/resolve", legacy_base)
+            if m:
+                repo = m.group(1)
+
+    # Layer 5: defaults.
+    if repo is None:
+        repo = HF_DATASET
+    if tag is None:
+        tag = DEFAULT_TAG
+
+    return repo, tag, base_override
+
+
 DEFAULT_CACHE_DIR = Path(os.environ.get("MAT_VIS_CACHE", Path.home() / ".cache" / "mat-vis"))
 
 # SSoT for version: clients/python/pyproject.toml. Derived at runtime so
@@ -643,6 +736,7 @@ class MatVisClient:
         manifest_url: str | None = None,
         cache_dir: Path | None = None,
         tag: str | None = None,
+        repo: str | None = None,
         cache: bool = True,
         on_event: "OnEvent | None" = None,
     ):
@@ -658,7 +752,22 @@ class MatVisClient:
         # Each shares this instance's cache_dir + cache flag so all tag
         # scopes resolve under one root.
         self._alt_clients: dict[str, MatVisClient] = {}
-        self._tag = tag
+
+        # mat-vis#384: resolve the (repo, tag, base_override) triple
+        # via the layered precedence chain documented on
+        # ``_resolve_repo_and_tag``. ``self._tag`` keeps the resolved
+        # value so cache scoping + URL composition agree even when the
+        # caller relied on env vars / defaults.
+        self._repo, self._tag, _base_override = _resolve_repo_and_tag(
+            repo_kwarg=repo,
+            tag_kwarg=tag,
+        )
+        # The legacy ``MAT_VIS_HF_BASE`` form lets callers point at a
+        # private mirror with a non-HF URL shape. When that's the only
+        # override active, preserve the full prefix verbatim — don't
+        # try to recompose from ``self._repo`` (which may have been
+        # parsed best-effort from the URL or fallen back to default).
+        self._base = _base_override or f"https://huggingface.co/datasets/{self._repo}/resolve"
         # mat-vis#312 + #355: optional observability callback. ``None``
         # = silent default; pass a reporter from
         # ``mat_vis_client.progress`` (or write your own) to receive
@@ -674,8 +783,7 @@ class MatVisClient:
             # client picks a sensible default release (DEFAULT_TAG) so
             # out-of-the-box use returns real data instead of the empty
             # `main` baseline (#242). Explicit ``tag=...`` overrides.
-            rev = tag or DEFAULT_TAG
-            self._manifest_url = f"{HF_BASE}/{rev}/release-manifest.json"
+            self._manifest_url = f"{self._base}/{self._tag}/release-manifest.json"
 
         # mat-vis#355: detect orphan cache layouts on first init and
         # emit a single CacheStaleEvent. Cheap (one listdir + str
@@ -790,26 +898,32 @@ class MatVisClient:
 
     @property
     def _cache_scope(self) -> Path:
-        """Version-namespaced + tag-scoped cache subdirectory.
+        """Version-namespaced + repo-scoped + tag-scoped cache subdirectory.
 
-        Layout (mat-vis#355): ``<cache_dir>/<client-version>/<tag>/...``.
+        Layout (mat-vis#355 + mat-vis#384):
+        ``<cache_dir>/<client-version>/<repo-slug>/<tag>/...``.
+
         The client-version segment ensures upgrades across major.minor
         boundaries never read through a stale layout (the bug surfaced
-        twice; see #281, #283 retraction). The tag segment keeps
-        per-release data isolated so a tag=v1 cache never serves bytes
-        for a tag=v2 request.
+        twice; see #281, #283 retraction). The repo-slug segment
+        (added mat-vis#384) keeps per-dataset data isolated so a
+        ``MatVisClient(repo="gerchowl/mat-vis-tst", tag="v1")`` cache
+        never serves bytes for a default-repo ``tag="v1"`` request.
+        The tag segment keeps per-release data isolated likewise.
 
-        Pre-#355 layout (``<cache_dir>/<tag-or-"latest">/...``)
-        becomes orphan on upgrade; the new client never reads it. A
-        ``cache_stale_detected`` event fires from
-        :meth:`_emit_legacy_layout_warning_if_any` at init so wired
-        reporters can surface the cleanup recommendation.
-
-        ``"latest"`` aliasing dropped in #355: when no tag is pinned,
-        falls back to ``DEFAULT_TAG`` everywhere so cache scoping
-        matches the actual HF revision being read.
+        For the default repo (``gerchowl/mat-vis``) the layout
+        appearing under ``<client-version>/`` is
+        ``gerchowl__mat-vis/<tag>``. Pre-#384 default-repo caches
+        (``<client-version>/<tag>/...``) become one-shot orphans and
+        get reaped by the standard
+        :meth:`_emit_legacy_layout_warning_if_any` path.
         """
-        return self._cache_dir / _CLIENT_CACHE_SEGMENT / (self._tag or DEFAULT_TAG)
+        return (
+            self._cache_dir
+            / _CLIENT_CACHE_SEGMENT
+            / self._repo.replace("/", "__")
+            / (self._tag or DEFAULT_TAG)
+        )
 
     def at(self, tag: str) -> "MatVisClient":
         """Return a client pinned to ``tag``, sharing this one's cache.
@@ -826,6 +940,11 @@ class MatVisClient:
             self._alt_clients[tag] = MatVisClient(
                 cache_dir=self._cache_dir,
                 tag=tag,
+                # mat-vis#384: forward the resolved repo so
+                # ``client.at("v...")`` keeps routing to the same
+                # dataset even when the parent was constructed via
+                # env-var overrides.
+                repo=self._repo,
                 cache=self._cache,
                 on_event=self._on_event,
             )
@@ -1122,7 +1241,11 @@ class MatVisClient:
         return self._tag or self.manifest.get("release_tag", DEFAULT_TAG)
 
     def _hf_url(self, path: str) -> str:
-        return f"{HF_BASE}/{self._revision()}/{path}"
+        # mat-vis#384: composes from ``self._base`` (resolved at init
+        # via ``_resolve_repo_and_tag``) so a constructor ``repo=``
+        # kwarg or ``MAT_VIS_DATASET=repo@tag`` env var routes every
+        # URL through the chosen dataset, not just the manifest.
+        return f"{self._base}/{self._revision()}/{path}"
 
     def sources(self, tier: str | None = None) -> list[str]:
         """List sources. With ``tier`` set, restricts to sources that

--- a/clients/python/tests/test_cache_lifecycle_e2e.py
+++ b/clients/python/tests/test_cache_lifecycle_e2e.py
@@ -227,7 +227,12 @@ def test_cross_process_warm_cache_serves_via_etag(stub_hf):
         assert out1 == {"manifest_tag": "v0.0.0-stub", "catalog_count": 1}
 
         # Cache file should exist with .etag siblings.
-        cache_scope = cache_dir / "v0.6" / "v0.0.0-stub"
+        # Layout (mat-vis#384): <cache_dir>/<client-version>/<repo-slug>/<tag>/.
+        # Default repo when only ``MAT_VIS_HF_BASE`` is set
+        # (stub-URL doesn't match the HF dataset URL pattern, so the
+        # resolver falls back to the production coord for slug
+        # purposes — the actual I/O still uses the stub base).
+        cache_scope = cache_dir / "v0.6" / "gerchowl__mat-vis" / "v0.0.0-stub"
         assert (cache_scope / ".manifest.json").exists()
         assert (cache_scope / ".manifest.etag").exists()
 
@@ -343,7 +348,12 @@ def test_real_hf_warm_cache_serves_via_304(e2e_or_skip):
             )
 
             # Verify ETag got written.
-            cache_scope = cache_dir / "v0.6" / E2E_FIXTURES_TAG
+            # mat-vis#384: cache layout includes the resolved repo
+            # slug. The legacy ``MAT_VIS_HF_BASE`` URL set above
+            # parses cleanly to ``E2E_FIXTURES_REPO``.
+            cache_scope = (
+                cache_dir / "v0.6" / E2E_FIXTURES_REPO.replace("/", "__") / E2E_FIXTURES_TAG
+            )
             etag_path = cache_scope / ".indexes" / f"{E2E_FIXTURE_SOURCE}.etag"
             # ETag is only written on the warm path (when cached_etag
             # was non-None at fetch time). Cold start uses _get_json

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -187,7 +187,8 @@ def mock_client():
         # Issue #258: pair the cache body with an ETag so the conditional
         # GET in `manifest` would short-circuit — but tests below patch
         # `_get_with_etag` directly to assert no HTTP escapes either way.
-        scope = Path(tmp) / "v0.6" / "v2026.04.0"
+        # mat-vis#384: layout is now <cache_dir>/<client-version>/<repo-slug>/<tag>/.
+        scope = client._cache_scope
         scope.mkdir(parents=True, exist_ok=True)
         (scope / ".manifest.json").write_text(json.dumps(MOCK_MANIFEST))
         (scope / ".manifest.etag").write_text('"mock-etag"')
@@ -254,8 +255,8 @@ class TestClientManifest:
             assert url.endswith("/v2026.04.0/release-manifest.json")
             assert kwargs.get("etag") is None
             # Body + etag both cached under tag scope
-            cached_body = Path(tmp) / "v0.6" / "v2026.04.0" / ".manifest.json"
-            cached_etag = Path(tmp) / "v0.6" / "v2026.04.0" / ".manifest.etag"
+            cached_body = Path(tmp) / "v0.6" / "gerchowl__mat-vis" / "v2026.04.0" / ".manifest.json"
+            cached_etag = Path(tmp) / "v0.6" / "gerchowl__mat-vis" / "v2026.04.0" / ".manifest.etag"
             assert cached_body.exists()
             assert json.loads(cached_body.read_text()) == MOCK_MANIFEST
             assert cached_etag.read_text() == '"abc123"'
@@ -308,7 +309,7 @@ class TestManifestEtagCache:
             # First call has no etag (cold cache).
             _, kwargs = mock_get.call_args
             assert kwargs.get("etag") is None
-            scope = Path(tmp) / "v0.6" / "v2026.04.0"
+            scope = Path(tmp) / "v0.6" / "gerchowl__mat-vis" / "v2026.04.0"
             assert (scope / ".manifest.json").exists()
             assert (scope / ".manifest.etag").read_text() == '"v1"'
 
@@ -331,7 +332,7 @@ class TestManifestEtagCache:
         """Fresh client + same cache_dir + 304: cached body served, no body refetch."""
         with tempfile.TemporaryDirectory() as tmp:
             # Seed cache from a "previous" lifecycle.
-            scope = Path(tmp) / "v0.6" / "v2026.04.0"
+            scope = Path(tmp) / "v0.6" / "gerchowl__mat-vis" / "v2026.04.0"
             scope.mkdir(parents=True, exist_ok=True)
             (scope / ".manifest.json").write_text(json.dumps(MOCK_MANIFEST))
             (scope / ".manifest.etag").write_text('"v1"')
@@ -353,7 +354,7 @@ class TestManifestEtagCache:
     def test_fresh_process_server_mutated_200(self):
         """Fresh client + same cache_dir + 200 with new body: cache replaced."""
         with tempfile.TemporaryDirectory() as tmp:
-            scope = Path(tmp) / "v0.6" / "v2026.04.0"
+            scope = Path(tmp) / "v0.6" / "gerchowl__mat-vis" / "v2026.04.0"
             scope.mkdir(parents=True, exist_ok=True)
             (scope / ".manifest.json").write_text(json.dumps(MOCK_MANIFEST))
             (scope / ".manifest.etag").write_text('"v1"')
@@ -391,7 +392,7 @@ class TestManifestEtagCache:
             ):
                 m = client.manifest
             assert m == MOCK_MANIFEST
-            scope = Path(tmp) / "v0.6" / "v2026.04.0"
+            scope = Path(tmp) / "v0.6" / "gerchowl__mat-vis" / "v2026.04.0"
             assert (scope / ".manifest.json").exists()
             # No etag file written → next lifecycle fetches unconditionally.
             assert not (scope / ".manifest.etag").exists()

--- a/clients/python/tests/test_client_legacy.py
+++ b/clients/python/tests/test_client_legacy.py
@@ -186,10 +186,12 @@ def mock_client():
         # first .manifest access would fall back to an unconditional
         # fetch and clobber our test mocks. Pre-set the in-memory
         # _manifest too so no HTTP is issued at all.
-        cache_path = Path(tmp) / "v0.6" / "v2026.04.1" / ".manifest.json"
-        cache_path.parent.mkdir(parents=True, exist_ok=True)
-        cache_path.write_text(json.dumps(MOCK_MANIFEST))
-        (Path(tmp) / "v0.6" / "v2026.04.1" / ".manifest.etag").write_text('"mock"')
+        # mat-vis#384: layout is now
+        # <cache_dir>/<client-version>/<repo-slug>/<tag>/.
+        scope = client._cache_scope
+        scope.mkdir(parents=True, exist_ok=True)
+        (scope / ".manifest.json").write_text(json.dumps(MOCK_MANIFEST))
+        (scope / ".manifest.etag").write_text('"mock"')
         client._manifest = MOCK_MANIFEST
         # Suppress the background update-check HTTP calls that would
         # otherwise consume our mocked _get_json side_effect iterations.
@@ -210,10 +212,11 @@ def mock_search_client():
     rich_manifest["sources"]["ambientcg"]["materials_count"] = 3
     with tempfile.TemporaryDirectory() as tmp:
         client = MatVisClient(tag="v2026.04.1", cache_dir=Path(tmp))
-        cache_path = Path(tmp) / "v0.6" / "v2026.04.1" / ".manifest.json"
-        cache_path.parent.mkdir(parents=True, exist_ok=True)
-        cache_path.write_text(json.dumps(rich_manifest))
-        (Path(tmp) / "v0.6" / "v2026.04.1" / ".manifest.etag").write_text('"mock"')
+        # mat-vis#384: layout includes repo slug.
+        scope = client._cache_scope
+        scope.mkdir(parents=True, exist_ok=True)
+        (scope / ".manifest.json").write_text(json.dumps(rich_manifest))
+        (scope / ".manifest.etag").write_text('"mock"')
         client._manifest = rich_manifest
         client._update_warned = True
         yield client
@@ -267,7 +270,8 @@ def _fresh_client(cache_dir: Path) -> MatVisClient:
     the conditional GET on first ``manifest`` access doesn't escape.
     """
     client = MatVisClient(tag="v2026.04.1", cache_dir=cache_dir)
-    scoped = cache_dir / "v0.6" / "v2026.04.1"
+    # mat-vis#384: layout includes repo slug.
+    scoped = client._cache_scope
     scoped.mkdir(parents=True, exist_ok=True)
     (scoped / ".manifest.json").write_text(json.dumps(MOCK_MANIFEST))
     (scoped / ".manifest.etag").write_text('"mock"')
@@ -431,7 +435,8 @@ class TestSchemaVersionStrict:
     """#69 — client requires ``schema_version``; no legacy fallback."""
 
     def _write_manifest(self, tmp: Path, data: dict) -> Path:
-        scoped = Path(tmp) / "v0.6" / "v2026.04.0"
+        # mat-vis#384: layout includes repo slug.
+        scoped = Path(tmp) / "v0.6" / "gerchowl__mat-vis" / "v2026.04.0"
         scoped.mkdir(parents=True, exist_ok=True)
         mf = scoped / ".manifest.json"
         mf.write_text(json.dumps(data))

--- a/clients/python/tests/test_client_repo_resolution.py
+++ b/clients/python/tests/test_client_repo_resolution.py
@@ -1,0 +1,223 @@
+"""Layered repo + tag resolution for ``MatVisClient`` (mat-vis#384).
+
+Covers the precedence chain on ``_resolve_repo_and_tag`` plus the
+end-to-end client-construction wiring (URL composition + cache
+namespacing). Pure unit tests — no network.
+
+Precedence (high → low):
+
+  1. Constructor kwargs ``MatVisClient(repo=..., tag=...)``.
+  2. ``MAT_VIS_DATASET=<repo>@<tag>`` (combined env var).
+  3. ``MAT_VIS_HF_DATASET=<repo>`` + ``MAT_VIS_TAG=<tag>``.
+  4. ``MAT_VIS_HF_BASE=<full-url>`` (legacy).
+  5. Default ``gerchowl/mat-vis`` @ ``DEFAULT_TAG``.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mat_vis_client import MatVisClient
+from mat_vis_client.client import (
+    DEFAULT_TAG,
+    HF_DATASET,
+    _resolve_repo_and_tag,
+)
+
+# Env vars the resolver consults — wiped per-test by the fixture below.
+_RESOLVER_ENV_VARS = (
+    "MAT_VIS_DATASET",
+    "MAT_VIS_HF_DATASET",
+    "MAT_VIS_TAG",
+    "MAT_VIS_HF_BASE",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Strip resolver-relevant env vars so each test starts from a
+    known baseline. Tests that want a var set call ``monkeypatch.setenv``
+    after this fixture has run."""
+    for name in _RESOLVER_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+# ── _resolve_repo_and_tag table-driven precedence tests ───────────
+
+
+class TestResolverPrecedence:
+    def test_layer1_kwargs_win_over_everything(self, monkeypatch):
+        # Set every env var to a poison value — kwargs must still win.
+        monkeypatch.setenv("MAT_VIS_DATASET", "poison/dataset@vBAD")
+        monkeypatch.setenv("MAT_VIS_HF_DATASET", "poison/hfds")
+        monkeypatch.setenv("MAT_VIS_TAG", "vBAD")
+        monkeypatch.setenv("MAT_VIS_HF_BASE", "https://poison.test/d/x/y/resolve")
+        repo, tag, base = _resolve_repo_and_tag(repo_kwarg="org/wins", tag_kwarg="vWIN")
+        assert (repo, tag, base) == ("org/wins", "vWIN", None)
+
+    def test_layer1_partial_kwargs_repo_only_uses_env_tag(self, monkeypatch):
+        """``repo=`` kwarg + no ``tag=`` kwarg: tag falls through to env."""
+        monkeypatch.setenv("MAT_VIS_TAG", "vENV")
+        repo, tag, base = _resolve_repo_and_tag(repo_kwarg="org/explicit", tag_kwarg=None)
+        assert (repo, tag, base) == ("org/explicit", "vENV", None)
+
+    def test_layer2_combined_env_var(self):
+        import os
+
+        os.environ["MAT_VIS_DATASET"] = "gerchowl/mat-vis-tst@v2026.04.99-tst-full-369"
+        try:
+            repo, tag, base = _resolve_repo_and_tag(repo_kwarg=None, tag_kwarg=None)
+        finally:
+            del os.environ["MAT_VIS_DATASET"]
+        assert repo == "gerchowl/mat-vis-tst"
+        assert tag == "v2026.04.99-tst-full-369"
+        assert base is None
+
+    def test_layer2_combined_env_var_overrides_split_form(self, monkeypatch):
+        """When ``MAT_VIS_DATASET`` is set, ``MAT_VIS_HF_DATASET`` and
+        ``MAT_VIS_TAG`` from the split form must be ignored — the
+        combined form is the more-specific layer."""
+        monkeypatch.setenv("MAT_VIS_DATASET", "winner/repo@vWIN")
+        monkeypatch.setenv("MAT_VIS_HF_DATASET", "loser/repo")
+        monkeypatch.setenv("MAT_VIS_TAG", "vLOSE")
+        repo, tag, _ = _resolve_repo_and_tag(repo_kwarg=None, tag_kwarg=None)
+        assert (repo, tag) == ("winner/repo", "vWIN")
+
+    def test_layer3_split_env_vars(self, monkeypatch):
+        monkeypatch.setenv("MAT_VIS_HF_DATASET", "gerchowl/mat-vis-tst")
+        monkeypatch.setenv("MAT_VIS_TAG", "v2026.04.99")
+        repo, tag, base = _resolve_repo_and_tag(repo_kwarg=None, tag_kwarg=None)
+        assert (repo, tag, base) == ("gerchowl/mat-vis-tst", "v2026.04.99", None)
+
+    def test_layer3_dataset_env_with_default_tag(self, monkeypatch):
+        """``MAT_VIS_HF_DATASET`` alone → repo overridden, tag falls
+        back to ``DEFAULT_TAG``."""
+        monkeypatch.setenv("MAT_VIS_HF_DATASET", "gerchowl/mat-vis-tst")
+        repo, tag, base = _resolve_repo_and_tag(repo_kwarg=None, tag_kwarg=None)
+        assert (repo, tag, base) == ("gerchowl/mat-vis-tst", DEFAULT_TAG, None)
+
+    def test_layer4_legacy_hf_base_only(self, monkeypatch):
+        """``MAT_VIS_HF_BASE`` alone → repo parsed from URL,
+        ``base_override`` returned for verbatim URL composition."""
+        monkeypatch.setenv(
+            "MAT_VIS_HF_BASE",
+            "https://huggingface.co/datasets/gerchowl/mat-vis-tst/resolve",
+        )
+        repo, tag, base = _resolve_repo_and_tag(repo_kwarg=None, tag_kwarg=None)
+        assert repo == "gerchowl/mat-vis-tst"
+        assert tag == DEFAULT_TAG
+        assert base == "https://huggingface.co/datasets/gerchowl/mat-vis-tst/resolve"
+
+    def test_layer4_legacy_hf_base_non_hf_url(self, monkeypatch):
+        """Private-mirror URL that doesn't match the HF dataset
+        pattern: regex misses, repo defaults, base preserved verbatim."""
+        monkeypatch.setenv(
+            "MAT_VIS_HF_BASE",
+            "https://internal.mirror.example/private/textures",
+        )
+        repo, tag, base = _resolve_repo_and_tag(repo_kwarg=None, tag_kwarg=None)
+        # Repo couldn't be parsed → falls back to default.
+        assert repo == HF_DATASET
+        assert tag == DEFAULT_TAG
+        # Base preserved verbatim so URL composition still works.
+        assert base == "https://internal.mirror.example/private/textures"
+
+    def test_layer5_pure_default(self):
+        """No env, no kwargs → production defaults."""
+        repo, tag, base = _resolve_repo_and_tag(repo_kwarg=None, tag_kwarg=None)
+        assert repo == HF_DATASET
+        assert tag == DEFAULT_TAG
+        assert base is None
+
+    def test_higher_layer_wins_when_both_set(self, monkeypatch):
+        """When both combined-env (layer 2) AND legacy HF_BASE (layer 4)
+        are set, the combined-env value wins; HF_BASE is ignored."""
+        monkeypatch.setenv("MAT_VIS_DATASET", "winner/repo@vWIN")
+        monkeypatch.setenv(
+            "MAT_VIS_HF_BASE",
+            "https://huggingface.co/datasets/loser/repo/resolve",
+        )
+        repo, tag, base = _resolve_repo_and_tag(repo_kwarg=None, tag_kwarg=None)
+        assert (repo, tag, base) == ("winner/repo", "vWIN", None)
+
+    def test_combined_env_with_at_in_tag(self, monkeypatch):
+        """Defensive: ``rsplit("@", 1)`` so values containing ``@``
+        round-trip cleanly when only the FINAL ``@`` is the separator.
+        """
+        monkeypatch.setenv("MAT_VIS_DATASET", "org/repo@feature@v1")
+        repo, tag, _ = _resolve_repo_and_tag(repo_kwarg=None, tag_kwarg=None)
+        assert (repo, tag) == ("org/repo@feature", "v1")
+
+
+# ── End-to-end client wiring (URL composition + cache scope) ──────
+
+
+class TestClientWithRepoKwarg:
+    def test_repo_kwarg_routes_url_composition(self):
+        """``MatVisClient(repo=..., tag=...)`` composes manifest_url + hf_url
+        against the chosen dataset, not the prod default."""
+        with tempfile.TemporaryDirectory() as tmp:
+            client = MatVisClient(
+                repo="gerchowl/mat-vis-tst",
+                tag="v2026.04.99-tst-full-369",
+                cache_dir=Path(tmp),
+            )
+            assert (
+                client._manifest_url == "https://huggingface.co/datasets/gerchowl/mat-vis-tst"
+                "/resolve/v2026.04.99-tst-full-369/release-manifest.json"
+            )
+            assert client._hf_url("ambientcg.json") == (
+                "https://huggingface.co/datasets/gerchowl/mat-vis-tst"
+                "/resolve/v2026.04.99-tst-full-369/ambientcg.json"
+            )
+
+    def test_repo_kwarg_namespaces_cache(self):
+        """Two clients pointed at the SAME tag but DIFFERENT repos
+        must not collide on disk — pre-#384 they shared a scope."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_dir = Path(tmp)
+            c_prod = MatVisClient(repo="gerchowl/mat-vis", tag="v2026.04.2", cache_dir=cache_dir)
+            c_tst = MatVisClient(repo="gerchowl/mat-vis-tst", tag="v2026.04.2", cache_dir=cache_dir)
+            assert c_prod._cache_scope != c_tst._cache_scope, (
+                "cache scopes collided — one repo would serve the other's bytes"
+            )
+            # Sanity: both share the version segment (parent of the
+            # repo segment), only the repo segment differs.
+            assert c_prod._cache_scope.parent.parent == c_tst._cache_scope.parent.parent
+
+    def test_combined_env_var_drives_construction(self, monkeypatch):
+        """No kwargs, only ``MAT_VIS_DATASET`` env: client routes there."""
+        monkeypatch.setenv("MAT_VIS_DATASET", "gerchowl/mat-vis-tst@v2026.04.99")
+        with tempfile.TemporaryDirectory() as tmp:
+            client = MatVisClient(cache_dir=Path(tmp))
+            assert client._repo == "gerchowl/mat-vis-tst"
+            assert client._tag == "v2026.04.99"
+            assert "gerchowl/mat-vis-tst" in client._manifest_url
+            assert "v2026.04.99" in client._manifest_url
+
+    def test_at_forwards_repo(self):
+        """``client.at("v...")`` keeps routing to the same repo so
+        per-tag scopes under env-driven overrides don't silently drift
+        back to prod."""
+        with tempfile.TemporaryDirectory() as tmp:
+            parent = MatVisClient(
+                repo="gerchowl/mat-vis-tst",
+                tag="v2026.04.99",
+                cache_dir=Path(tmp),
+            )
+            child = parent.at("v2026.04.50")
+            assert child._repo == "gerchowl/mat-vis-tst"
+            assert child._tag == "v2026.04.50"
+            assert "gerchowl/mat-vis-tst" in child._hf_url("x.json")
+
+    def test_legacy_hf_base_url_preserved_verbatim(self, monkeypatch):
+        """Private-mirror URL shape (non-HF) stays intact end-to-end —
+        important for back-compat with existing CI / tests / mirrors."""
+        monkeypatch.setenv("MAT_VIS_HF_BASE", "https://mirror.example/textures")
+        with tempfile.TemporaryDirectory() as tmp:
+            client = MatVisClient(tag="v2026.04.0", cache_dir=Path(tmp))
+            assert client._base == "https://mirror.example/textures"
+            assert client._manifest_url.startswith("https://mirror.example/textures/v2026.04.0/")


### PR DESCRIPTION
## Summary

Closes #384.

Adds layered repo + tag override for `MatVisClient` so callers can point any client at a non-default HF dataset via three mechanisms — constructor kwargs, a single combined env var, or split env vars — without breaking the legacy `MAT_VIS_HF_BASE` form.

## Precedence chain (high → low)

| # | Mechanism | Example |
|---|---|---|
| 1 | Constructor kwargs | `MatVisClient(repo="gerchowl/mat-vis-tst", tag="v2026.04.99")` |
| 2 | Combined env var | `MAT_VIS_DATASET=gerchowl/mat-vis-tst@v2026.04.99` |
| 3 | Split env vars (PR #388 + new tag) | `MAT_VIS_HF_DATASET=gerchowl/mat-vis-tst` + `MAT_VIS_TAG=v2026.04.99` |
| 4 | Legacy full URL (back-compat) | `MAT_VIS_HF_BASE=https://huggingface.co/datasets/<repo>/resolve` |
| 5 | Default | `gerchowl/mat-vis @ DEFAULT_TAG` |

## Implementation

- **New `_resolve_repo_and_tag()` helper** — pure function returning `(repo, tag, base_override)`. Single call site in `__init__`. 11 table-driven tests cover every layer + edge cases (combined-env wins over split form, partial kwargs, non-HF private-mirror URLs, `@` in branch names, etc.).
- **`self._base`** replaces global `HF_BASE` reads in `_hf_url` + manifest URL composition. Every URL the client touches now routes through the resolved coordinate.
- **`at()` forwards `self._repo`** so per-tag scopes under env-driven overrides don't silently drift back to prod.
- **Cache layout gains a repo-slug segment**: `<cache_dir>/<client-version>/<repo-slug>/<tag>/`. Two clients pointed at the same tag but different repos no longer collide. Pre-#384 default-repo caches become one-shot orphans on upgrade — one cache miss, no data loss.
- **Standalone client mirrors all of the above** so the two clients honor identical precedence. Drift test still green. Also fixes the standalone tree-URL gap called out in #384's hidden-gap section (line 518 used to hardcode `HF_DATASET`).
- **Legacy `MAT_VIS_HF_BASE` URL preserved verbatim** for I/O so private-mirror URL shapes that don't match `huggingface.co/datasets/<repo>` keep working. The repo is best-effort parsed from the URL only for cache namespacing.

## Test plan

- [x] **Full client suite**: `uv run --with pytest --with-editable clients/python pytest clients/python/tests/` → **542 passed, 29 skipped, 2 xfailed**.
- [x] **Cross-client drift + version sync**: `pytest tests/test_standalone_drift.py tests/test_version_sync.py` → **11 passed**.
- [x] **New unit suite** `tests/test_client_repo_resolution.py` (16 cases): every precedence layer + cache-keying regression test (two clients, same tag, different repos → distinct cache scopes) + URL-composition assertions + `at()` repo forwarding + legacy URL verbatim preservation.
- [x] **Live smoke against tst dataset**:
  ```
  MAT_VIS_DATASET=gerchowl/mat-vis-tst@v2026.04.99-tst-full-369 \
    python -c "from mat_vis_client import MatVisClient; \
               print(len(MatVisClient().index('ambientcg')))"
  # → 1949 (matches the acceptance criteria from the issue)
  ```

## Notes / follow-ups

- Out of scope (P1, deferred): `bake/preview/run.py` (#361) `--repo` flag — orchestrator file does not yet exist on `dev`. Tracked in the issue.
- Coexistence with PR #388 (standalone tree-URL fix): this PR also includes the tree-URL fix using `self._repo` (which subsumes #388's `MAT_VIS_HF_DATASET` env-var routing). When #388 lands first, this PR will need a small rebase; when this PR lands first, #388 becomes redundant.