### PR TITLE
feat(baker+adapter): subsurface scalar coverage — wax/jade/skin SSS (#409)

### DIFF
--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -1446,6 +1446,12 @@ class MatVisClient:
         "clearcoat_roughness",
         "specular_intensity",
         "emissive",
+        # Subsurface scattering (#409). glTF adapter emits the (draft)
+        # ``KHR_materials_subsurface`` extension; Three.js adapter is a
+        # documented no-op (no native MeshPhysical SSS field).
+        "subsurface",
+        "subsurface_color",
+        "subsurface_radius",
     )
 
     def _scalars_for(self, source: str, material_id: str) -> dict:

--- a/clients/python/src/mat_vis_client/adapters.py
+++ b/clients/python/src/mat_vis_client/adapters.py
@@ -367,6 +367,13 @@ def to_threejs(
     if scalars.get("dispersion") is not None:
         result["dispersion"] = scalars["dispersion"]
 
+    # mat-vis#409: Three.js MeshPhysicalMaterial has no native SSS field.
+    # subsurface / subsurface_color / subsurface_radius land in the
+    # substrate for glTF and future use; the Three.js adapter is
+    # intentionally a no-op here. Future workaround if a consumer asks:
+    # approximate via ``transmission`` + ``thickness`` (dense scattering
+    # cue), but that lies about the per-channel mean-free-path. See #409.
+
     # Textures as data URIs
     for channel, prop in _THREEJS_TEX_MAP.items():
         if channel in textures:
@@ -502,6 +509,36 @@ def to_gltf(
         material.setdefault("extensions", {})["KHR_materials_dispersion"] = {
             "dispersion": dispersion
         }
+
+    # KHR_materials_subsurface (#409). Draft / unratified Khronos
+    # extension — the original proposal (PR KhronosGroup/glTF#1928,
+    # closed) used ``scatterColor`` + ``scatterDistance``; the current
+    # successor draft (PR #2453, ``KHR_materials_volume_scatter``) uses
+    # ``scatterAlbedo`` + a different parameterization. Neither shape
+    # round-trips MaterialX's ``subsurface`` / ``subsurface_color`` /
+    # ``subsurface_radius`` triplet faithfully, so we emit the
+    # MaterialX-faithful triplet under the canonical-but-unratified
+    # ``KHR_materials_subsurface`` name with the issue-specified
+    # ``subsurfaceFactor`` / ``subsurfaceColorFactor`` /
+    # ``subsurfaceRadiusFactor`` keys. Consumers that don't recognize
+    # the extension fall back to opaque-dielectric — exactly the
+    # status quo. Three.js consumers see nothing (no MeshPhysical
+    # SSS field; see adapter no-op above). Suppressed when the factor
+    # is 0 or None, mirroring the clearcoat / transmission /
+    # dispersion suppression pattern.
+    subsurface = scalars.get("subsurface")
+    if subsurface is not None and subsurface > 0.0:
+        sss_ext: dict = {"subsurfaceFactor": subsurface}
+        subsurface_color = scalars.get("subsurface_color")
+        if subsurface_color is not None:
+            sss_ext["subsurfaceColorFactor"] = list(subsurface_color)
+        subsurface_radius = scalars.get("subsurface_radius")
+        if subsurface_radius is not None:
+            # MaterialX subsurface_radius is per-channel mean-free-path
+            # (length per RGB channel, typically mm). glTF radius factor
+            # carries identical semantics — emit verbatim, no conversion.
+            sss_ext["subsurfaceRadiusFactor"] = list(subsurface_radius)
+        material.setdefault("extensions", {})["KHR_materials_subsurface"] = sss_ext
 
     # Opacity texture — glTF 2.0 has no standalone alphaMap slot. Alpha
     # must live in baseColorTexture's alpha channel + alphaMode/alphaCutoff

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -2132,6 +2132,13 @@ class MatVisClient:
         "clearcoat_roughness",
         "specular_intensity",
         "emissive",
+        # Subsurface scattering (#409). The glTF adapter emits the
+        # (draft) ``KHR_materials_subsurface`` extension; the Three.js
+        # adapter is a documented no-op because MeshPhysicalMaterial
+        # has no native SSS field.
+        "subsurface",
+        "subsurface_color",
+        "subsurface_radius",
     )
 
     def _scalars_for(self, source: str, material_id: str) -> dict:

--- a/clients/python/tests/test_adapters_subsurface.py
+++ b/clients/python/tests/test_adapters_subsurface.py
@@ -1,0 +1,129 @@
+"""Adapter coverage for subsurface scattering (#409).
+
+| input              | Three.js                | glTF                                          |
+|--------------------|-------------------------|-----------------------------------------------|
+| subsurface         | (no-op — documented)    | KHR_materials_subsurface.subsurfaceFactor     |
+| subsurface_color   | (no-op — documented)    | KHR_materials_subsurface.subsurfaceColorFactor|
+| subsurface_radius  | (no-op — documented)    | KHR_materials_subsurface.subsurfaceRadiusFactor|
+
+Three.js ``MeshPhysicalMaterial`` has no native SSS field; the adapter is
+intentionally a no-op and these tests pin that contract. The glTF
+adapter emits a (draft / unratified) ``KHR_materials_subsurface``
+extension carrying the MaterialX-faithful triplet so the substrate
+round-trips correctly through glTF consumers that recognize the
+extension. See #409.
+"""
+
+from __future__ import annotations
+
+from mat_vis_client.adapters import to_gltf, to_threejs
+
+
+# ── Three.js: documented no-op ────────────────────────────────────
+
+
+class TestThreejsSubsurfaceNoOp:
+    """``MeshPhysicalMaterial`` has no SSS field. Verify the SSS scalars
+    do NOT leak into the Three.js output under any spelling — neither
+    as a top-level property nor as a renamed alias. This pin protects
+    against a well-meaning future change quietly emitting a property
+    that ``new THREE.MeshPhysicalMaterial(...)`` will silently swallow."""
+
+    def test_subsurface_does_not_leak(self) -> None:
+        out = to_threejs(
+            {
+                "subsurface": 1.0,
+                "subsurface_color": [0.9, 0.5, 0.4],
+                "subsurface_radius": [1.0, 0.2, 0.1],
+            }
+        )
+        # No subsurface key in any casing; no _color / _radius siblings.
+        for key in out:
+            assert "subsurface" not in key.lower(), f"unexpected SSS key {key!r}"
+
+    def test_subsurface_factor_alone_does_not_leak(self) -> None:
+        out = to_threejs({"subsurface": 0.5})
+        for key in out:
+            assert "subsurface" not in key.lower()
+
+    def test_subsurface_does_not_disturb_other_fields(self) -> None:
+        # SSS-bearing inputs must not silently disable other passthrough
+        # fields. Pin a mix.
+        out = to_threejs(
+            {
+                "roughness": 0.4,
+                "metalness": 0.0,
+                "subsurface": 0.5,
+                "subsurface_color": [0.9, 0.5, 0.4],
+                "subsurface_radius": [1.0, 0.2, 0.1],
+            }
+        )
+        assert out["roughness"] == 0.4
+        assert out["metalness"] == 0.0
+
+
+# ── glTF: KHR_materials_subsurface emission ──────────────────────
+
+
+class TestGltfSubsurface:
+    def test_subsurface_factor_emits_extension(self) -> None:
+        out = to_gltf({"subsurface": 0.25})
+        ext = out["extensions"]["KHR_materials_subsurface"]
+        assert ext == {"subsurfaceFactor": 0.25}
+
+    def test_full_triplet_emits_all_three_factors(self) -> None:
+        out = to_gltf(
+            {
+                "subsurface": 1.0,
+                "subsurface_color": [0.9, 0.85, 0.7],
+                "subsurface_radius": [11.6, 9.4, 7.4],
+            }
+        )
+        ext = out["extensions"]["KHR_materials_subsurface"]
+        assert ext == {
+            "subsurfaceFactor": 1.0,
+            "subsurfaceColorFactor": [0.9, 0.85, 0.7],
+            # Per-channel mean-free-path carried verbatim — MaterialX
+            # and the draft glTF extension share length-per-channel
+            # semantics, no unit conversion at the boundary.
+            "subsurfaceRadiusFactor": [11.6, 9.4, 7.4],
+        }
+
+    def test_subsurface_zero_omits_extension(self) -> None:
+        # Mirrors clearcoat / transmission / dispersion suppression:
+        # no-op extension entries bloat glTF output for the 441/454
+        # corpus materials authoring the default.
+        out = to_gltf({"subsurface": 0.0, "subsurface_color": [0.5, 0.5, 0.5]})
+        assert "extensions" not in out or "KHR_materials_subsurface" not in out.get(
+            "extensions", {}
+        )
+
+    def test_subsurface_none_omits_extension(self) -> None:
+        out = to_gltf({"subsurface": None})
+        assert "extensions" not in out or "KHR_materials_subsurface" not in out.get(
+            "extensions", {}
+        )
+
+    def test_subsurface_color_alone_does_not_emit_extension(self) -> None:
+        # Without subsurface > 0, the SSS layer is disabled — the color
+        # / radius authoring scaffolding has no rendering effect. Don't
+        # ship an extension that turns into a no-op for consumers.
+        out = to_gltf({"subsurface_color": [0.5, 0.5, 0.5]})
+        assert "extensions" not in out or "KHR_materials_subsurface" not in out.get(
+            "extensions", {}
+        )
+
+    def test_partial_triplet_emits_only_authored_factors(self) -> None:
+        # Factor authored without color/radius: emit just the factor.
+        out = to_gltf({"subsurface": 0.4})
+        ext = out["extensions"]["KHR_materials_subsurface"]
+        assert "subsurfaceFactor" in ext
+        assert "subsurfaceColorFactor" not in ext
+        assert "subsurfaceRadiusFactor" not in ext
+
+    def test_subsurface_factor_with_color_only(self) -> None:
+        out = to_gltf({"subsurface": 0.5, "subsurface_color": [0.8, 0.5, 0.4]})
+        ext = out["extensions"]["KHR_materials_subsurface"]
+        assert ext["subsurfaceFactor"] == 0.5
+        assert ext["subsurfaceColorFactor"] == [0.8, 0.5, 0.4]
+        assert "subsurfaceRadiusFactor" not in ext

--- a/src/mat_vis_baker/_mtlx_scalars.py
+++ b/src/mat_vis_baker/_mtlx_scalars.py
@@ -56,6 +56,12 @@ _FLOAT_INPUTS: dict[str, str] = {
     # factor is silently dropped — every entry looks the same to
     # consumers reading the scalar block.
     "coat": "clearcoat",  # KHR_materials_clearcoat.clearcoatFactor
+    # Subsurface scattering factor (#409). 13 gpuopen entries author
+    # ``subsurface > 0`` (wax-like, resin, semi-transparent); dropping
+    # this made wax / jade / skin render as opaque dielectric. Wired
+    # for glTF via the (draft) subsurface extension; Three.js adapter
+    # is intentionally a no-op (MeshPhysicalMaterial has no SSS field).
+    "subsurface": "subsurface",
 }
 
 # Color3 inputs. Same direct value=/1-hop graph→constant promotion as
@@ -64,6 +70,11 @@ _FLOAT_INPUTS: dict[str, str] = {
 _COLOR3_INPUTS: dict[str, str] = {
     # mtlx input name -> PBRBlock attribute
     "specular_color": "specular_color",  # KHR_materials_specular.specularColorFactor
+    # Subsurface scattering color + per-channel mean-free-path (#409).
+    # Both are emitted unconditionally when authored; the adapter
+    # decides whether the SSS extension fires (only when subsurface>0).
+    "subsurface_color": "subsurface_color",
+    "subsurface_radius": "subsurface_radius",
 }
 
 # Inputs that have no PBRBlock home today. Non-zero values are dropped
@@ -74,9 +85,6 @@ _LOSSY_INPUTS: tuple[str, ...] = (
     "sheen",
     "sheen_roughness",
     "sheen_color",
-    "subsurface",
-    "subsurface_color",
-    "subsurface_radius",
     "thin_film_thickness",
     "emission",
     "emission_color",

--- a/src/mat_vis_baker/common.py
+++ b/src/mat_vis_baker/common.py
@@ -469,6 +469,22 @@ class PBRBlock:
     thickness: float | None = None  # <standard_surface>.transmission_depth
     dispersion: float | None = None  # <standard_surface>.transmission_dispersion
 
+    # Subsurface scattering (#409). 13 gpuopen entries author
+    # ``subsurface > 0`` (wax, resin, semi-translucent). Three.js
+    # MeshPhysicalMaterial has no native SSS field — adapter is a
+    # documented no-op there; glTF adapter emits the draft
+    # ``KHR_materials_subsurface`` extension (vendor-prefixed because
+    # the Khronos draft is not yet ratified). Units: ``subsurface``
+    # is a unitless 0..1 mix factor; ``subsurface_color`` is linear
+    # RGB; ``subsurface_radius`` is per-channel mean-free-path in
+    # MaterialX scene units (typically mm). The glTF extension carries
+    # these values verbatim — same per-channel length semantics, no
+    # unit conversion.
+    # subsurface_radius is per-channel mean-free-path in MaterialX scene units.
+    subsurface: float | None = None  # <standard_surface>.subsurface
+    subsurface_color: list[float] | None = None  # <standard_surface>.subsurface_color (linear RGB)
+    subsurface_radius: list[float] | None = None  # <standard_surface>.subsurface_radius
+
 
 def apply_pbr_neutral_multiplier_conventions(
     pbr: PBRBlock,

--- a/tests/test_index_builder.py
+++ b/tests/test_index_builder.py
@@ -87,6 +87,10 @@ def test_mat_vis_block_has_stable_key_set() -> None:
         "dispersion",
         # Clearcoat on/off switch (#396) — additive.
         "clearcoat",
+        # Subsurface scattering (#409) — additive.
+        "subsurface",
+        "subsurface_color",
+        "subsurface_radius",
     }
     # Nested AttributionBlock
     assert set(mv["attribution"].keys()) == {"authors", "license_spdx", "source_url"}
@@ -120,6 +124,10 @@ def test_mat_vis_block_defaults_are_null_or_empty() -> None:
     assert mv["pbr"]["dispersion"] is None
     # Clearcoat on/off switch (#396) — additive, default-None.
     assert mv["pbr"]["clearcoat"] is None
+    # Subsurface scattering (#409) — additive, default-None.
+    assert mv["pbr"]["subsurface"] is None
+    assert mv["pbr"]["subsurface_color"] is None
+    assert mv["pbr"]["subsurface_radius"] is None
     assert mv["attribution"]["authors"] == []
     assert mv["dates"]["published"] is None
     assert mv["dates"]["updated"] is None

--- a/tests/test_mtlx_scalars.py
+++ b/tests/test_mtlx_scalars.py
@@ -286,9 +286,13 @@ FIXTURE_LOSSY_ZERO_COLOR3 = """<?xml version="1.0"?>
 
 def test_lossy_subsurface_and_sheen_logged_at_debug(caplog):
     with caplog.at_level(logging.DEBUG, logger="mat-vis-baker.gpuopen-scalars"):
-        parse_standard_surface_scalars(FIXTURE_LOSSY_SUBSURFACE_SHEEN, material_id="m-sss")
+        pbr = parse_standard_surface_scalars(FIXTURE_LOSSY_SUBSURFACE_SHEEN, material_id="m-sss")
     msgs = [rec.message for rec in caplog.records]
-    assert any("subsurface=0.5" in m for m in msgs)
+    # subsurface is now extracted into pbr.subsurface (#409) — wired
+    # via the draft glTF subsurface extension. No longer lossy.
+    assert pbr.subsurface == 0.5
+    assert not any("subsurface=0.5" in m for m in msgs)
+    # sheen still has no PBRBlock home — logged as lossy.
     assert any("sheen=0.3" in m for m in msgs)
 
 

--- a/tests/test_mtlx_scalars_pbr_coverage.py
+++ b/tests/test_mtlx_scalars_pbr_coverage.py
@@ -1,4 +1,4 @@
-"""Bake-side extraction tests for #340 / #396 — full MeshPhysicalMaterial coverage.
+"""Bake-side extraction tests for #340 / #396 / #409 — full MeshPhysicalMaterial coverage.
 
 Scalar fields extracted from ``<standard_surface>``:
 - coat                   → clearcoat (float, #396)
@@ -7,11 +7,15 @@ Scalar fields extracted from ``<standard_surface>``:
 - specular_color         → specular_color (color3, linear, #340)
 - transmission_dispersion → dispersion (float, #340)
 - transmission_depth     → thickness (float, only when transmission > 0, #340)
+- subsurface             → subsurface (float, #409)
+- subsurface_color       → subsurface_color (color3, linear, #409)
+- subsurface_radius      → subsurface_radius (color3, per-channel mfp, #409)
 
 All extracted from <standard_surface> direct `value=` attributes or
 1-hop nodegraph→<constant> chains. Survey of 454 gpuopen materials
 confirms each input is authored ~80-95% of the time; specular_color
-is 94% non-default; coat is 3/454 (Car Paint family).
+is 94% non-default; coat is 3/454 (Car Paint family); subsurface
+is 13/454 with ``subsurface > 0`` (wax, resin, semi-translucent).
 """
 
 from __future__ import annotations
@@ -161,6 +165,122 @@ class TestClearcoat:
         assert pbr.clearcoat == pytest.approx(0.75)
 
 
+class TestSubsurface:
+    """``subsurface`` factor + ``subsurface_color`` + ``subsurface_radius``
+    extraction (#409). Survey of 454 gpuopen materials: 13 author
+    ``subsurface > 0`` (wax-like, resin, semi-translucent); the rest
+    default to 0.0 with sometimes non-default color/radius scaffolding
+    that has no rendering effect when the factor is zero. The baker
+    still extracts color/radius unconditionally so the adapter can
+    decide whether to ship the extension."""
+
+    def test_subsurface_authored_non_default(self) -> None:
+        # gpuopen 'Wax (White)' and 'Skin' families author subsurface=1.0.
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="subsurface" type="float" value="1.0"/>')
+        )
+        assert pbr.subsurface == pytest.approx(1.0)
+
+    def test_subsurface_authored_partial(self) -> None:
+        # Real corpus: values like 0.1, 0.15, 0.178, 0.2, 0.25, 0.3, 0.5.
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="subsurface" type="float" value="0.25"/>')
+        )
+        assert pbr.subsurface == pytest.approx(0.25)
+
+    def test_subsurface_default_zero_extracted(self) -> None:
+        # 441/454 corpus materials default to 0.0 — extracting it
+        # confirms provenance. Adapter suppresses the no-op extension.
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="subsurface" type="float" value="0.0"/>')
+        )
+        assert pbr.subsurface == pytest.approx(0.0)
+
+    def test_subsurface_unset_stays_none(self) -> None:
+        pbr = parse_standard_surface_scalars(_wrap())
+        assert pbr.subsurface is None
+
+    def test_subsurface_color_authored_tinted(self) -> None:
+        # Linear RGB per MaterialX 1.38 — extracted verbatim.
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="subsurface_color" type="color3" value="0.8, 0.4, 0.3"/>')
+        )
+        assert pbr.subsurface_color == pytest.approx([0.8, 0.4, 0.3])
+
+    def test_subsurface_color_unset_stays_none(self) -> None:
+        pbr = parse_standard_surface_scalars(_wrap())
+        assert pbr.subsurface_color is None
+
+    def test_subsurface_radius_per_channel_mfp(self) -> None:
+        # MaterialX subsurface_radius is color3 carrying per-wavelength
+        # mean-free-path (typically mm). Skin-like values: ~[1, 0.2, 0.1].
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="subsurface_radius" type="color3" value="1.0, 0.2, 0.1"/>')
+        )
+        assert pbr.subsurface_radius == pytest.approx([1.0, 0.2, 0.1])
+
+    def test_subsurface_radius_unset_stays_none(self) -> None:
+        pbr = parse_standard_surface_scalars(_wrap())
+        assert pbr.subsurface_radius is None
+
+    def test_subsurface_full_triplet_authored(self) -> None:
+        # Real-corpus shape: all three authored together (wax white).
+        pbr = parse_standard_surface_scalars(
+            _wrap(
+                '<input name="subsurface" type="float" value="1.0"/>',
+                '<input name="subsurface_color" type="color3" value="0.9, 0.85, 0.7"/>',
+                '<input name="subsurface_radius" type="color3" value="11.6, 9.4, 7.4"/>',
+            )
+        )
+        assert pbr.subsurface == pytest.approx(1.0)
+        assert pbr.subsurface_color == pytest.approx([0.9, 0.85, 0.7])
+        assert pbr.subsurface_radius == pytest.approx([11.6, 9.4, 7.4])
+
+    def test_subsurface_graph_constant_promoted(self) -> None:
+        # 1-hop nodegraph → <constant> resolution applies to ``subsurface``
+        # the same way it does for every other _FLOAT_INPUT.
+        mtlx = """<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="NG_SSS">
+    <constant name="sss_const" type="float">
+      <input name="value" type="float" value="0.42"/>
+    </constant>
+    <output name="sss_out" type="float" nodename="sss_const"/>
+  </nodegraph>
+  <standard_surface name="SR_T" type="surfaceshader">
+    <input name="subsurface" type="float" output="sss_out" nodegraph="NG_SSS"/>
+  </standard_surface>
+  <surfacematerial name="T" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_T"/>
+  </surfacematerial>
+</materialx>
+"""
+        pbr = parse_standard_surface_scalars(mtlx)
+        assert pbr.subsurface == pytest.approx(0.42)
+
+    def test_subsurface_texture_bound_stays_none(self) -> None:
+        # texture-bound subsurface leaves the field None — consistent
+        # with metalness-texture-bound handling.
+        mtlx = """<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="NG_SSS">
+    <image name="sss_img" type="float">
+      <input name="file" type="filename" value="sss.png"/>
+    </image>
+    <output name="sss_out" type="float" nodename="sss_img"/>
+  </nodegraph>
+  <standard_surface name="SR_T" type="surfaceshader">
+    <input name="subsurface" type="float" output="sss_out" nodegraph="NG_SSS"/>
+  </standard_surface>
+  <surfacematerial name="T" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_T"/>
+  </surfacematerial>
+</materialx>
+"""
+        pbr = parse_standard_surface_scalars(mtlx)
+        assert pbr.subsurface is None
+
+
 class TestDispersion:
     def test_dispersion_authored(self) -> None:
         pbr = parse_standard_surface_scalars(
@@ -220,6 +340,10 @@ class TestPBRBlockFieldsExist:
             "specular_color",
             "thickness",
             "dispersion",
+            # Subsurface scattering (#409) — additive triplet.
+            "subsurface",
+            "subsurface_color",
+            "subsurface_radius",
         ):
             assert getattr(pbr, fname) is None, f"{fname} should default to None"
 
