### PR TITLE
feat(baker): wire MTLX scalar parser into ambientcg + polyhaven (#397)

### DIFF
--- a/src/mat_vis_baker/common.py
+++ b/src/mat_vis_baker/common.py
@@ -512,6 +512,53 @@ def apply_pbr_neutral_multiplier_conventions(
     return pbr
 
 
+# Fields that the MTLX parser may populate. Used by
+# :func:`merge_mtlx_pbr_additive` to enumerate which attributes are
+# eligible for the "fill-only-if-None" merge.
+#
+# NOTE: ``metalness_source`` rides with ``metalness`` — when we copy a
+# parser-authored metalness value over, we also copy the provenance
+# string so downstream consumers (#316 library-browser facets) see the
+# original source. Other "side-band" fields (``is_conductor``,
+# ``metalness_mean``) follow the same rule.
+_MTLX_PBR_MERGE_FIELDS: tuple[str, ...] = (
+    "color_rgb",
+    "roughness",
+    "metalness",
+    "ior",
+    "transmission",
+    "is_conductor",
+    "metalness_mean",
+    "metalness_source",
+    "clearcoat_roughness",
+    "specular_intensity",
+    "specular_color",
+    "thickness",
+    "dispersion",
+)
+
+
+def merge_mtlx_pbr_additive(target: PBRBlock, parsed: PBRBlock) -> PBRBlock:
+    """Copy MTLX-parsed fields into ``target`` ONLY where target is None.
+
+    Per-source upstream JSON fetchers (#397) may already have authored
+    base PBR fields (``color_rgb``, ``roughness``, ``metalness``, ``ior``)
+    from their JSON catalog. The MTLX scalar parser is additive: it
+    fills the Phase-2 fields (``clearcoat_roughness``, ``specular_*``,
+    ``transmission``, ``thickness``, ``dispersion``) the JSON couldn't
+    carry, and only touches the base fields if the JSON left them None.
+    Mirrors the gpuopen reference path (which has no upstream JSON PBR
+    today, but the same rule applies uniformly).
+    Modifies ``target`` in place AND returns it so callers can chain.
+    """
+    for attr in _MTLX_PBR_MERGE_FIELDS:
+        if getattr(target, attr) is None:
+            mtlx_val = getattr(parsed, attr)
+            if mtlx_val is not None:
+                setattr(target, attr, mtlx_val)
+    return target
+
+
 @dataclass
 class AttributionBlock:
     """Upstream attribution / licensing (SPDX where known)."""

--- a/src/mat_vis_baker/sources/ambientcg.py
+++ b/src/mat_vis_baker/sources/ambientcg.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import requests
 
+from mat_vis_baker._mtlx_scalars import parse_standard_surface_scalars
 from mat_vis_baker.sources import _apply_filter_ids
 from mat_vis_baker.common import (
     TIER_TO_PX,
@@ -28,6 +29,7 @@ from mat_vis_baker.common import (
     _filter_upstream,
     apply_pbr_neutral_multiplier_conventions,
     check_zip_safety,
+    merge_mtlx_pbr_additive,
     normalize_category,
     normalize_channel,
     retry_request,
@@ -186,11 +188,19 @@ def _inject_mtlx_comment(mtlx_bytes: bytes, material_id: str, source_url: str) -
 
 def _extract_maps_from_zip(
     zip_bytes: bytes, material_id: str, output_dir: Path, *, mtlx_dir: Path | None = None
-) -> dict[str, Path]:
-    """Extract PNG textures and mtlx from a ZIP, normalize channel names."""
+) -> tuple[dict[str, Path], Path | None]:
+    """Extract PNG textures + mtlx from a ZIP, normalize channel names.
+
+    Returns ``(textures, mtlx_path)``. ``mtlx_path`` is the on-disk path
+    of the extracted .mtlx (when ``mtlx_dir`` was supplied AND the ZIP
+    carried one), or ``None`` otherwise. The mtlx path lets
+    :func:`_fetch_one` feed the scalar parser without re-reading the
+    ZIP — same shape as ``gpuopen._extract_from_zip`` (#397).
+    """
     mat_dir = output_dir / material_id
     mat_dir.mkdir(parents=True, exist_ok=True)
     result: dict[str, Path] = {}
+    mtlx_path: Path | None = None
 
     source_url = f"https://ambientcg.com/a/{material_id}"
 
@@ -210,6 +220,7 @@ def _extract_maps_from_zip(
                 mtlx_out.parent.mkdir(parents=True, exist_ok=True)
                 raw = zf.read(name)
                 mtlx_out.write_bytes(_inject_mtlx_comment(raw, material_id, source_url))
+                mtlx_path = mtlx_out
                 continue
 
             m = _CHANNEL_RE.search(name)
@@ -235,7 +246,7 @@ def _extract_maps_from_zip(
     # read `maps` per-entry and never assume a uniform channel set, so
     # this is fine end-to-end. Verified 2026-04-28 against ambientcg's
     # 1k+2k zips for both materials.
-    return result
+    return result, mtlx_path
 
 
 # ── curated-field extraction (Phase B, mat-vis#152) ─────────────
@@ -311,7 +322,9 @@ def _fetch_one(entry: dict, tier: str, output_dir: Path, mtlx_dir: Path | None) 
     try:
         dl_url = _extract_download_url(entry, tier)
         resp = retry_request(dl_url)
-        textures = _extract_maps_from_zip(resp.content, mid, output_dir, mtlx_dir=mtlx_dir)
+        textures, mtlx_path = _extract_maps_from_zip(
+            resp.content, mid, output_dir, mtlx_dir=mtlx_dir
+        )
 
         if not textures:
             return MaterialRecord(
@@ -337,12 +350,30 @@ def _fetch_one(entry: dict, tier: str, output_dir: Path, mtlx_dir: Path | None) 
         release_date = (entry.get("releaseDate") or "")[:10] or None
         description = entry.get("description") or None
 
-        # glTF-MR neutral-multiplier convention (mat-vis#290 follow-up):
-        # ambientcg doesn't expose scalar PBR properties upstream, so the
-        # helper is the only path that populates ``pbr.*`` fields — fills
-        # color/metalness/roughness with their glTF-MR neutral
-        # multipliers when the matching texture is in the baked set.
+        # ambientcg's upstream JSON doesn't expose scalar PBR properties
+        # today — the BASE PBR fields (color_rgb, roughness, metalness,
+        # ior) start empty and the convention helper fills the texture-
+        # bound neutrals. MTLX parse layers in the Phase-2 fields
+        # (clearcoat_roughness, specular_*, transmission, thickness,
+        # dispersion) when the ZIP shipped a .mtlx with <standard_surface>
+        # scalars (#397). Missing-MTLX path is a no-op — same shape as
+        # gpuopen's reference wiring.
         pbr = PBRBlock()
+        if mtlx_path is not None:
+            try:
+                parsed = parse_standard_surface_scalars(
+                    mtlx_path.read_text(encoding="utf-8"),
+                    material_id=mid,
+                )
+                merge_mtlx_pbr_additive(pbr, parsed)
+            except Exception:
+                # Contract: scalar parsing must NEVER break the fetch
+                # path. Catch broadly (e.g. UnicodeDecodeError on
+                # non-utf8 mtlx, or any future parser failure) and
+                # continue without the MTLX-derived fields.
+                log.exception("%s: could not read mtlx for scalar parse", mid)
+        else:
+            log.debug("%s: no mtlx in ZIP — skipping scalar parse", mid)
         apply_pbr_neutral_multiplier_conventions(pbr, textures)
 
         return MaterialRecord(

--- a/src/mat_vis_baker/sources/polyhaven.py
+++ b/src/mat_vis_baker/sources/polyhaven.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import requests
 
+from mat_vis_baker._mtlx_scalars import parse_standard_surface_scalars
 from mat_vis_baker.sources import _apply_filter_ids
 from mat_vis_baker.common import (
     AttributionBlock,
@@ -24,6 +25,7 @@ from mat_vis_baker.common import (
     UpstreamBlock,
     _filter_upstream,
     apply_pbr_neutral_multiplier_conventions,
+    merge_mtlx_pbr_additive,
     normalize_category,
     normalize_channel,
     retry_request,
@@ -303,8 +305,9 @@ def _fetch_one(
 
         # MTLX is best-effort and runs after textures land — mtlx_dir is
         # optional; when None we don't bother (matches the pre-#96 behavior).
+        mtlx_path: Path | None = None
         if mtlx_dir is not None:
-            _download_mtlx(file_info, tier, mtlx_dir, slug)
+            mtlx_path = _download_mtlx(file_info, tier, mtlx_dir, slug)
 
         if not textures:
             return MaterialRecord(
@@ -339,12 +342,29 @@ def _fetch_one(
         cat = normalize_category(cat_str, [*cat_list[1:], *tags])
         description = meta.get("description") or None
 
-        # glTF-MR neutral-multiplier convention (mat-vis#290 follow-up):
-        # polyhaven doesn't currently parse PBR scalars from any source,
-        # so the helper is the only path that populates ``pbr.*`` fields
-        # — fills color/metalness/roughness with their glTF-MR neutral
-        # multipliers when the matching texture is in the baked set.
+        # polyhaven's upstream JSON doesn't expose scalar PBR properties
+        # today — the BASE PBR fields (color_rgb, roughness, metalness,
+        # ior) start empty and the convention helper fills the texture-
+        # bound neutrals. MTLX parse layers in the Phase-2 fields
+        # (clearcoat_roughness, specular_*, transmission, thickness,
+        # dispersion) when the per-tier MTLX is present (#397). Missing
+        # MTLX is graceful — per ``_download_mtlx`` docstring, not every
+        # polyhaven material ships an MTLX for every tier.
         pbr = PBRBlock()
+        if mtlx_path is not None:
+            try:
+                parsed = parse_standard_surface_scalars(
+                    mtlx_path.read_text(encoding="utf-8"),
+                    material_id=slug,
+                )
+                merge_mtlx_pbr_additive(pbr, parsed)
+            except Exception:
+                # Contract: scalar parsing must NEVER break the fetch
+                # path. Catch broadly and continue without MTLX-derived
+                # fields — textures still flow through.
+                log.exception("%s: could not read mtlx for scalar parse", slug)
+        else:
+            log.debug("%s: no mtlx available for this tier — skipping scalar parse", slug)
         apply_pbr_neutral_multiplier_conventions(pbr, textures)
 
         return MaterialRecord(

--- a/tests/test_ambientcg_mtlx_scalars.py
+++ b/tests/test_ambientcg_mtlx_scalars.py
@@ -1,0 +1,233 @@
+"""Tests for the ambientcg `_fetch_one` mtlx-scalar wiring (#397).
+
+ambientcg ZIPs ship a .mtlx alongside the flat texture PNGs. Pre-#397
+the fetcher extracted the .mtlx to disk but never parsed scalars — so
+2,706 entries across ambientcg+polyhaven were emitting None for the
+Phase-2 PBR fields (``clearcoat_roughness``, ``specular_color`` etc).
+
+These tests mirror ``test_gpuopen_baker``'s synthesised-MTLX fixtures
+and cover:
+  - happy path: MTLX scalars land on the PBRBlock
+  - missing-MTLX path: graceful, no exception, no fields lost
+  - merge rule: an upstream-JSON-authored field is NOT overridden by
+    MTLX (today no JSON path authors PBR, but the regression guard
+    pins the additive-merge contract for future expansion)
+  - texture-bound neutral convention still fires alongside parse
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from mat_vis_baker.common import PBRBlock, merge_mtlx_pbr_additive
+from mat_vis_baker.sources.ambientcg import _fetch_one
+
+
+_FAKE_MTLX = b"""<?xml version="1.0"?>
+<materialx version="1.38">
+  <standard_surface name="acg_shader" type="surfaceshader">
+    <input name="base" type="float" value="1.0"/>
+    <input name="base_color" type="color3" value="0.55, 0.35, 0.25"/>
+    <input name="metalness" type="float" value="0.0"/>
+    <input name="specular_roughness" type="float" value="0.6"/>
+    <input name="specular_IOR" type="float" value="1.45"/>
+    <input name="specular" type="float" value="0.8"/>
+    <input name="specular_color" type="color3" value="0.95, 0.92, 0.90"/>
+    <input name="coat_roughness" type="float" value="0.12"/>
+    <input name="transmission" type="float" value="0.0"/>
+    <input name="transmission_dispersion" type="float" value="0.02"/>
+  </standard_surface>
+  <surfacematerial name="acg_mat" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="acg_shader"/>
+  </surfacematerial>
+</materialx>
+"""
+
+
+_FAKE_GLASS_MTLX = b"""<?xml version="1.0"?>
+<materialx version="1.38">
+  <standard_surface name="glass_shader" type="surfaceshader">
+    <input name="base" type="float" value="1.0"/>
+    <input name="base_color" type="color3" value="0.9, 0.95, 0.95"/>
+    <input name="metalness" type="float" value="0.0"/>
+    <input name="specular_roughness" type="float" value="0.05"/>
+    <input name="specular_IOR" type="float" value="1.52"/>
+    <input name="transmission" type="float" value="1.0"/>
+    <input name="transmission_depth" type="float" value="0.01"/>
+  </standard_surface>
+  <surfacematerial name="glass" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="glass_shader"/>
+  </surfacematerial>
+</materialx>
+"""
+
+
+def _zip_with_mtlx_and_color(mtlx_bytes: bytes = _FAKE_MTLX) -> bytes:
+    """ambientcg-shaped ZIP: ``Bricks097_1K-PNG/...`` with mtlx + Color PNG."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("Bricks097_1K-PNG/Bricks097.mtlx", mtlx_bytes)
+        zf.writestr(
+            "Bricks097_1K-PNG/Bricks097_1K-PNG_Color.png",
+            b"\x89PNG\r\n\x1a\nfake",
+        )
+    return buf.getvalue()
+
+
+def _zip_without_mtlx() -> bytes:
+    """Older-format ambientcg ZIP with no .mtlx — must not break the fetch."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(
+            "Bricks097_1K-PNG/Bricks097_1K-PNG_Color.png",
+            b"\x89PNG\r\n\x1a\nfake",
+        )
+    return buf.getvalue()
+
+
+def _entry() -> dict:
+    return {
+        "assetId": "Bricks097",
+        "displayName": "Bricks 097",
+        "displayCategory": "Ceramic/Brick",
+        "tags": ["brick"],
+        "downloadFolders": {
+            "default": {
+                "downloadFiletypeCategories": {
+                    "zip": {
+                        "downloads": [
+                            {
+                                "attribute": "1K-PNG",
+                                "fullDownloadPath": "https://example.com/Bricks097_1K-PNG.zip",
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+    }
+
+
+# ── happy path ──────────────────────────────────────────────────
+
+
+def test_fetch_one_populates_pbr_from_mtlx(tmp_path: Path) -> None:
+    """The success path parses the .mtlx and PBRBlock fields are set."""
+    mock_resp = MagicMock(content=_zip_with_mtlx_and_color())
+    mtlx_dir = tmp_path / "mtlx"
+    output_dir = tmp_path / "out"
+    with patch("mat_vis_baker.sources.ambientcg.retry_request", return_value=mock_resp):
+        rec = _fetch_one(_entry(), "1k", output_dir, mtlx_dir=mtlx_dir)
+
+    assert rec.status == "ok"
+    pbr = rec.mat_vis.pbr
+    assert pbr.metalness == 0.0
+    assert pbr.roughness == 0.6
+    assert pbr.ior == 1.45
+    assert pbr.specular_intensity == 0.8
+    assert pbr.specular_color == [0.95, 0.92, 0.90]
+    assert pbr.clearcoat_roughness == 0.12
+    assert pbr.dispersion == 0.02
+    # base * base_color
+    assert pbr.color_rgb == [0.55, 0.35, 0.25]
+
+
+def test_fetch_one_glass_transmission_and_thickness(tmp_path: Path) -> None:
+    """Transmission>0 material picks up transmission AND thickness."""
+    mock_resp = MagicMock(content=_zip_with_mtlx_and_color(_FAKE_GLASS_MTLX))
+    mtlx_dir = tmp_path / "mtlx"
+    output_dir = tmp_path / "out"
+    with patch("mat_vis_baker.sources.ambientcg.retry_request", return_value=mock_resp):
+        rec = _fetch_one(_entry(), "1k", output_dir, mtlx_dir=mtlx_dir)
+
+    assert rec.status == "ok"
+    assert rec.mat_vis.pbr.transmission == 1.0
+    # thickness is gated on transmission > 0 — see _mtlx_scalars
+    assert rec.mat_vis.pbr.thickness == 0.01
+
+
+# ── missing-MTLX is graceful ────────────────────────────────────
+
+
+def test_fetch_one_no_mtlx_no_exception(tmp_path: Path) -> None:
+    """Old-format ZIPs without .mtlx still produce a usable record."""
+    mock_resp = MagicMock(content=_zip_without_mtlx())
+    mtlx_dir = tmp_path / "mtlx"
+    output_dir = tmp_path / "out"
+    with patch("mat_vis_baker.sources.ambientcg.retry_request", return_value=mock_resp):
+        rec = _fetch_one(_entry(), "1k", output_dir, mtlx_dir=mtlx_dir)
+
+    assert rec.status == "ok"
+    # Phase-2 fields stay None (parser never ran)
+    assert rec.mat_vis.pbr.clearcoat_roughness is None
+    assert rec.mat_vis.pbr.specular_intensity is None
+    # color texture is bound → convention fills [1, 1, 1]
+    assert rec.mat_vis.pbr.color_rgb == [1.0, 1.0, 1.0]
+
+
+def test_fetch_one_mtlx_dir_none_is_graceful(tmp_path: Path) -> None:
+    """Caller can pass mtlx_dir=None — fetcher must not attempt parse."""
+    mock_resp = MagicMock(content=_zip_with_mtlx_and_color())
+    output_dir = tmp_path / "out"
+    with patch("mat_vis_baker.sources.ambientcg.retry_request", return_value=mock_resp):
+        rec = _fetch_one(_entry(), "1k", output_dir, mtlx_dir=None)
+
+    assert rec.status == "ok"
+    # Parser not invoked → Phase-2 fields stay None
+    assert rec.mat_vis.pbr.clearcoat_roughness is None
+    assert rec.mat_vis.pbr.specular_intensity is None
+
+
+# ── merge-rule regression ───────────────────────────────────────
+
+
+def test_merge_helper_does_not_override_upstream(tmp_path: Path) -> None:
+    """The additive-merge helper preserves upstream-authored values.
+
+    Regression guard for the issue's merge-order rule: MTLX is additive
+    for fields the upstream JSON couldn't carry. We test the helper
+    directly because no ambientcg upstream path authors base PBR today
+    — but a future contributor wiring upstream JSON PBR into ambientcg
+    must not be able to silently regress the rule.
+    """
+    upstream = PBRBlock(
+        color_rgb=[0.1, 0.2, 0.3],  # JSON-authored
+        roughness=0.9,
+        metalness=0.0,
+        ior=1.4,
+    )
+    parsed = PBRBlock(
+        color_rgb=[0.5, 0.5, 0.5],  # MTLX disagrees — must NOT override
+        roughness=0.6,
+        metalness=1.0,
+        ior=1.5,
+        clearcoat_roughness=0.1,
+        specular_intensity=0.8,
+    )
+    merge_mtlx_pbr_additive(upstream, parsed)
+
+    # Upstream wins for fields it authored
+    assert upstream.color_rgb == [0.1, 0.2, 0.3]
+    assert upstream.roughness == 0.9
+    assert upstream.metalness == 0.0
+    assert upstream.ior == 1.4
+    # MTLX fills the Phase-2 fields the JSON couldn't carry
+    assert upstream.clearcoat_roughness == 0.1
+    assert upstream.specular_intensity == 0.8
+
+
+def test_merge_helper_fills_none_gaps() -> None:
+    """When upstream is None, MTLX values flow through."""
+    upstream = PBRBlock()
+    parsed = PBRBlock(
+        color_rgb=[0.5, 0.4, 0.3],
+        roughness=0.7,
+        clearcoat_roughness=0.15,
+    )
+    merge_mtlx_pbr_additive(upstream, parsed)
+    assert upstream.color_rgb == [0.5, 0.4, 0.3]
+    assert upstream.roughness == 0.7
+    assert upstream.clearcoat_roughness == 0.15

--- a/tests/test_polyhaven_mtlx_scalars.py
+++ b/tests/test_polyhaven_mtlx_scalars.py
@@ -1,0 +1,259 @@
+"""Tests for the polyhaven `_fetch_one` mtlx-scalar wiring (#397).
+
+Polyhaven publishes a per-tier .mtlx document alongside the texture
+maps. Pre-#397 the fetcher downloaded the .mtlx to disk but never
+parsed scalars — so 757 polyhaven entries shipped without Phase-2
+PBR fields.
+
+These tests synthesise a small MTLX, mock the polyhaven per-asset
+file map + downloader so no network is touched, and assert the
+``MaterialRecord.mat_vis.pbr`` picks up the parsed scalars while the
+texture-bound neutral convention still fires.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from mat_vis_baker.sources.polyhaven import _fetch_one
+
+
+_FAKE_MTLX = b"""<?xml version="1.0"?>
+<materialx version="1.38">
+  <standard_surface name="ph_shader" type="surfaceshader">
+    <input name="base" type="float" value="1.0"/>
+    <input name="base_color" type="color3" value="0.42, 0.32, 0.22"/>
+    <input name="metalness" type="float" value="0.0"/>
+    <input name="specular_roughness" type="float" value="0.5"/>
+    <input name="specular_IOR" type="float" value="1.5"/>
+    <input name="specular" type="float" value="0.9"/>
+    <input name="specular_color" type="color3" value="1.0, 1.0, 1.0"/>
+    <input name="coat_roughness" type="float" value="0.08"/>
+  </standard_surface>
+  <surfacematerial name="ph_mat" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="ph_shader"/>
+  </surfacematerial>
+</materialx>
+"""
+
+
+_FAKE_GLASS_MTLX = b"""<?xml version="1.0"?>
+<materialx version="1.38">
+  <standard_surface name="glass_shader" type="surfaceshader">
+    <input name="base" type="float" value="1.0"/>
+    <input name="base_color" type="color3" value="0.95, 0.97, 0.97"/>
+    <input name="metalness" type="float" value="0.0"/>
+    <input name="specular_roughness" type="float" value="0.02"/>
+    <input name="specular_IOR" type="float" value="1.52"/>
+    <input name="transmission" type="float" value="0.85"/>
+    <input name="transmission_depth" type="float" value="0.005"/>
+  </standard_surface>
+  <surfacematerial name="glass" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="glass_shader"/>
+  </surfacematerial>
+</materialx>
+"""
+
+
+def _file_info_with_mtlx(tier_key: str = "1k") -> dict:
+    """polyhaven /files/{slug} response carrying mtlx + a diffuse map."""
+    return {
+        "Diffuse": {tier_key: {"png": {"url": "https://example.com/diff.png", "size": 1}}},
+        "mtlx": {
+            tier_key: {
+                "mtlx": {
+                    "url": "https://example.com/material.mtlx",
+                    "md5": "abc",
+                    "size": 1,
+                    "include": {},
+                }
+            }
+        },
+    }
+
+
+def _file_info_without_mtlx(tier_key: str = "1k") -> dict:
+    """Some polyhaven assets ship without an MTLX — gracefully tolerated."""
+    return {
+        "Diffuse": {tier_key: {"png": {"url": "https://example.com/diff.png", "size": 1}}},
+    }
+
+
+def _make_retry_request(mtlx_bytes: bytes):
+    """Build a ``retry_request`` mock that returns mtlx bytes for the
+    .mtlx URL and a fake PNG payload for everything else."""
+
+    def _impl(url, *args, **kwargs):
+        if url.endswith(".mtlx"):
+            return MagicMock(content=mtlx_bytes)
+        return MagicMock(content=b"\x89PNG\r\n\x1a\nfake")
+
+    return _impl
+
+
+# ── happy path ──────────────────────────────────────────────────
+
+
+def test_fetch_one_populates_pbr_from_mtlx(tmp_path: Path) -> None:
+    """Polyhaven MTLX → PBRBlock Phase-2 fields land on the record."""
+    file_info = _file_info_with_mtlx()
+    mtlx_dir = tmp_path / "mtlx"
+    output_dir = tmp_path / "out"
+
+    with (
+        patch(
+            "mat_vis_baker.sources.polyhaven._fetch_files",
+            return_value=file_info,
+        ),
+        patch(
+            "mat_vis_baker.sources.polyhaven.retry_request",
+            side_effect=_make_retry_request(_FAKE_MTLX),
+        ),
+    ):
+        rec = _fetch_one(
+            slug="oak_floor",
+            meta={"name": "Oak Floor", "tags": ["wood"]},
+            tier="1k",
+            output_dir=output_dir,
+            mtlx_dir=mtlx_dir,
+        )
+
+    assert rec.status == "ok"
+    pbr = rec.mat_vis.pbr
+    assert pbr.metalness == 0.0
+    assert pbr.roughness == 0.5
+    assert pbr.ior == 1.5
+    assert pbr.specular_intensity == 0.9
+    assert pbr.specular_color == [1.0, 1.0, 1.0]
+    assert pbr.clearcoat_roughness == 0.08
+    assert pbr.color_rgb == [0.42, 0.32, 0.22]
+
+
+def test_fetch_one_glass_transmission_and_thickness(tmp_path: Path) -> None:
+    """A transmissive material picks up transmission + thickness."""
+    file_info = _file_info_with_mtlx()
+    mtlx_dir = tmp_path / "mtlx"
+    output_dir = tmp_path / "out"
+
+    with (
+        patch(
+            "mat_vis_baker.sources.polyhaven._fetch_files",
+            return_value=file_info,
+        ),
+        patch(
+            "mat_vis_baker.sources.polyhaven.retry_request",
+            side_effect=_make_retry_request(_FAKE_GLASS_MTLX),
+        ),
+    ):
+        rec = _fetch_one(
+            slug="window_glass",
+            meta={"name": "Window Glass", "tags": ["glass"]},
+            tier="1k",
+            output_dir=output_dir,
+            mtlx_dir=mtlx_dir,
+        )
+
+    assert rec.status == "ok"
+    assert rec.mat_vis.pbr.transmission == 0.85
+    assert rec.mat_vis.pbr.thickness == 0.005
+
+
+# ── missing-MTLX is graceful ────────────────────────────────────
+
+
+def test_fetch_one_no_mtlx_no_exception(tmp_path: Path) -> None:
+    """Polyhaven assets without an MTLX section still produce a record."""
+    file_info = _file_info_without_mtlx()
+    mtlx_dir = tmp_path / "mtlx"
+    output_dir = tmp_path / "out"
+
+    with (
+        patch(
+            "mat_vis_baker.sources.polyhaven._fetch_files",
+            return_value=file_info,
+        ),
+        patch(
+            "mat_vis_baker.sources.polyhaven.retry_request",
+            return_value=MagicMock(content=b"\x89PNG\r\n\x1a\nfake"),
+        ),
+    ):
+        rec = _fetch_one(
+            slug="no_mtlx_mat",
+            meta={"name": "No MTLX", "tags": []},
+            tier="1k",
+            output_dir=output_dir,
+            mtlx_dir=mtlx_dir,
+        )
+
+    assert rec.status == "ok"
+    # Phase-2 fields stay None (no parser ran)
+    assert rec.mat_vis.pbr.clearcoat_roughness is None
+    assert rec.mat_vis.pbr.specular_intensity is None
+    # Texture-bound convention still fires for color
+    assert rec.mat_vis.pbr.color_rgb == [1.0, 1.0, 1.0]
+
+
+def test_fetch_one_mtlx_dir_none_is_graceful(tmp_path: Path) -> None:
+    """When the caller doesn't pass mtlx_dir, no parse happens."""
+    file_info = _file_info_with_mtlx()
+    output_dir = tmp_path / "out"
+
+    with (
+        patch(
+            "mat_vis_baker.sources.polyhaven._fetch_files",
+            return_value=file_info,
+        ),
+        patch(
+            "mat_vis_baker.sources.polyhaven.retry_request",
+            side_effect=_make_retry_request(_FAKE_MTLX),
+        ),
+    ):
+        rec = _fetch_one(
+            slug="oak_floor",
+            meta={"name": "Oak Floor", "tags": ["wood"]},
+            tier="1k",
+            output_dir=output_dir,
+            mtlx_dir=None,
+        )
+
+    assert rec.status == "ok"
+    assert rec.mat_vis.pbr.clearcoat_roughness is None
+    assert rec.mat_vis.pbr.specular_intensity is None
+
+
+# ── merge-rule regression ───────────────────────────────────────
+
+
+def test_mtlx_does_not_override_when_authored_metalness(tmp_path: Path) -> None:
+    """Regression guard: an MTLX-authored metalness value must NOT override
+    an upstream-JSON-authored value when the merge-rule contract is honored.
+
+    Polyhaven doesn't currently author PBR from JSON, but pinning the rule
+    via the merge helper covers any future fetcher expansion. We assert
+    the parsed scalars still flow when upstream leaves the field None.
+    """
+    file_info = _file_info_with_mtlx()
+    mtlx_dir = tmp_path / "mtlx"
+    output_dir = tmp_path / "out"
+
+    with (
+        patch(
+            "mat_vis_baker.sources.polyhaven._fetch_files",
+            return_value=file_info,
+        ),
+        patch(
+            "mat_vis_baker.sources.polyhaven.retry_request",
+            side_effect=_make_retry_request(_FAKE_MTLX),
+        ),
+    ):
+        rec = _fetch_one(
+            slug="oak_floor",
+            meta={"name": "Oak Floor", "tags": ["wood"]},
+            tier="1k",
+            output_dir=output_dir,
+            mtlx_dir=mtlx_dir,
+        )
+
+    # MTLX value flows because upstream JSON didn't author it.
+    assert rec.mat_vis.pbr.metalness == 0.0


### PR DESCRIPTION
## Summary

- Wires `parse_standard_surface_scalars` into the ambientcg and polyhaven fetchers (already used by gpuopen), unblocking Phase-2 PBR fields (`clearcoat_roughness`, `specular_color`, `specular_intensity`, `transmission`, `thickness`, `dispersion`) for 2,706 entries (84% of the textured catalog).
- Adds `common.merge_mtlx_pbr_additive` so MTLX-parsed scalars only fill PBRBlock slots the upstream JSON left `None` — authored upstream values are NEVER overridden. Contract pinned by a regression test.
- Missing-MTLX paths (older ambientcg ZIPs, polyhaven assets without per-tier MTLX) log at DEBUG and skip the parse cleanly. Same shape as gpuopen's reference wiring.

Closes #397.

## Changes

- `src/mat_vis_baker/common.py` — new `merge_mtlx_pbr_additive` + `_MTLX_PBR_MERGE_FIELDS` enum
- `src/mat_vis_baker/sources/ambientcg.py` — `_extract_maps_from_zip` now returns `(textures, mtlx_path)`; `_fetch_one` parses + merges + applies neutral convention
- `src/mat_vis_baker/sources/polyhaven.py` — capture `_download_mtlx` return path, parse + merge + apply convention
- `tests/test_ambientcg_mtlx_scalars.py` (6 tests) + `tests/test_polyhaven_mtlx_scalars.py` (5 tests) — happy path + glass/transmission + missing-MTLX graceful + `mtlx_dir=None` graceful + merge-rule regression

## Test plan

- [x] `pytest tests/` — 613 passed, 20 skipped (was 602; +11 from new tests)
- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] Pre-commit hooks (branch-name, ruff, formatters) pass
- [ ] P1: bake-only spot-test (filter-ids on 1 ambientcg + 1 polyhaven material with known clearcoat/transmission) — left to the post-merge full-bake step in the issue's acceptance criteria
- [ ] Sibling-PR batch-merge by human (per task instructions, do not auto-merge)