### PR TITLE
bugfix(baker): wire physicallybased transmissionDepth -> pbr.thickness (#398)

### DIFF
--- a/src/mat_vis_baker/sources/physicallybased.py
+++ b/src/mat_vis_baker/sources/physicallybased.py
@@ -101,6 +101,35 @@ def _transmission(raw: object) -> float | None:
         return None
 
 
+def _thickness(raw: object, transmission: object) -> float | None:
+    """Map upstream ``transmissionDepth`` → ``PBRBlock.thickness``, gated on
+    ``transmission > 0`` (mat-vis#398).
+
+    Mirrors the MTLX-parse convention (``_mtlx_scalars.py:660-674``):
+    thickness/``transmission_depth`` is the KHR_materials_volume
+    absorption-distance scalar and is only meaningful when the material
+    is transmissive. For opaque entries the value is rendering dead-code
+    and we drop it so the adapter doesn't ship a no-op volume extension.
+
+    Unit: physicallybased.info publishes ``transmissionDepth`` in metres
+    (e.g. Blood=0.08, Coffee=0.1), matching the MaterialX/glTF
+    ``thicknessFactor`` convention — no conversion needed.
+    """
+    if raw is None:
+        return None
+    try:
+        t = float(transmission) if transmission is not None else 0.0
+    except (TypeError, ValueError):
+        return None
+    if t <= 0.0:
+        return None
+    try:
+        v = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return v if v > 0.0 else None
+
+
 def _complex_ior(raw: object) -> list[float] | None:
     """Passthrough ``complexIor`` verbatim as a list of floats.
 
@@ -181,6 +210,7 @@ def fetch(*, session: requests.Session | None = None) -> list[MaterialRecord]:
                     ior=mat.get("ior"),
                     specular_f0=_specular_f0(mat.get("specularColor")),
                     transmission=_transmission(mat.get("transmission")),
+                    thickness=_thickness(mat.get("transmissionDepth"), mat.get("transmission")),
                     complex_ior=_complex_ior(mat.get("complexIor")),
                 ),
                 attribution=AttributionBlock(

--- a/tests/test_physicallybased_thickness.py
+++ b/tests/test_physicallybased_thickness.py
@@ -1,0 +1,128 @@
+"""Tests for mat-vis#398: physicallybased ``transmissionDepth`` →
+``PBRBlock.thickness`` mapping with the transmission>0 gate.
+
+Pre-fix, the fetcher emitted ``pbr.thickness = None`` for every entry
+even though ``transmissionDepth`` is in the upstream allowlist. Without
+thickness, the glTF adapter emits no ``KHR_materials_volume.thicknessFactor``
+and transmissive entries (Blood, Coffee — the only two with depth set
+upstream today) render as thin sheets.
+
+Convention mirrors the MTLX-parse path
+(``_mtlx_scalars.py:660-674``): thickness is only meaningful when the
+material is transmissive (``transmission > 0``); opaque entries drop the
+value so the adapter doesn't ship a no-op volume extension.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from mat_vis_baker.sources.physicallybased import _thickness, fetch
+
+
+# ── unit-level helper coverage ──────────────────────────────────────
+
+
+def test_thickness_transmissive_keeps_value() -> None:
+    """transmission>0 + valid depth → float passthrough."""
+    assert _thickness(0.08, 1.0) == 0.08
+
+
+def test_thickness_opaque_drops_value() -> None:
+    """transmission==0 → None even if depth authored upstream."""
+    assert _thickness(0.08, 0.0) is None
+
+
+def test_thickness_missing_transmission_drops_value() -> None:
+    """transmission missing → treat as opaque (None)."""
+    assert _thickness(0.08, None) is None
+
+
+def test_thickness_missing_depth_returns_none() -> None:
+    """No depth → None regardless of transmission."""
+    assert _thickness(None, 1.0) is None
+    assert _thickness(None, None) is None
+
+
+def test_thickness_zero_or_negative_depth_drops() -> None:
+    """Non-positive depth is dead authoring scaffold; drop it."""
+    assert _thickness(0.0, 1.0) is None
+    assert _thickness(-0.5, 1.0) is None
+
+
+def test_thickness_non_numeric_raw_returns_none() -> None:
+    assert _thickness("not a float", 1.0) is None
+
+
+def test_thickness_non_numeric_transmission_returns_none() -> None:
+    assert _thickness(0.08, "bogus") is None
+
+
+# ── end-to-end fetcher coverage ─────────────────────────────────────
+
+
+def test_fetch_maps_transmission_depth_to_thickness() -> None:
+    """Mocked physicallybased.info response covering the three cases the
+    issue calls out: transmissive→thickness set, opaque→thickness None,
+    missing field→thickness None."""
+    fake_api = [
+        {
+            "name": "Blood",
+            "category": "liquid",
+            "color": [0.5, 0.0, 0.0],
+            "ior": 1.301,
+            "roughness": 0.0,
+            "transmission": 1.0,
+            "transmissionDepth": 0.08,
+            "tags": [],
+        },
+        {
+            "name": "Aluminum",
+            "category": "metal",
+            "color": [0.9, 0.9, 0.9],
+            "ior": 1.39,
+            "metalness": 1.0,
+            "roughness": 0.0,
+            # opaque + authored depth must drop
+            "transmission": 0.0,
+            "transmissionDepth": 0.5,
+            "tags": [],
+        },
+        {
+            "name": "Banana",
+            "category": "organic",
+            "color": [1.0, 0.8, 0.2],
+            "ior": 1.45,
+            # no transmission, no depth — both None
+            "tags": [],
+        },
+    ]
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = fake_api
+
+    with patch(
+        "mat_vis_baker.sources.physicallybased.retry_request",
+        return_value=mock_resp,
+    ):
+        records = fetch()
+
+    by_name = {r.mat_vis.name: r for r in records}
+
+    blood = by_name["Blood"].mat_vis.pbr
+    assert blood.transmission == 1.0
+    assert blood.thickness == 0.08, (
+        "transmissive material must carry upstream transmissionDepth "
+        "through to PBRBlock.thickness (mat-vis#398)"
+    )
+
+    aluminum = by_name["Aluminum"].mat_vis.pbr
+    assert aluminum.transmission == 0.0
+    assert aluminum.thickness is None, (
+        "opaque material must drop thickness even when upstream authored "
+        "a depth value — KHR_materials_volume is rendering dead-code for "
+        "transmission=0 (mirrors _mtlx_scalars.py:660-674)"
+    )
+
+    banana = by_name["Banana"].mat_vis.pbr
+    assert banana.transmission is None
+    assert banana.thickness is None


### PR DESCRIPTION
## Summary

- One-field fix: 21 transmissive physicallybased entries (Glass, Acrylic, Water, Wine, …) shipped with `pbr.thickness = None` even though `transmissionDepth` is already in the upstream allowlist. Without thickness, the glTF adapter emits no `KHR_materials_volume.thicknessFactor` and transmissive materials render as thin sheets.
- Adds `_thickness(raw, transmission)` helper gated on `transmission > 0`, mirroring the MTLX-parse convention (`_mtlx_scalars.py:660-674`), and wires it into `PBRBlock` construction.
- Upstream publishes `transmissionDepth` in metres (Blood=0.08, Coffee=0.1 today) — matches MaterialX / glTF `thicknessFactor` so no unit conversion is needed; documented in the helper docstring.

## Notes

- Upstream survey today: 21/86 entries have `transmission > 0`, but only 2 (Blood, Coffee) actually author `transmissionDepth`. The remaining 19 stay `None` (correctly — there's nothing upstream to map). The acceptance bar from the issue ("≥15 transmissive entries ship `pbr.thickness > 0`") would require upstream to populate more entries; this PR fixes the wiring so they flow through once upstream fills them in.
- Opaque entries still ship `thickness = None` (transmission>0 gate).

## Test plan

- [x] New unit tests in `tests/test_physicallybased_thickness.py` (8 cases): helper-level transmission/depth combinations + end-to-end fetcher mock covering transmissive→set, opaque→None, missing→None
- [x] Full suite green locally: `pytest tests/` → 610 passed, 20 skipped

Closes #398.