@@ -233,9 +357,15 @@ class TestPBRBlockFieldsExist:
         pbr.specular_color = [0.95, 0.5, 0.3]
         pbr.thickness = 5.0
         pbr.dispersion = 0.1
+        pbr.subsurface = 0.5
+        pbr.subsurface_color = [0.9, 0.6, 0.5]
+        pbr.subsurface_radius = [1.0, 0.2, 0.1]
         assert pbr.clearcoat == 1.0
         assert pbr.clearcoat_roughness == 0.2
         assert pbr.specular_intensity == 0.8
         assert pbr.specular_color == [0.95, 0.5, 0.3]
         assert pbr.thickness == 5.0
         assert pbr.dispersion == 0.1
+        assert pbr.subsurface == 0.5
+        assert pbr.subsurface_color == [0.9, 0.6, 0.5]
+        assert pbr.subsurface_radius == [1.0, 0.2, 0.1]


### PR DESCRIPTION
## Summary

Closes #409. Phase 3d of the #405 PBR-coverage sweep.

Adds `subsurface` (factor) + `subsurface_color` (linear RGB color3) + `subsurface_radius` (per-channel mean-free-path color3) to `PBRBlock`, extracts all three from `<standard_surface>` MTLX, and wires the glTF adapter to emit `KHR_materials_subsurface`. **Three.js adapter is an intentional no-op** — `MeshPhysicalMaterial` has no native SSS field; documented inline so future readers don't mistake it for a miss.

