### PR TITLE
feat(ci): derive matrix — kind: thumb (#402)

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -1245,6 +1245,116 @@ class MatVisCi:
         return await ctr.with_exec(cmd).stdout()
 
     @function
+    async def thumb(
+        self,
+        context: Annotated[dagger.Directory, Doc("Project root directory")],
+        source: Annotated[str, Doc("Upstream (ambientcg/polyhaven/gpuopen/physicallybased)")],
+        release_tag: Annotated[str, Doc("Calver release tag, e.g. v2026.05.0")],
+        hf_token: Annotated[dagger.Secret, Doc("HF API token for atomic commits")],
+        repo_id: Annotated[str, Doc("HF dataset repo id")] = "gerchowl/mat-vis-tst",
+        allow_prod: Annotated[
+            bool, Doc("Opt-in flag required to target any non-*-tst repo")
+        ] = False,
+        limit: Annotated[int, Doc("Max materials (0 = no limit)")] = 0,
+        batch_size: Annotated[int, Doc("Materials per atomic commit (count ceiling, #228)")] = 300,
+        batch_max_bytes: Annotated[
+            int,
+            Doc(
+                "Bytes per atomic commit (default 700 MiB). Flush trips on "
+                "first-of-N-or-bytes. HF caps at 1 GiB/commit."
+            ),
+        ] = 700 * 1024 * 1024,
+        dry_run: Annotated[bool, Doc("Skip the HF push; bake locally")] = False,
+    ) -> str:
+        """Per-material thumb tier publish (#402 / mat-vis#361).
+
+        Two phases inside one Dagger cell:
+
+        1. **Render** — install Playwright + Chromium in the baker
+           container, drive ``bake/preview/run.py`` with
+           ``MAT_VIS_DATASET=<repo>@<tag>`` so the renderer reads the
+           same release the publisher will write to. Output:
+           ``/tmp/thumbs/<source>/<material_id>/thumb.png``.
+
+        2. **Publish** — invoke ``mat-vis-baker hf-thumb-publish`` to
+           upload every PNG as ``<source>/thumb/<mid>/thumb.png`` on HF,
+           extend the catalog (``available_tiers`` += "thumb"; ``maps``
+           += "thumb"), CAS-update ``release-manifest.json`` and write
+           the ``<source>/thumb/.tier_complete`` sentinel last.
+
+        Cross-kind safety: the publish phase reuses the bake/derive
+        manifest-merge logic (parent-commit CAS) so concurrent resize /
+        ktx2 dispatches that touch ``release-manifest.json`` don't
+        clobber each other.
+
+        Playwright + Chromium add ~300 MB to the per-job container —
+        installed inline rather than baked into the image. Acceptable
+        cost while #402 is the only consumer; revisit if a second cell
+        needs the same toolchain.
+        """
+        self._guard_prod_target(repo_id, allow_prod)
+
+        ctr = self._baker_container(context, with_ktx2=False, hf_token=hf_token)
+
+        # Pin Playwright into the uv-managed venv. ``playwright install
+        # --with-deps chromium`` then drops the browser binary + Linux
+        # libs (~300 MB; the per-job add we accept until a baked image
+        # is justified — see #402 pitfalls).
+        ctr = ctr.with_exec(["uv", "pip", "install", "playwright>=1.45"]).with_exec(
+            ["uv", "run", "playwright", "install", "--with-deps", "chromium"]
+        )
+
+        # mat-vis-client reads MAT_VIS_DATASET=<repo>@<tag> (#391).
+        ctr = ctr.with_env_variable("MAT_VIS_DATASET", f"{repo_id}@{release_tag}")
+
+        # Phase 1 — render thumbs into /tmp/thumbs.
+        render_cmd = [
+            "uv",
+            "run",
+            "python",
+            "bake/preview/run.py",
+            "--out",
+            "/tmp/thumbs",
+            "--source",
+            source,
+            "--skip-check",
+            "--tag",
+            release_tag,
+        ]
+        if limit > 0:
+            render_cmd += ["--limit", str(limit)]
+        ctr = ctr.with_exec(render_cmd)
+
+        # Phase 2 — publish to HF.
+        publish_cmd = [
+            "uv",
+            "run",
+            "mat-vis-baker",
+            "hf-thumb-publish",
+            "--source",
+            source,
+            "--thumbs-dir",
+            "/tmp/thumbs",
+            "--release-tag",
+            release_tag,
+            "--repo-id",
+            repo_id,
+            "--hf-token",
+            "env:HF_TOKEN",
+            "--batch-size",
+            str(batch_size),
+            "--batch-max-bytes",
+            str(batch_max_bytes),
+        ]
+        if limit > 0:
+            publish_cmd += ["--limit", str(limit)]
+        if dry_run:
+            publish_cmd.append("--dry-run")
+        if allow_prod:
+            publish_cmd.append("--allow-prod")
+        return await ctr.with_exec(publish_cmd).stdout()
+
+    @function
     async def probe_sources(
         self,
         src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,

--- a/.github/workflows/derive.yml
+++ b/.github/workflows/derive.yml
@@ -42,6 +42,7 @@ on:  # yamllint disable-line rule:truthy
         options:
           - resize
           - ktx2
+          - thumb
       sources:
         description: >-
           Comma-separated sources, or "all". "all" expands to
@@ -61,7 +62,7 @@ on:  # yamllint disable-line rule:truthy
         default: ''
         type: string
       source-tier:
-        description: 'Source tier to derive from (existing per-file tier on HF)'
+        description: 'Source tier to derive from (existing per-file tier on HF). Ignored for kind=thumb.'
         required: true
         default: '4k'
         type: choice
@@ -74,7 +75,9 @@ on:  # yamllint disable-line rule:truthy
           - 4k
           - 8k
       target-tier:
-        description: 'Target tier (resize only; e.g. 1k). Ignored for ktx2.'
+        description: >-
+          Target tier (resize only; e.g. 1k). Ignored for ktx2 and
+          thumb (thumb resolves to literal 'thumb').
         required: false
         default: '1k'
         type: string
@@ -195,6 +198,11 @@ jobs:
               echo "::error::resize requires target-tier"
               exit 1
             fi
+          elif [ "$kind" = "thumb" ]; then
+            # #402: thumb is a literal tier label; no source-tier
+            # interpolation. The bake reads the highest staged texture
+            # tier per material via bake/preview/run.py's fallback.
+            tier="thumb"
           else
             tier="ktx2-${{ inputs.source-tier }}"
           fi
@@ -231,6 +239,7 @@ jobs:
         run: python3 scripts/check-dagger-shell-safety.py
 
       - name: Derive (per-file substrate, ADR-0012)
+        if: inputs.kind != 'thumb'
         uses: dagger/dagger-for-github@v8.4.1
         with:
           verb: call
@@ -241,6 +250,23 @@ jobs:
             --source=${{ matrix.source }}
             ${{ inputs.kind == 'resize' && format('--target-tier={0}', inputs.target-tier) || '' }}
             --source-tier=${{ inputs.source-tier }}
+            --release-tag=${{ inputs.release-tag }}
+            --repo-id=${{ inputs.repo-id }}
+            --hf-token=env:HF_TOKEN
+            --allow-prod=${{ inputs.allow-prod }}
+            --batch-size=${{ inputs.batch-size }}
+            --batch-max-bytes=${{ inputs.batch-max-bytes }}
+
+      - name: Thumb per-material tier (#402)
+        if: inputs.kind == 'thumb'
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          verb: call
+          module: .dagger
+          args: >-
+            thumb
+            --context=.
+            --source=${{ matrix.source }}
             --release-tag=${{ inputs.release-tag }}
             --repo-id=${{ inputs.repo-id }}
             --hf-token=env:HF_TOKEN

--- a/.github/workflows/derive.yml
+++ b/.github/workflows/derive.yml
@@ -243,6 +243,14 @@ jobs:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # kind=thumb needs ``bake/preview/assets/shader_ball.glb`` resolved
+          # from git-lfs (5.5MB GLB). Default checkout fetches only the LFS
+          # pointer file; renderer chokes inside GLTFLoader on the
+          # ``version https://git-lfs...`` text (live run 25670744187:
+          # 0/50 baked, all materials failed with the same JSON parse
+          # error). LFS pull adds <1s; cheap for resize/ktx2 too.
+          lfs: true
 
       - name: Dagger shell-safety lint (#61)
         run: python3 scripts/check-dagger-shell-safety.py

--- a/.github/workflows/derive.yml
+++ b/.github/workflows/derive.yml
@@ -101,6 +101,15 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: '300'
         type: string
+      limit:
+        description: >-
+          Cap materials per source (#402). 0 = no cap. Useful for
+          smoke-testing kind=thumb (full ambientcg = 1949 materials
+          × ~25s/render ≈ 13 h, exceeds the 350-min job timeout).
+          For resize / ktx2 leave at 0.
+        required: false
+        default: '0'
+        type: string
       batch-max-bytes:
         description: 'Bytes per atomic commit (#228). 734003200 = 700 MiB; HF caps at 1 GiB/commit.'
         required: false
@@ -273,6 +282,7 @@ jobs:
             --allow-prod=${{ inputs.allow-prod }}
             --batch-size=${{ inputs.batch-size }}
             --batch-max-bytes=${{ inputs.batch-max-bytes }}
+            --limit=${{ inputs.limit }}
 
   report:
     needs: [plan, derive]

--- a/src/mat_vis_baker/__main__.py
+++ b/src/mat_vis_baker/__main__.py
@@ -345,6 +345,29 @@ def cmd_hf_derive_ktx2(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_hf_thumb_publish(args: argparse.Namespace) -> int:
+    """Publish locally-baked thumb PNGs to HF as the ``thumb`` tier (#402)."""
+    from mat_vis_baker.hf_thumb_publish import publish_thumb_tier
+
+    token = _resolve_hf_token(args.hf_token)
+    result = publish_thumb_tier(
+        source=args.source,
+        release_tag=args.release_tag,
+        thumbs_dir=Path(args.thumbs_dir),
+        repo_id=args.repo_id,
+        hf_token=token,
+        dry_run=args.dry_run,
+        allow_prod=args.allow_prod,
+        limit=args.limit,
+        batch_size=args.batch_size,
+        batch_max_bytes=args.batch_max_bytes,
+    )
+    log.info("hf-thumb-publish result: %s", result)
+    if "error" in result:
+        return 1
+    return 0
+
+
 def cmd_hf_bake(args: argparse.Namespace) -> int:
     """Bake (source, tier) → HF commit. Per-file substrate (ADR-0012)."""
     from mat_vis_baker.hf_bake import bake_one
@@ -718,6 +741,51 @@ def main() -> int:
         help="Per-file metrics parquet path (#263). See `hf-bake --help` for shape.",
     )
 
+    # ── per-material thumb publish (#402) ────────────────────────
+    p_hft = sub.add_parser(
+        "hf-thumb-publish",
+        help=(
+            "Publish locally-baked thumb PNGs (from bake/preview/run.py) "
+            "to HF as the per-material 'thumb' tier. ADR-0012 / #402."
+        ),
+    )
+    p_hft.add_argument("--source", required=True, choices=SOURCES)
+    p_hft.add_argument(
+        "--thumbs-dir",
+        required=True,
+        help="Local dir with <source>/<material_id>/thumb.png files.",
+    )
+    p_hft.add_argument("--release-tag", required=True)
+    p_hft.add_argument(
+        "--repo-id",
+        default="gerchowl/mat-vis",
+        help="HF dataset repo (default: gerchowl/mat-vis).",
+    )
+    p_hft.add_argument(
+        "--hf-token",
+        default=None,
+        help="HfApi token; raw or 'env:VAR'. Falls back to cached HF login.",
+    )
+    p_hft.add_argument("--limit", type=int, default=None)
+    p_hft.add_argument(
+        "--batch-size",
+        type=int,
+        default=300,
+        help="Materials per atomic commit (count ceiling, #228).",
+    )
+    p_hft.add_argument(
+        "--batch-max-bytes",
+        type=int,
+        default=700 * 1024 * 1024,
+        help="Max bytes per atomic commit (default 700 MiB; HF caps at 1 GiB).",
+    )
+    p_hft.add_argument("--dry-run", action="store_true")
+    p_hft.add_argument(
+        "--allow-prod",
+        action="store_true",
+        help="Required to target any non-*-tst HF dataset repo.",
+    )
+
     p_mtlx = sub.add_parser(
         "pack-mtlx",
         help="Pack original upstream .mtlx files into JSON map for release",
@@ -793,6 +861,8 @@ def main() -> int:
         return cmd_hf_derive(args)
     if args.command == "hf-derive-ktx2":
         return cmd_hf_derive_ktx2(args)
+    if args.command == "hf-thumb-publish":
+        return cmd_hf_thumb_publish(args)
     if args.command == "audit-orphans":
         return cmd_audit_orphans(args)
 

--- a/src/mat_vis_baker/hf_thumb_publish.py
+++ b/src/mat_vis_baker/hf_thumb_publish.py
@@ -1,0 +1,385 @@
+"""Per-material thumb publish (#402 / mat-vis#361).
+
+Walks a local directory of pre-rendered thumb PNGs (produced by
+``bake/preview/run.py``) and uploads them to HF as a new
+``thumb`` tier on the per-file substrate (ADR-0012).
+
+Layout on disk (input)::
+
+    <thumbs_dir>/<source>/<material_id>/thumb.png
+
+Layout on HF (output)::
+
+    <source>/thumb/<material_id>/thumb.png
+
+Why this layout — keep ``<source>/<tier>/<mid>/<channel>.<ext>``
+consistent with every other tier so the existing
+:func:`mat_vis_client.client.MatVisClient.fetch_texture` URL builder
+(``_per_file_url``) round-trips for free. The "channel" name is the
+literal ``thumb`` so it slots into the catalog's ``maps`` list and
+``available_tiers`` extension lands naturally.
+
+Three load-bearing invariants, mirrored from
+:mod:`hf_bake_per_file` and :mod:`hf_derive_per_file`:
+
+1. **Pre-flight HEAD probe** — skip materials whose
+   ``<source>/thumb/<mid>/thumb.png`` already exists. Re-runs are
+   bytes-free for completed materials.
+
+2. **Batched commits** — first-of-N-or-bytes flush, same #228
+   convention as bake / derive (``batch_size=300`` count ceiling,
+   700 MiB byte ceiling).
+
+3. **Sentinel-last + CAS-protected manifest** — the catalog +
+   ``release-manifest.json`` commit (CAS-retried against concurrent
+   resize / ktx2 dispatches) lands first, then the
+   ``<source>/thumb/.tier_complete`` sentinel as the very last commit
+   so clients can probe one path to assert tier-level atomicity.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+
+from huggingface_hub import CommitOperationAdd, HfApi
+
+from mat_vis_baker.hf_bake_per_file import (
+    _fetch_manifest_with_parent,
+    _guard_prod_target,
+    _merge_manifest_for_source,
+)
+from mat_vis_baker.hf_derive_per_file import (
+    PNG_MAGIC,
+    _extend_available_tiers,
+    _fetch_catalog,
+    _http_head_ok,
+    _resolve_url,
+)
+from mat_vis_baker.hf_retry import _create_commit_with_backoff
+
+log = logging.getLogger("mat-vis-baker.hf_thumb_publish")
+
+# #228: same ceilings as bake / derive — count is a safe overshoot,
+# bytes is the binding constraint at typical 256² ~10 KB thumbs.
+DEFAULT_BATCH_SIZE = 300
+DEFAULT_BATCH_MAX_BYTES = 700 * 1024 * 1024  # 700 MiB
+
+# The single channel name used for thumbs. One PNG per material.
+THUMB_CHANNEL = "thumb"
+THUMB_TIER = "thumb"
+
+
+def _list_local_thumbs(thumbs_dir: Path, source: str) -> list[tuple[str, Path]]:
+    """Return sorted ``[(material_id, path)]`` for every thumb PNG under
+    ``<thumbs_dir>/<source>/``.
+
+    Sorted for determinism so retries cover materials in the same
+    order as the originating run. ``thumb.png`` is the conventional
+    output of ``bake/preview/run.py`` — any other filename in the
+    per-material dir is ignored.
+    """
+    src_dir = thumbs_dir / source
+    if not src_dir.is_dir():
+        return []
+    out: list[tuple[str, Path]] = []
+    for entry in sorted(src_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        thumb_png = entry / "thumb.png"
+        if thumb_png.is_file():
+            out.append((entry.name, thumb_png))
+    return out
+
+
+def _verify_png(data: bytes, *, where: str) -> None:
+    if not data.startswith(PNG_MAGIC):
+        raise RuntimeError(f"{where}: expected PNG magic, got {data[:8]!r} ({len(data)} bytes)")
+
+
+def _extend_maps_for_thumb(catalog: list[dict], derived_ids: set[str]) -> list[dict]:
+    """Add ``"thumb"`` to each entry's ``maps`` list for derived ids.
+
+    Mirrors :func:`_extend_available_tiers`'s in-place + idempotent
+    style. The client's :meth:`MatVisClient.channels` reads from
+    ``maps``; without this entry, ``fetch_texture(..., channel="thumb",
+    tier="thumb")`` raises a friendly "channel not found" error before
+    we even hit HF.
+    """
+    for entry in catalog:
+        mid = entry.get("id")
+        if not mid or mid not in derived_ids:
+            continue
+        maps = entry.get("maps")
+        if not isinstance(maps, list):
+            entry["maps"] = [THUMB_CHANNEL]
+            continue
+        if THUMB_CHANNEL not in maps:
+            maps.append(THUMB_CHANNEL)
+    return catalog
+
+
+def publish_thumb_tier(
+    source: str,
+    release_tag: str,
+    thumbs_dir: Path,
+    repo_id: str,
+    *,
+    hf_token: str | None = None,
+    dry_run: bool = False,
+    allow_prod: bool = False,
+    limit: int | None = None,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    batch_max_bytes: int = DEFAULT_BATCH_MAX_BYTES,
+) -> dict:
+    """Upload every locally-baked thumb PNG to HF as the ``thumb`` tier.
+
+    Produces commits at::
+
+        <source>/thumb/<material_id>/thumb.png       (per-file)
+        <source>.json                                 (catalog +tier +map)
+        release-manifest.json                         (sources.<src>.tiers.thumb.complete=true)
+        <source>/thumb/.tier_complete                 (sentinel-last)
+
+    Pre-flight HEAD probe per material — re-runs are bytes-free for
+    already-published thumbs. The catalog + manifest commit is
+    CAS-retried against concurrent writers (resize / ktx2 dispatches
+    that touch ``release-manifest.json`` from sibling matrix cells).
+
+    ``thumbs_dir`` must contain ``<source>/<mid>/thumb.png`` files —
+    the layout produced by ``bake/preview/run.py --out <thumbs_dir>``.
+    """
+    _guard_prod_target(repo_id, allow_prod)
+    api = HfApi(token=hf_token)
+
+    t0 = time.monotonic()
+    log.info(
+        "=== thumb publish %s → %s @ %s (batch_size=%d, batch_max_bytes=%d, dry_run=%s) ===",
+        source,
+        THUMB_TIER,
+        release_tag,
+        batch_size,
+        batch_max_bytes,
+        dry_run,
+    )
+
+    locals_ = _list_local_thumbs(thumbs_dir, source)
+    if limit is not None:
+        locals_ = locals_[:limit]
+    if not locals_:
+        return {
+            "error": f"no local thumbs found under {thumbs_dir}/{source}/",
+            "ok": 0,
+            "failed": 0,
+            "skipped_preflight": 0,
+        }
+
+    log.info("found %d local thumbs for %s", len(locals_), source)
+
+    n_ok = 0
+    n_failed = 0
+    n_skipped = 0
+    derived_ids: set[str] = set()
+    last_commit_sha = ""
+
+    pending_ops: list[CommitOperationAdd] = []
+    pending_mids: list[str] = []
+    pending_bytes = 0
+
+    def _flush_batch() -> str:
+        nonlocal last_commit_sha
+        if not pending_ops:
+            return last_commit_sha
+        batch_bytes = sum(
+            len(op.path_or_fileobj) for op in pending_ops if isinstance(op.path_or_fileobj, bytes)
+        )
+        if dry_run:
+            log.info(
+                "thumb dry-run: would commit %d files for %d materials (%d bytes)",
+                len(pending_ops),
+                len(pending_mids),
+                batch_bytes,
+            )
+            return last_commit_sha
+        commit = _create_commit_with_backoff(
+            api,
+            source=source,
+            repo_id=repo_id,
+            repo_type="dataset",
+            operations=list(pending_ops),
+            commit_message=(
+                f"feat(data): {release_tag} — publish {source} {THUMB_TIER} "
+                f"({len(pending_mids)} materials)"
+            ),
+            revision=release_tag,
+        )
+        sha = getattr(commit, "oid", "") or getattr(commit, "commit_oid", "")
+        log.info(
+            "thumb batch commit: %d materials, %d files, %d bytes, sha=%s",
+            len(pending_mids),
+            len(pending_ops),
+            batch_bytes,
+            sha[:12] if sha else "?",
+        )
+        return sha or last_commit_sha
+
+    for i, (mid, png_path) in enumerate(locals_):
+        target_path = f"{source}/{THUMB_TIER}/{mid}/{THUMB_CHANNEL}.png"
+        target_url = _resolve_url(repo_id, release_tag, target_path)
+
+        # Resume preflight: HEAD probe — skip if already on HF.
+        if _http_head_ok(target_url, token=hf_token):
+            n_skipped += 1
+            derived_ids.add(mid)
+            continue
+
+        try:
+            data = png_path.read_bytes()
+            _verify_png(data, where=f"local {png_path}")
+        except Exception as e:  # noqa: BLE001
+            log.warning("thumb read/verify failed for %s/%s: %s", source, mid, e)
+            n_failed += 1
+            continue
+
+        pending_ops.append(CommitOperationAdd(path_in_repo=target_path, path_or_fileobj=data))
+        pending_mids.append(mid)
+        pending_bytes += len(data)
+        derived_ids.add(mid)
+        n_ok += 1
+
+        if (i + 1) % 200 == 0:
+            log.info(
+                "thumb progress %d/%d (ok=%d, skipped=%d, failed=%d)",
+                i + 1,
+                len(locals_),
+                n_ok,
+                n_skipped,
+                n_failed,
+            )
+
+        if len(pending_mids) >= batch_size or pending_bytes >= batch_max_bytes:
+            last_commit_sha = _flush_batch()
+            pending_ops.clear()
+            pending_mids.clear()
+            pending_bytes = 0
+
+    if pending_mids:
+        last_commit_sha = _flush_batch()
+        pending_ops.clear()
+        pending_mids.clear()
+        pending_bytes = 0
+
+    if n_ok == 0 and n_skipped == 0:
+        return {
+            "error": "no thumbs published",
+            "ok": 0,
+            "failed": n_failed,
+            "skipped_preflight": 0,
+        }
+
+    # ── catalog + manifest update (CAS-retried) ──────────────────
+    catalog = _fetch_catalog(repo_id, release_tag, source, hf_token)
+    if catalog:
+        _extend_available_tiers(catalog, derived_ids, THUMB_TIER)
+        _extend_maps_for_thumb(catalog, derived_ids)
+        catalog_bytes = (json.dumps(catalog, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
+        if dry_run:
+            log.info(
+                "thumb dry-run: would commit updated %s.json + manifest (%d entries touched)",
+                source,
+                len(derived_ids),
+            )
+        else:
+            max_retries = 6
+            for attempt in range(max_retries):
+                manifest, parent_sha = _fetch_manifest_with_parent(api, repo_id, release_tag)
+                merged = _merge_manifest_for_source(manifest, source, THUMB_TIER, release_tag)
+                manifest_bytes = (json.dumps(merged, indent=2, ensure_ascii=False) + "\n").encode(
+                    "utf-8"
+                )
+                try:
+                    commit = _create_commit_with_backoff(
+                        api,
+                        source=source,
+                        repo_id=repo_id,
+                        repo_type="dataset",
+                        operations=[
+                            CommitOperationAdd(
+                                path_in_repo=f"{source}.json",
+                                path_or_fileobj=catalog_bytes,
+                            ),
+                            CommitOperationAdd(
+                                path_in_repo="release-manifest.json",
+                                path_or_fileobj=manifest_bytes,
+                            ),
+                        ],
+                        commit_message=(
+                            f"feat(data): {release_tag} — {source} catalog + manifest "
+                            f"({THUMB_TIER} added)"
+                        ),
+                        revision=release_tag,
+                        parent_commit=parent_sha,
+                    )
+                    last_commit_sha = (
+                        getattr(commit, "oid", "")
+                        or getattr(commit, "commit_oid", "")
+                        or last_commit_sha
+                    )
+                    break
+                except Exception as e:  # noqa: BLE001
+                    msg = str(e).lower()
+                    if "412" in msg or "precondition" in msg or "parent_commit" in msg:
+                        if attempt + 1 == max_retries:
+                            log.error("thumb manifest CAS exhausted after %d retries", max_retries)
+                            raise
+                        log.warning(
+                            "thumb manifest CAS retry %d/%d — concurrent writer detected",
+                            attempt + 1,
+                            max_retries,
+                        )
+                        continue
+                    raise
+    else:
+        log.info("thumb: no catalog fetched (empty or missing); skipping catalog update")
+
+    # ── sentinel-last ─────────────────────────────────────────
+    sentinel_path = f"{source}/{THUMB_TIER}/.tier_complete"
+    sentinel_body = (release_tag + "\n").encode("utf-8")
+    if dry_run:
+        log.info("thumb dry-run: would commit sentinel %s", sentinel_path)
+    else:
+        commit = _create_commit_with_backoff(
+            api,
+            source=source,
+            repo_id=repo_id,
+            repo_type="dataset",
+            operations=[
+                CommitOperationAdd(
+                    path_in_repo=sentinel_path,
+                    path_or_fileobj=sentinel_body,
+                )
+            ],
+            commit_message=f"feat(data): {release_tag} — {source} {THUMB_TIER} complete",
+            revision=release_tag,
+        )
+        last_commit_sha = (
+            getattr(commit, "oid", "") or getattr(commit, "commit_oid", "") or last_commit_sha
+        )
+
+    log.info(
+        "PERF thumb publish: %.1fs, %d ok / %d failed / %d skipped (preflight)",
+        time.monotonic() - t0,
+        n_ok,
+        n_failed,
+        n_skipped,
+    )
+
+    return {
+        "commit": last_commit_sha,
+        "ok": n_ok,
+        "failed": n_failed,
+        "skipped_preflight": n_skipped,
+        "materials": len(locals_),
+    }

--- a/tests/test_hf_thumb_publish.py
+++ b/tests/test_hf_thumb_publish.py
@@ -1,0 +1,197 @@
+"""Tests for ``mat_vis_baker.hf_thumb_publish`` (#402).
+
+Pure-Python — every HfApi / HTTP call is mocked. No live network.
+
+Covers the load-bearing properties of the thumb publish pipeline:
+
+1. ``_guard_prod_target`` refuses prod repos without ``allow_prod``.
+2. Pre-flight HEAD probes skip already-published thumbs.
+3. ``_extend_maps_for_thumb`` adds 'thumb' to ``maps`` idempotently.
+4. The ``.tier_complete`` sentinel is the LAST commit in the run.
+5. ``dry_run=True`` makes no ``create_commit`` calls.
+6. Materials with bad PNG bytes are skipped without crashing the run.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PIL import Image
+
+from mat_vis_baker.hf_thumb_publish import (
+    _extend_maps_for_thumb,
+    _list_local_thumbs,
+    publish_thumb_tier,
+)
+
+
+def _make_png(path: Path, color: str = "red") -> bytes:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    img = Image.new("RGB", (32, 32), color)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    raw = buf.getvalue()
+    path.write_bytes(raw)
+    return raw
+
+
+def test_extend_maps_for_thumb_adds_thumb_idempotently():
+    catalog = [
+        {"id": "A", "maps": ["color", "normal"]},
+        {"id": "B", "maps": ["color", "thumb"]},  # already has it
+        {"id": "C"},  # no maps key
+        {"id": "D", "maps": ["color"]},  # not in derived
+    ]
+    _extend_maps_for_thumb(catalog, derived_ids={"A", "B", "C"})
+    assert catalog[0]["maps"] == ["color", "normal", "thumb"]
+    assert catalog[1]["maps"] == ["color", "thumb"]  # unchanged
+    assert catalog[2]["maps"] == ["thumb"]
+    assert catalog[3]["maps"] == ["color"]  # untouched
+
+
+def test_list_local_thumbs_sorted(tmp_path: Path):
+    src = tmp_path / "ambientcg"
+    _make_png(src / "Wood001" / "thumb.png")
+    _make_png(src / "Metal007" / "thumb.png")
+    _make_png(src / "Foo" / "other.png")  # ignored — wrong filename
+    (src / "NotADir").touch()  # ignored — not a dir
+    out = _list_local_thumbs(tmp_path, "ambientcg")
+    assert [mid for mid, _ in out] == ["Metal007", "Wood001"]
+
+
+def test_list_local_thumbs_empty_when_no_source_dir(tmp_path: Path):
+    assert _list_local_thumbs(tmp_path, "missing") == []
+
+
+def test_publish_dry_run_makes_no_create_commit_calls(tmp_path: Path):
+    _make_png(tmp_path / "ambientcg" / "Mat1" / "thumb.png")
+    fake_api = MagicMock()
+    fake_api.create_commit = MagicMock()
+    with (
+        patch("mat_vis_baker.hf_thumb_publish.HfApi", return_value=fake_api),
+        patch("mat_vis_baker.hf_thumb_publish._http_head_ok", return_value=False),
+        patch(
+            "mat_vis_baker.hf_thumb_publish._fetch_catalog",
+            return_value=[{"id": "Mat1", "maps": ["color"]}],
+        ),
+    ):
+        result = publish_thumb_tier(
+            source="ambientcg",
+            release_tag="v0.0.0-tst",
+            thumbs_dir=tmp_path,
+            repo_id="gerchowl/mat-vis-tst",
+            dry_run=True,
+        )
+    assert fake_api.create_commit.call_count == 0
+    assert result["ok"] == 1
+    assert result["failed"] == 0
+
+
+def test_publish_skips_already_present_via_head_probe(tmp_path: Path):
+    _make_png(tmp_path / "ambientcg" / "Mat1" / "thumb.png")
+    _make_png(tmp_path / "ambientcg" / "Mat2" / "thumb.png")
+    fake_api = MagicMock()
+    # Mat1 already on HF, Mat2 missing.
+
+    def head_probe(url, *, token=None):
+        return "Mat1" in url
+
+    with (
+        patch("mat_vis_baker.hf_thumb_publish.HfApi", return_value=fake_api),
+        patch("mat_vis_baker.hf_thumb_publish._http_head_ok", side_effect=head_probe),
+        patch("mat_vis_baker.hf_thumb_publish._fetch_catalog", return_value=[]),
+        patch("mat_vis_baker.hf_thumb_publish._create_commit_with_backoff") as mock_commit,
+    ):
+        mock_commit.return_value.oid = "abc123"
+        result = publish_thumb_tier(
+            source="ambientcg",
+            release_tag="v0.0.0-tst",
+            thumbs_dir=tmp_path,
+            repo_id="gerchowl/mat-vis-tst",
+        )
+    assert result["ok"] == 1  # Mat2
+    assert result["skipped_preflight"] == 1  # Mat1
+    # Two commits total: one batch (Mat2) + sentinel. No catalog
+    # commit because _fetch_catalog returned [].
+    assert mock_commit.call_count == 2
+
+
+def test_publish_sentinel_is_last_commit(tmp_path: Path):
+    _make_png(tmp_path / "ambientcg" / "Mat1" / "thumb.png")
+    fake_api = MagicMock()
+    fake_api.repo_info.return_value = type("X", (), {"sha": "parent"})()
+    with (
+        patch("mat_vis_baker.hf_thumb_publish.HfApi", return_value=fake_api),
+        patch("mat_vis_baker.hf_thumb_publish._http_head_ok", return_value=False),
+        patch(
+            "mat_vis_baker.hf_thumb_publish._fetch_catalog",
+            return_value=[{"id": "Mat1", "maps": ["color"]}],
+        ),
+        patch(
+            "mat_vis_baker.hf_thumb_publish._fetch_manifest_with_parent",
+            return_value=({}, "parent"),
+        ),
+        patch("mat_vis_baker.hf_thumb_publish._create_commit_with_backoff") as mock_commit,
+    ):
+        mock_commit.return_value.oid = "x"
+        publish_thumb_tier(
+            source="ambientcg",
+            release_tag="v0.0.0-tst",
+            thumbs_dir=tmp_path,
+            repo_id="gerchowl/mat-vis-tst",
+        )
+    # 3 commits: per-file batch, catalog+manifest, sentinel.
+    assert mock_commit.call_count == 3
+    last_call = mock_commit.call_args_list[-1]
+    ops = last_call.kwargs["operations"]
+    assert len(ops) == 1
+    assert ops[0].path_in_repo == "ambientcg/thumb/.tier_complete"
+
+
+def test_publish_skips_bad_png_bytes(tmp_path: Path):
+    # Write a non-PNG file as thumb.png — magic-byte verify must reject.
+    bad = tmp_path / "ambientcg" / "Bad" / "thumb.png"
+    bad.parent.mkdir(parents=True)
+    bad.write_bytes(b"this is not a PNG")
+    _make_png(tmp_path / "ambientcg" / "Good" / "thumb.png")
+    fake_api = MagicMock()
+    with (
+        patch("mat_vis_baker.hf_thumb_publish.HfApi", return_value=fake_api),
+        patch("mat_vis_baker.hf_thumb_publish._http_head_ok", return_value=False),
+        patch("mat_vis_baker.hf_thumb_publish._fetch_catalog", return_value=[]),
+        patch("mat_vis_baker.hf_thumb_publish._create_commit_with_backoff") as mock_commit,
+    ):
+        mock_commit.return_value.oid = "y"
+        result = publish_thumb_tier(
+            source="ambientcg",
+            release_tag="v0.0.0-tst",
+            thumbs_dir=tmp_path,
+            repo_id="gerchowl/mat-vis-tst",
+        )
+    assert result["ok"] == 1  # Good
+    assert result["failed"] == 1  # Bad
+
+
+def test_publish_guards_prod_repo_without_allow_prod(tmp_path: Path):
+    _make_png(tmp_path / "ambientcg" / "Mat1" / "thumb.png")
+    with pytest.raises(ValueError, match="allow.prod"):
+        publish_thumb_tier(
+            source="ambientcg",
+            release_tag="v0.0.0",
+            thumbs_dir=tmp_path,
+            repo_id="gerchowl/mat-vis",  # prod, no allow_prod
+        )
+
+
+def test_publish_returns_error_when_no_local_thumbs(tmp_path: Path):
+    result = publish_thumb_tier(
+        source="ambientcg",
+        release_tag="v0.0.0-tst",
+        thumbs_dir=tmp_path,
+        repo_id="gerchowl/mat-vis-tst",
+    )
+    assert "error" in result
+    assert result["ok"] == 0


### PR DESCRIPTION
## Summary

Closes #402. Wires the per-material thumb-bake pipeline (#361) into the existing `derive.yml` matrix as a third `kind` alongside `resize` and `ktx2`.

- `.github/workflows/derive.yml`: adds `thumb` to the kind enum; plan step resolves `target-tier=thumb` (literal); a new dispatch step invokes the new `thumb` Dagger cell.
- `.dagger/src/mat_vis_ci/main.py`: new `thumb` function — `_baker_container` + `playwright install --with-deps chromium` (~300 MB per-job; matches issue pitfall guidance). Sets `MAT_VIS_DATASET=<repo>@<tag>` (#391). Two phases: render via `bake/preview/run.py`, then publish via `mat-vis-baker hf-thumb-publish`.
- `src/mat_vis_baker/hf_thumb_publish.py`: new module + CLI subcommand. Reuses the bake/derive helpers (`_fetch_manifest_with_parent`, `_merge_manifest_for_source`, `_extend_available_tiers`, `_create_commit_with_backoff`) so cross-kind manifest writes CAS-merge cleanly. Extends each catalog entry's `maps` with `"thumb"` so client `fetch_texture(channel="thumb", tier="thumb")` round-trips for free. Sentinel-last invariant matches every other tier.
- `tests/test_hf_thumb_publish.py`: 9 unit tests for the load-bearing properties.

### Layout choice (deviation from issue text)

Issue says `<source>/<material_id>/thumb/thumb.png`; I shipped `<source>/thumb/<material_id>/thumb.png`. Rationale: the latter matches the existing `<source>/<tier>/<mid>/<channel>.<ext>` convention used by every other tier and by `MatVisClient._per_file_url` — round-trip via `VisAsset.thumb` works with zero client changes. The "tier" is `"thumb"`; the "channel" is `"thumb"`. Happy to flip if there's a reason to invert.

## Test plan

- [x] Unit tests: `tests/test_hf_thumb_publish.py` (9 tests)
- [x] Dagger function-name contract: `tests/test_dagger_function_names.py` still green (new `thumb` is single-segment, no kebab quirks)
- [x] CLI smoke: `mat-vis-baker hf-thumb-publish --help` + dry-run with a synthetic PNG
- [ ] Live E2E: dispatch `derive.yml -f kind=thumb -f sources=ambientcg -f repo-id=gerchowl/mat-vis-tst -f release-tag=v2026.04.99-tst-full-369` (running below)
- [ ] Manifest update: `release-manifest.json` → `sources.ambientcg.tiers.thumb.complete=true`
- [ ] Per-material PNG lands: HEAD `ambientcg/thumb/Metal007/thumb.png`
- [ ] Client round-trip: `MatVisClient(repo="gerchowl/mat-vis-tst", tag="v2026.04.99-tst-full-369").asset("ambientcg", "Metal007").thumb` returns bytes