### PR TITLE
feat(baker): extract `coat` factor into PBRBlock.clearcoat (#396)

### DIFF
--- a/src/mat_vis_baker/_mtlx_scalars.py
+++ b/src/mat_vis_baker/_mtlx_scalars.py
@@ -51,6 +51,11 @@ _FLOAT_INPUTS: dict[str, str] = {
     "specular": "specular_intensity",  # KHR_materials_specular.specularFactor
     "transmission_dispersion": "dispersion",  # KHR_materials_dispersion.dispersion
     "coat_roughness": "clearcoat_roughness",  # KHR_materials_clearcoat.clearcoatRoughnessFactor
+    # Clearcoat enabled/disabled switch (#396). Without this, the
+    # ``coat_roughness`` parameter ships but the on/off ``coat``
+    # factor is silently dropped — every entry looks the same to
+    # consumers reading the scalar block.
+    "coat": "clearcoat",  # KHR_materials_clearcoat.clearcoatFactor
 }
 
 # Color3 inputs. Same direct value=/1-hop graph→constant promotion as
@@ -64,7 +69,6 @@ _COLOR3_INPUTS: dict[str, str] = {
 # Inputs that have no PBRBlock home today. Non-zero values are dropped
 # with a structured warning so a future schema add knows where to look.
 _LOSSY_INPUTS: tuple[str, ...] = (
-    "coat",
     "coat_IOR",
     "coat_color",
     "sheen",

--- a/src/mat_vis_baker/common.py
+++ b/src/mat_vis_baker/common.py
@@ -456,6 +456,11 @@ class PBRBlock:
     # routes these to KHR_materials_specular / _volume / _dispersion /
     # _clearcoat extensions for glTF and to MeshPhysicalMaterial native
     # properties for Three.js. py-mat #100.
+    # Clearcoat enabled/disabled switch (#396). Sibling of
+    # ``clearcoat_roughness`` — without this, consumers can't tell when
+    # clearcoat is intended (the roughness defaults to 0.1 for the whole
+    # gpuopen corpus regardless of whether ``coat`` is authored).
+    clearcoat: float | None = None  # <standard_surface>.coat
     clearcoat_roughness: float | None = None  # <standard_surface>.coat_roughness
     specular_intensity: float | None = None  # <standard_surface>.specular
     specular_color: list[float] | None = None  # <standard_surface>.specular_color, LINEAR RGB

--- a/tests/test_index_builder.py
+++ b/tests/test_index_builder.py
@@ -85,6 +85,8 @@ def test_mat_vis_block_has_stable_key_set() -> None:
         "specular_color",
         "thickness",
         "dispersion",
+        # Clearcoat on/off switch (#396) — additive.
+        "clearcoat",
     }
     # Nested AttributionBlock
     assert set(mv["attribution"].keys()) == {"authors", "license_spdx", "source_url"}
@@ -116,6 +118,8 @@ def test_mat_vis_block_defaults_are_null_or_empty() -> None:
     assert mv["pbr"]["specular_color"] is None
     assert mv["pbr"]["thickness"] is None
     assert mv["pbr"]["dispersion"] is None
+    # Clearcoat on/off switch (#396) — additive, default-None.
+    assert mv["pbr"]["clearcoat"] is None
     assert mv["attribution"]["authors"] == []
     assert mv["dates"]["published"] is None
     assert mv["dates"]["updated"] is None

--- a/tests/test_mtlx_scalars.py
+++ b/tests/test_mtlx_scalars.py
@@ -245,11 +245,13 @@ def test_lossy_coat_inputs_logged_and_dropped(caplog):
     # noise, not signal. Capture at DEBUG so the test still observes.
     with caplog.at_level(logging.DEBUG, logger="mat-vis-baker.gpuopen-scalars"):
         pbr = parse_standard_surface_scalars(FIXTURE_LOSSY_COAT, material_id="m-coat")
-    # Coat amount has no PBRBlock home — verify NOT smuggled into any field.
     assert pbr.color_rgb == [0.5, 0.5, 0.5]
     msgs = [rec.message for rec in caplog.records]
-    assert any("coat=0.8" in m for m in msgs)
-    # coat_roughness is now extracted into pbr.clearcoat_roughness (#340).
+    # coat is now extracted into pbr.clearcoat (#396) — it's the on/off
+    # switch for KHR_materials_clearcoat. No longer logged as lossy.
+    assert pbr.clearcoat == 0.8
+    assert not any("coat=0.8" in m for m in msgs)
+    # coat_roughness is also extracted into pbr.clearcoat_roughness (#340).
     assert pbr.clearcoat_roughness == 0.1
     # sheen=0.0 should NOT be logged (zero is not lossy).
     assert not any("sheen=" in m for m in msgs)

--- a/tests/test_mtlx_scalars_pbr_coverage.py
+++ b/tests/test_mtlx_scalars_pbr_coverage.py
@@ -1,15 +1,17 @@
-"""Bake-side extraction tests for #340 — full MeshPhysicalMaterial PBR coverage.
+"""Bake-side extraction tests for #340 / #396 — full MeshPhysicalMaterial coverage.
 
-5 new scalar fields + 1 conditional + 1 color3:
-- coat_roughness         → clearcoat_roughness (float)
-- specular               → specular_intensity (float)
-- specular_color         → specular_color (color3, linear)
-- transmission_dispersion → dispersion (float)
-- transmission_depth     → thickness (float, only when transmission > 0)
+Scalar fields extracted from ``<standard_surface>``:
+- coat                   → clearcoat (float, #396)
+- coat_roughness         → clearcoat_roughness (float, #340)
+- specular               → specular_intensity (float, #340)
+- specular_color         → specular_color (color3, linear, #340)
+- transmission_dispersion → dispersion (float, #340)
+- transmission_depth     → thickness (float, only when transmission > 0, #340)
 
-All extracted from <standard_surface> direct `value=` attributes.
-Survey of 454 gpuopen materials confirms each input is authored
-~80-95% of the time; specular_color is 94% non-default.
+All extracted from <standard_surface> direct `value=` attributes or
+1-hop nodegraph→<constant> chains. Survey of 454 gpuopen materials
+confirms each input is authored ~80-95% of the time; specular_color
+is 94% non-default; coat is 3/454 (Car Paint family).
 """
 
 from __future__ import annotations
@@ -88,6 +90,77 @@ class TestClearcoatRoughness:
         assert pbr.clearcoat_roughness == pytest.approx(0.1)
 
 
+class TestClearcoat:
+    """``coat`` factor extraction (#396) — the on/off switch for
+    KHR_materials_clearcoat. Survey of 454 gpuopen materials: 451
+    author the default 0.0, 3 (Car Paint family) author > 0."""
+
+    def test_coat_authored_non_default(self) -> None:
+        # Car Paint family authors coat=1.0 — fully-clearcoated.
+        pbr = parse_standard_surface_scalars(_wrap('<input name="coat" type="float" value="1.0"/>'))
+        assert pbr.clearcoat == pytest.approx(1.0)
+
+    def test_coat_authored_partial(self) -> None:
+        pbr = parse_standard_surface_scalars(_wrap('<input name="coat" type="float" value="0.5"/>'))
+        assert pbr.clearcoat == pytest.approx(0.5)
+
+    def test_coat_default_zero_extracted(self) -> None:
+        # 451/454 corpus materials default to 0.0 — extracting it
+        # confirms provenance. Adapter suppresses the spec-default
+        # KHR extension entry.
+        pbr = parse_standard_surface_scalars(_wrap('<input name="coat" type="float" value="0.0"/>'))
+        assert pbr.clearcoat == pytest.approx(0.0)
+
+    def test_coat_unset_stays_none(self) -> None:
+        pbr = parse_standard_surface_scalars(_wrap())
+        assert pbr.clearcoat is None
+
+    def test_coat_texture_bound_stays_none(self) -> None:
+        # 1 corpus material binds ``coat`` to a texture via nodegraph.
+        # Consistent with metalness-texture-bound handling: leave the
+        # field None; the baker carries the texture path separately.
+        mtlx = """<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="NG_COAT">
+    <image name="coat_img" type="float">
+      <input name="file" type="filename" value="coat.png"/>
+    </image>
+    <output name="coat_out" type="float" nodename="coat_img"/>
+  </nodegraph>
+  <standard_surface name="SR_T" type="surfaceshader">
+    <input name="coat" type="float" output="coat_out" nodegraph="NG_COAT"/>
+  </standard_surface>
+  <surfacematerial name="T" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_T"/>
+  </surfacematerial>
+</materialx>
+"""
+        pbr = parse_standard_surface_scalars(mtlx)
+        assert pbr.clearcoat is None
+
+    def test_coat_graph_constant_promoted(self) -> None:
+        # 1-hop nodegraph → <constant> resolution applies to ``coat``
+        # the same way it does for every other _FLOAT_INPUT.
+        mtlx = """<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="NG_COAT">
+    <constant name="coat_const" type="float">
+      <input name="value" type="float" value="0.75"/>
+    </constant>
+    <output name="coat_out" type="float" nodename="coat_const"/>
+  </nodegraph>
+  <standard_surface name="SR_T" type="surfaceshader">
+    <input name="coat" type="float" output="coat_out" nodegraph="NG_COAT"/>
+  </standard_surface>
+  <surfacematerial name="T" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_T"/>
+  </surfacematerial>
+</materialx>
+"""
+        pbr = parse_standard_surface_scalars(mtlx)
+        assert pbr.clearcoat == pytest.approx(0.75)
+
+
 class TestDispersion:
     def test_dispersion_authored(self) -> None:
         pbr = parse_standard_surface_scalars(
@@ -141,6 +214,7 @@ class TestPBRBlockFieldsExist:
 
         pbr = PBRBlock()
         for fname in (
+            "clearcoat",
             "clearcoat_roughness",
             "specular_intensity",
             "specular_color",
@@ -153,11 +227,13 @@ class TestPBRBlockFieldsExist:
         from mat_vis_baker.common import PBRBlock
 
         pbr = PBRBlock()
+        pbr.clearcoat = 1.0
         pbr.clearcoat_roughness = 0.2
         pbr.specular_intensity = 0.8
         pbr.specular_color = [0.95, 0.5, 0.3]
         pbr.thickness = 5.0
         pbr.dispersion = 0.1
+        assert pbr.clearcoat == 1.0
         assert pbr.clearcoat_roughness == 0.2
         assert pbr.specular_intensity == 0.8
         assert pbr.specular_color == [0.95, 0.5, 0.3]


### PR DESCRIPTION
## Summary

Closes #396.

The gpuopen MTLX scalar parser extracts `coat_roughness` → `PBRBlock.clearcoat_roughness` (#340) but the matching `coat` factor (the on/off switch for clearcoat) was in `_LOSSY_INPUTS` and silently dropped. On the v2026.04.99 corpus, 423/454 gpuopen entries shipped `clearcoat_roughness` at default, but the 3 entries authoring `coat > 0` (Car Paint family) were indistinguishable from the rest.

- Move `coat` from `_LOSSY_INPUTS` to `_FLOAT_INPUTS` in `src/mat_vis_baker/_mtlx_scalars.py`.
- Add `PBRBlock.clearcoat: float | None = None` sibling to `clearcoat_roughness` in `src/mat_vis_baker/common.py`.
- Extend stable-key-set + default-None contract tests in `tests/test_index_builder.py`.
- New `TestClearcoat` class in `tests/test_mtlx_scalars_pbr_coverage.py` covers direct value, partial, default-zero, unset, texture-bound (stays None), and 1-hop graph-constant promotion.
- Update existing `test_lossy_coat_inputs_logged_and_dropped` to reflect that `coat` is no longer lossy.

Adapter wiring (`to_threejs` → `clearcoat`, `to_gltf` → `KHR_materials_clearcoat.clearcoatFactor`) and client passthrough are already in place from #380 — no client-side changes needed.

## Acceptance criteria

- [x] `PBRBlock.clearcoat` field added (additive — stable key-set contract honored)
- [x] Parser extracts `coat` value via direct or 1-hop graph-constant promotion
- [x] Adapter routes `clearcoat` factor for Three.js + glTF (already wired — verified by existing `test_adapters_emissive_clearcoat.py` suite)
- [x] Unit tests: authored-clearcoat fixtures + regression-guard for default
- [x] Index-builder test pin (`PBRBlock` stable key-set updated)
- [x] Stable-key-set test in `test_index_builder.py` extended
- [x] All existing tests pass (608 baker, 590 client passed in this branch)

## Test plan

- [x] `uv run --extra baker --extra dev pytest tests/` — 608 passed, 20 skipped
- [x] `cd clients/python && uv run --extra test --extra gltf --extra search pytest tests/` — 590 passed, 29 skipped, 2 xfailed
- [ ] Post-merge: dispatch `bake.yml` on `gerchowl/mat-vis-tst` and confirm ≥3 gpuopen entries (Car Paint family) emit `pbr.clearcoat > 0` in the substrate

## Pitfalls

- **Schema-add stickiness**: once shipped, clients pin to it. Decision per #396: net-additive, no removal pressure given Three.js MeshPhysical's first-class `clearcoat` property.
- **Texture-bound `coat`**: 1 corpus material has it texture-bound. Field stays `None` (consistent with metalness-texture-bound handling); no neutral-multiplier convention added.