Mechanically identical to #400 (`coat` factor → `clearcoat`): `_LOSSY_INPUTS` → `_FLOAT_INPUTS` / `_COLOR3_INPUTS` in the parser; additive fields on `PBRBlock`; stable-key-set + adapter coverage tests.

## Corpus audit

Grepped the v2026.04.99-tst-full-369 MTLX dumps for `<input name="subsurface" type="float" value="…"` with non-zero values:

| source     | total entries | `subsurface > 0` |
| ---------- | ------------- | ---------------- |
| gpuopen    | 454           | **13**           |
| polyhaven  | 757           | 0                |
| ambientcg  | 1949          | 0                |

Confirms the #409 prediction. The 13 gpuopen entries span 0.1 .. 1.0 with two at full-bake `subsurface=1.0`. polyhaven authors `subsurface_color` / `subsurface_radius` defaults on every entry but never raises `subsurface` above 0 — no rendering SSS in polyhaven today, exactly as the audit caveat in #405 anticipated.

## Acceptance criteria

- [x] `PBRBlock.subsurface` / `subsurface_color` / `subsurface_radius` added (additive — stable key-set contract honored)
- [x] Parser extracts all three via direct `value=` or 1-hop graph-constant promotion
- [x] Stable-key-set + default-None tests in `tests/test_index_builder.py` updated
- [x] Parser coverage tests with synthesised MTLX (TestSubsurface in `tests/test_mtlx_scalars_pbr_coverage.py`)
- [x] glTF adapter emits the SSS extension when `subsurface > 0`; omits it at 0/None or when only color/radius authored
- [x] Three.js adapter: documented no-op, pinned by `tests/test_adapters_subsurface.py::TestThreejsSubsurfaceNoOp`
- [x] All baker + client tests pass (638 baker passed, 600 client passed locally)

## glTF extension naming — context

The issue noted that `KHR_materials_subsurface` was experimental and that the canonical name should be verified. Findings:

- **`KHR_materials_subsurface`** (Khronos PR #1928, closed) parameterized SSS via `scatterColor` + `scatterDistance` — neither field name nor parameterization matches MaterialX's `subsurface` / `subsurface_color` / `subsurface_radius` triplet.
- **`KHR_materials_volume_scatter`** (Khronos PR #2453, open, draft) is the active successor, using `scatterAlbedo` and a different parameterization again.
- Neither extension is in the registered Khronos folder (`extensions/2.0/Khronos`) of the glTF repo today.

Decision: emit the MaterialX-faithful triplet under the canonical-but-unratified name **`KHR_materials_subsurface`** with field names `subsurfaceFactor` / `subsurfaceColorFactor` / `subsurfaceRadiusFactor` (the shape #409 originally specified). Rationale:

1. **Round-trip preservation**: consumers reading the substrate then re-emitting MaterialX get the exact triplet back.
2. **Graceful degradation**: glTF consumers that don't recognize the extension fall back to opaque-dielectric — exactly the status-quo behavior for the 441/454 gpuopen entries that author `subsurface=0`.
3. **No drift risk**: every emission point is suppressed when `subsurface ≤ 0`, so no no-op extension entries land in the substrate.

If/when the Khronos successor lands (`KHR_materials_volume_scatter`), a future PR can swap the extension key and translate the triplet to the official parameterization. The substrate scalars stay correct under either choice.

## Pitfalls

- **Three.js gap is real**: this is the one Phase 3 child where the field ships but only the glTF adapter can consume it. Consumers using Three.js will see `subsurface`/`_color`/`_radius` in the catalog but won't see SSS in their renders. The Three.js adapter test (`TestThreejsSubsurfaceNoOp`) pins this contract so a well-meaning future change can't quietly leak a property name that `MeshPhysicalMaterial` will silently swallow.
- **`subsurface_radius` units**: MaterialX color3 carrying per-wavelength mean-free-path (typically mm). The glTF extension carries the same per-channel length semantics — no unit conversion at the boundary. Documented in `PBRBlock` and in the glTF adapter inline comment.

## Test plan

- [x] `uv pip install -e ".[baker]" && uv run --extra baker --extra dev pytest tests/` — 638 passed, 20 skipped
- [x] `cd clients/python && uv run --extra test --extra gltf --extra search pytest tests/` — 600 passed, 29 skipped, 2 xfailed
- [ ] Post-merge: dispatch `bake.yml` on `gerchowl/mat-vis-tst` and confirm 13 gpuopen entries (wax/resin/translucent family) emit `pbr.subsurface > 0` in the substrate

## References

- mat-vis#405 — Phase 3 PBR coverage epic
- mat-vis#400 / #396 — reference mechanical pattern (`coat` factor)
- KhronosGroup/glTF PR #1928 — original `KHR_materials_subsurface` draft (closed)
- KhronosGroup/glTF PR #2453 — successor `KHR_materials_volume_scatter` (open, draft)