### PR TITLE
feat(baker+adapter): sheen scalar coverage — velvet/satin/fabric (#407)

### DIFF
--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -1446,17 +1446,18 @@ class MatVisClient:
         "clearcoat_roughness",
         "specular_intensity",
         "emissive",
-        # Subsurface scattering (#409). glTF adapter emits the (draft)
-        # ``KHR_materials_subsurface`` extension; Three.js adapter is a
-        # documented no-op (no native MeshPhysical SSS field).
+        # Subsurface scattering (#409). glTF KHR_materials_subsurface;
+        # Three.js no-op (no native MeshPhysical SSS).
         "subsurface",
         "subsurface_color",
         "subsurface_radius",
-        # Emission scalar coverage (#406 / #405 Phase 3a) — factor +
-        # linear-RGB tint. Adapter splits HDR strengths > 1 into
-        # emissiveIntensity / KHR_materials_emissive_strength.
+        # Emission (#406 / #405 Phase 3a) — HDR-aware factor + linear RGB.
         "emission",
         "emission_color",
+        # KHR_materials_sheen — velvet/satin/fabric (#407 / #405 Phase 3b).
+        "sheen",
+        "sheen_color",
+        "sheen_roughness",
     )
 
     def _scalars_for(self, source: str, material_id: str) -> dict:

--- a/clients/python/src/mat_vis_client/adapters.py
+++ b/clients/python/src/mat_vis_client/adapters.py
@@ -55,6 +55,11 @@ def _to_data_uri(png_bytes: bytes) -> str:
 _KHR_IOR_DEFAULT = 1.5
 _KHR_TRANSMISSION_DEFAULT = 0.0
 _KHR_CLEARCOAT_DEFAULT = 0.0
+# KHR_materials_sheen default — sheenColorFactor magnitude 0.0
+# (= no sheen). Mirrors the clearcoat suppression pattern: emitting a
+# no-op extension entry that matches the spec default just bloats glTF
+# output. #407.
+_KHR_SHEEN_DEFAULT = 0.0
 
 
 def _ior_at_default(ior: float | None) -> bool:
@@ -83,47 +88,35 @@ def _resolve_emission_split(
     """Resolve ``emission`` factor + ``emission_color`` into the
     (color, strength) pair Three.js/glTF HDR emission needs (#406).
 
-    Returns ``None`` when the material is non-emissive — neither
-    ``emission`` nor ``emission_color`` is authored, OR ``emission``
-    is authored at the spec default 0.0. The caller suppresses the
-    output field entirely in that case.
-
-    Otherwise returns ``(emissive_color, strength)`` where:
-
-    - ``emissive_color`` is ``emission_color * min(emission, 1)``, clamped
-      to [0, 1]. Falls back to white (``[1, 1, 1]``) when emission_color
-      is unauthored — matches MaterialX 1.38 ``<standard_surface>``
-      defaults. Goes into Three.js ``emissive`` / glTF ``emissiveFactor``.
-    - ``strength`` is ``max(emission, 1.0)`` — the HDR multiplier. Equal
-      to 1.0 for SDR cases (caller suppresses), > 1 for HDR (caller
-      emits Three.js ``emissiveIntensity`` / glTF
-      KHR_materials_emissive_strength).
-
-    Adapter contract: ``emission`` is the canonical scalar HDR factor
-    on the substrate (PBRBlock.emission, #406). The legacy ``emissive``
-    key (RGB triple, no factor) is read elsewhere — when both arrive
-    in the scalars dict, ``emission`` wins because it carries the HDR
-    information the legacy key cannot express.
+    Returns ``None`` when the material is non-emissive. Otherwise
+    returns ``(emissive_color, strength)`` where emissive_color =
+    ``emission_color * min(emission, 1)`` clamped to [0,1], and
+    strength = ``max(emission, 1.0)`` (caller emits HDR strength
+    extension when > 1).
     """
     emission = scalars.get("emission")
     emission_color = scalars.get("emission_color")
     if emission is None and emission_color is None:
         return None
-    # Treat a None factor with an authored color as "factor=1.0" — the
-    # color was authored intentionally; ignoring it because the factor
-    # is None would silently drop authored intent.
     factor = 1.0 if emission is None else float(emission)
     if factor <= 0.0:
         return None
     color = list(emission_color) if emission_color is not None else [1.0, 1.0, 1.0]
     if len(color) < 3:
         return None
-    # Clamp color to [0,1]; multiply by min(factor, 1) so the SDR
-    # component lives inside Three.js Color / glTF emissiveFactor.
     sdr = min(factor, 1.0)
     emissive_color = [max(0.0, min(1.0, float(c) * sdr)) for c in color[:3]]
     strength = max(factor, 1.0)
     return emissive_color, strength
+
+
+def _sheen_at_default(s: float | None) -> bool:
+    """True if ``s`` is None or matches the KHR_materials_sheen default (0.0).
+
+    Polyhaven authors sheen=0 on 757/757 entries — without this
+    suppression every entry would ship the extension. #407.
+    """
+    return s is None or math.isclose(s, _KHR_SHEEN_DEFAULT, abs_tol=1e-9)
 
 
 def _color_hex_to_int(hex_str: str) -> int:
@@ -432,9 +425,18 @@ def to_threejs(
     # mat-vis#409: Three.js MeshPhysicalMaterial has no native SSS field.
     # subsurface / subsurface_color / subsurface_radius land in the
     # substrate for glTF and future use; the Three.js adapter is
-    # intentionally a no-op here. Future workaround if a consumer asks:
-    # approximate via ``transmission`` + ``thickness`` (dense scattering
-    # cue), but that lies about the per-channel mean-free-path. See #409.
+    # intentionally a no-op here.
+
+    # KHR_materials_sheen → MeshPhysicalMaterial.sheen / sheenColor /
+    # sheenRoughness (#407 / #405 Phase 3b). Only emit when sheen > 0 —
+    # default values would otherwise pollute every non-fabric material.
+    sheen = scalars.get("sheen")
+    if not _sheen_at_default(sheen):
+        result["sheen"] = sheen
+        sheen_color = scalars.get("sheen_color")
+        result["sheenColor"] = list(sheen_color) if sheen_color is not None else [1.0, 1.0, 1.0]
+        sheen_roughness = scalars.get("sheen_roughness")
+        result["sheenRoughness"] = sheen_roughness if sheen_roughness is not None else 1.0
 
     # Textures as data URIs
     for channel, prop in _THREEJS_TEX_MAP.items():
@@ -592,21 +594,9 @@ def to_gltf(
         }
 
     # KHR_materials_subsurface (#409). Draft / unratified Khronos
-    # extension — the original proposal (PR KhronosGroup/glTF#1928,
-    # closed) used ``scatterColor`` + ``scatterDistance``; the current
-    # successor draft (PR #2453, ``KHR_materials_volume_scatter``) uses
-    # ``scatterAlbedo`` + a different parameterization. Neither shape
-    # round-trips MaterialX's ``subsurface`` / ``subsurface_color`` /
-    # ``subsurface_radius`` triplet faithfully, so we emit the
-    # MaterialX-faithful triplet under the canonical-but-unratified
-    # ``KHR_materials_subsurface`` name with the issue-specified
-    # ``subsurfaceFactor`` / ``subsurfaceColorFactor`` /
-    # ``subsurfaceRadiusFactor`` keys. Consumers that don't recognize
-    # the extension fall back to opaque-dielectric — exactly the
-    # status quo. Three.js consumers see nothing (no MeshPhysical
-    # SSS field; see adapter no-op above). Suppressed when the factor
-    # is 0 or None, mirroring the clearcoat / transmission /
-    # dispersion suppression pattern.
+    # extension — emit MaterialX-faithful triplet under the canonical
+    # name. Consumers that don't recognize the extension fall back to
+    # opaque-dielectric.
     subsurface = scalars.get("subsurface")
     if subsurface is not None and subsurface > 0.0:
         sss_ext: dict = {"subsurfaceFactor": subsurface}
@@ -615,11 +605,23 @@ def to_gltf(
             sss_ext["subsurfaceColorFactor"] = list(subsurface_color)
         subsurface_radius = scalars.get("subsurface_radius")
         if subsurface_radius is not None:
-            # MaterialX subsurface_radius is per-channel mean-free-path
-            # (length per RGB channel, typically mm). glTF radius factor
-            # carries identical semantics — emit verbatim, no conversion.
             sss_ext["subsurfaceRadiusFactor"] = list(subsurface_radius)
         material.setdefault("extensions", {})["KHR_materials_subsurface"] = sss_ext
+
+    # KHR_materials_sheen — fabric/velvet/satin retroreflective edge
+    # backscatter (#407 / #405 Phase 3b). Emit only when sheen > 0.
+    # sheenColorFactor = sheen * sheen_color per spec convention.
+    sheen = scalars.get("sheen")
+    if not _sheen_at_default(sheen):
+        sheen_color = scalars.get("sheen_color")
+        if sheen_color is None:
+            sheen_color = [1.0, 1.0, 1.0]
+        scf = [float(sheen) * float(c) for c in list(sheen_color)[:3]]
+        sheen_ext: dict = {"sheenColorFactor": scf}
+        sheen_roughness = scalars.get("sheen_roughness")
+        if sheen_roughness is not None:
+            sheen_ext["sheenRoughnessFactor"] = sheen_roughness
+        material.setdefault("extensions", {})["KHR_materials_sheen"] = sheen_ext
 
     # Opacity texture — glTF 2.0 has no standalone alphaMap slot. Alpha
     # must live in baseColorTexture's alpha channel + alphaMode/alphaCutoff

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -2132,18 +2132,18 @@ class MatVisClient:
         "clearcoat_roughness",
         "specular_intensity",
         "emissive",
-        # Subsurface scattering (#409). The glTF adapter emits the
-        # (draft) ``KHR_materials_subsurface`` extension; the Three.js
-        # adapter is a documented no-op because MeshPhysicalMaterial
-        # has no native SSS field.
+        # Subsurface scattering (#409). glTF emits KHR_materials_subsurface;
+        # Three.js adapter is a documented no-op (no native MeshPhysical SSS).
         "subsurface",
         "subsurface_color",
         "subsurface_radius",
-        # Emission scalar coverage (#406 / #405 Phase 3a) — factor +
-        # linear-RGB tint. Adapter splits HDR strengths > 1 into
-        # emissiveIntensity / KHR_materials_emissive_strength.
+        # Emission (#406 / #405 Phase 3a) — HDR-aware factor + linear RGB.
         "emission",
         "emission_color",
+        # KHR_materials_sheen — velvet/satin/fabric (#407 / #405 Phase 3b).
+        "sheen",
+        "sheen_color",
+        "sheen_roughness",
     )
 
     def _scalars_for(self, source: str, material_id: str) -> dict:

--- a/clients/python/tests/test_adapters_sheen.py
+++ b/clients/python/tests/test_adapters_sheen.py
@@ -1,0 +1,137 @@
+"""Tests for KHR_materials_sheen adapter coverage (#407).
+
+Velvet/satin/fabric retroreflective edge backscatter. The MaterialX
+``<standard_surface>`` ``sheen`` / ``sheen_color`` / ``sheen_roughness``
+inputs map to:
+
+    | scalar              | to_threejs              | to_gltf                                                     |
+    |---------------------|-------------------------|-------------------------------------------------------------|
+    | sheen               | result["sheen"]         | KHR_materials_sheen.sheenColorFactor (magnitude × color)    |
+    | sheen_color         | result["sheenColor"]    | KHR_materials_sheen.sheenColorFactor (color × magnitude)    |
+    | sheen_roughness     | result["sheenRoughness"]| KHR_materials_sheen.sheenRoughnessFactor                    |
+
+Sheen at the spec default 0.0 is omitted (no-op extension entry and
+non-fabric MeshPhysicalMaterial pollution, mirroring the existing
+clearcoat=0.0 suppression pattern). Audit at v2026.04.99: polyhaven
+authors sheen=0.0 on 757/757 entries, ambientcg never authors the
+inputs, gpuopen 0/454 — gating on >0 keeps the output clean.
+"""
+
+from __future__ import annotations
+
+from mat_vis_client.adapters import to_gltf, to_threejs
+
+
+# ── Three.js MeshPhysicalMaterial ───────────────────────────────
+
+
+class TestSheenToThreejs:
+    def test_sheen_emitted_with_full_triple(self) -> None:
+        result = to_threejs(
+            {
+                "sheen": 0.8,
+                "sheen_color": [0.3, 0.5, 1.0],
+                "sheen_roughness": 0.5,
+            }
+        )
+        assert result["sheen"] == 0.8
+        assert result["sheenColor"] == [0.3, 0.5, 1.0]
+        assert result["sheenRoughness"] == 0.5
+
+    def test_sheen_zero_omitted(self) -> None:
+        # Polyhaven authors sheen=0.0 on all 757 entries; the adapter
+        # MUST suppress to avoid polluting every non-fabric material's
+        # parameter dict with sheenColor/sheenRoughness defaults.
+        result = to_threejs(
+            {
+                "sheen": 0.0,
+                "sheen_color": [1.0, 1.0, 1.0],
+                "sheen_roughness": 0.3,
+            }
+        )
+        assert "sheen" not in result
+        assert "sheenColor" not in result
+        assert "sheenRoughness" not in result
+
+    def test_sheen_none_omitted(self) -> None:
+        result = to_threejs({"sheen": None})
+        assert "sheen" not in result
+        assert "sheenColor" not in result
+        assert "sheenRoughness" not in result
+
+    def test_sheen_absent_when_not_in_scalars(self) -> None:
+        result = to_threejs({})
+        assert "sheen" not in result
+        assert "sheenColor" not in result
+        assert "sheenRoughness" not in result
+
+    def test_sheen_defaults_filled_when_factor_authored(self) -> None:
+        # sheen > 0 but sheen_color / sheen_roughness unset → fill
+        # MaterialX neutral defaults so Three.js doesn't render with
+        # uninitialized halo.
+        result = to_threejs({"sheen": 1.0})
+        assert result["sheen"] == 1.0
+        assert result["sheenColor"] == [1.0, 1.0, 1.0]
+        assert result["sheenRoughness"] == 1.0
+
+
+# ── glTF 2.0 with KHR_materials_sheen ───────────────────────────
+
+
+class TestSheenToGltf:
+    def test_sheen_emits_khr_extension(self) -> None:
+        result = to_gltf(
+            {
+                "sheen": 1.0,
+                "sheen_color": [0.2, 0.4, 0.9],
+                "sheen_roughness": 0.5,
+            }
+        )
+        ext = result["extensions"]["KHR_materials_sheen"]
+        # sheenColorFactor = sheen * sheen_color (per spec — the factor
+        # IS the tinted magnitude in linear RGB).
+        assert ext["sheenColorFactor"] == [0.2, 0.4, 0.9]
+        assert ext["sheenRoughnessFactor"] == 0.5
+
+    def test_sheen_color_factor_premultiplied(self) -> None:
+        # sheen=0.5, sheen_color=(1,1,1) → sheenColorFactor=(0.5, 0.5, 0.5).
+        result = to_gltf({"sheen": 0.5, "sheen_color": [1.0, 1.0, 1.0]})
+        ext = result["extensions"]["KHR_materials_sheen"]
+        assert ext["sheenColorFactor"] == [0.5, 0.5, 0.5]
+
+    def test_sheen_zero_omitted(self) -> None:
+        # Spec default sheenColorFactor=(0,0,0). 757/757 polyhaven
+        # entries author sheen=0; emitting the extension would bloat
+        # the substrate massively for no rendering effect.
+        result = to_gltf(
+            {
+                "sheen": 0.0,
+                "sheen_color": [1.0, 1.0, 1.0],
+                "sheen_roughness": 0.3,
+            }
+        )
+        assert "KHR_materials_sheen" not in result.get("extensions", {})
+
+    def test_sheen_none_omitted(self) -> None:
+        result = to_gltf({"sheen": None})
+        assert "KHR_materials_sheen" not in result.get("extensions", {})
+
+    def test_sheen_absent_when_not_in_scalars(self) -> None:
+        result = to_gltf({})
+        assert "KHR_materials_sheen" not in result.get("extensions", {})
+
+    def test_sheen_without_color_falls_back_to_white(self) -> None:
+        # sheen authored but sheen_color absent → adapter substitutes
+        # MaterialX neutral (1,1,1) so the extension is renderable.
+        result = to_gltf({"sheen": 0.7})
+        ext = result["extensions"]["KHR_materials_sheen"]
+        assert ext["sheenColorFactor"] == [0.7, 0.7, 0.7]
+
+    def test_sheen_roughness_omitted_when_unset(self) -> None:
+        # sheenRoughnessFactor has a spec default (0.0). When the input
+        # is unset we don't synthesize a value — the field stays absent
+        # and renderers apply their own default. Mirrors the clearcoat
+        # roughness handling.
+        result = to_gltf({"sheen": 0.5, "sheen_color": [1.0, 1.0, 1.0]})
+        ext = result["extensions"]["KHR_materials_sheen"]
+        assert "sheenRoughnessFactor" not in ext

--- a/src/mat_vis_baker/_mtlx_scalars.py
+++ b/src/mat_vis_baker/_mtlx_scalars.py
@@ -56,19 +56,13 @@ _FLOAT_INPUTS: dict[str, str] = {
     # factor is silently dropped — every entry looks the same to
     # consumers reading the scalar block.
     "coat": "clearcoat",  # KHR_materials_clearcoat.clearcoatFactor
-    # Subsurface scattering factor (#409). 13 gpuopen entries author
-    # ``subsurface > 0`` (wax-like, resin, semi-transparent); dropping
-    # this made wax / jade / skin render as opaque dielectric. Wired
-    # for glTF via the (draft) subsurface extension; Three.js adapter
-    # is intentionally a no-op (MeshPhysicalMaterial has no SSS field).
+    # Subsurface (#409) + emission (#406 / #405 Phase 3a).
     "subsurface": "subsurface",
-    # Emission factor (#406 / #405 Phase 3a). Without this, materials
-    # authoring ``emission > 0`` (LED signs, glowing decals, hot metals,
-    # screens) render as inert. Adapter wiring routes values ≤ 1 to
-    # Three.js ``emissive`` / glTF ``emissiveFactor``; values > 1 split
-    # into ``emissiveIntensity`` (Three.js HDR) / KHR_materials_emissive_strength
-    # (glTF HDR) with the color factor clamped to [0, 1].
     "emission": "emission",  # KHR_materials_emissive_strength.emissiveStrength (factor)
+    # Sheen factor + roughness (#407 / #405 Phase 3b). KHR_materials_sheen
+    # — velvet/satin/fabric backscatter.
+    "sheen": "sheen",  # KHR_materials_sheen.sheenColorFactor magnitude
+    "sheen_roughness": "sheen_roughness",  # KHR_materials_sheen.sheenRoughnessFactor
 }
 
 # Color3 inputs. Same direct value=/1-hop graph→constant promotion as
@@ -78,14 +72,12 @@ _COLOR3_INPUTS: dict[str, str] = {
     # mtlx input name -> PBRBlock attribute
     "specular_color": "specular_color",  # KHR_materials_specular.specularColorFactor
     # Subsurface scattering color + per-channel mean-free-path (#409).
-    # Both are emitted unconditionally when authored; the adapter
-    # decides whether the SSS extension fires (only when subsurface>0).
     "subsurface_color": "subsurface_color",
     "subsurface_radius": "subsurface_radius",
-    # Emission color (#406). Sibling of ``emission`` factor — RGB tint
-    # the emission factor multiplies. Authored linear per MaterialX 1.38;
-    # glTF ``emissiveFactor`` is also linear so no colorspace boundary.
-    "emission_color": "emission_color",  # glTF emissiveFactor RGB (linear)
+    # Emission color (#406) — linear RGB.
+    "emission_color": "emission_color",
+    # Sheen tint (#407) — KHR_materials_sheen.sheenColorFactor.
+    "sheen_color": "sheen_color",
 }
 
 # Inputs that have no PBRBlock home today. Non-zero values are dropped
@@ -93,9 +85,6 @@ _COLOR3_INPUTS: dict[str, str] = {
 _LOSSY_INPUTS: tuple[str, ...] = (
     "coat_IOR",
     "coat_color",
-    "sheen",
-    "sheen_roughness",
-    "sheen_color",
     "thin_film_thickness",
 )
 

--- a/src/mat_vis_baker/common.py
+++ b/src/mat_vis_baker/common.py
@@ -468,18 +468,7 @@ class PBRBlock:
     # transmission > 0; baker emits None for opaque materials.
     thickness: float | None = None  # <standard_surface>.transmission_depth
     dispersion: float | None = None  # <standard_surface>.transmission_dispersion
-    # Emission — Phase 3a of #405 (#406). ``emission`` is the scalar HDR
-    # factor (>= 0; values > 1 emit KHR_materials_emissive_strength on
-    # the glTF side / route through ``emissiveIntensity`` on Three.js).
-    # ``emission_color`` is the linear RGB tint that the factor
-    # multiplies. Both stay None when the material is non-emissive
-    # (the gpuopen+polyhaven+ambientcg corpus authors emission=0 for all
-    # 3160 entries today; schema is sticky pre-v0.7, hence the additive
-    # land). Adapter contract:
-    #   - Three.js: emissive = emission_color * min(emission, 1),
-    #               emissiveIntensity = max(emission, 1)
-    #   - glTF:     emissiveFactor = emission_color * min(emission, 1);
-    #               emission > 1 ⇒ KHR_materials_emissive_strength.emissiveStrength
+    # Emission — Phase 3a of #405 (#406).
     emission: float | None = None  # <standard_surface>.emission
     emission_color: list[float] | None = None  # <standard_surface>.emission_color, LINEAR RGB
 
@@ -487,17 +476,19 @@ class PBRBlock:
     # ``subsurface > 0`` (wax, resin, semi-translucent). Three.js
     # MeshPhysicalMaterial has no native SSS field — adapter is a
     # documented no-op there; glTF adapter emits the draft
-    # ``KHR_materials_subsurface`` extension (vendor-prefixed because
-    # the Khronos draft is not yet ratified). Units: ``subsurface``
-    # is a unitless 0..1 mix factor; ``subsurface_color`` is linear
-    # RGB; ``subsurface_radius`` is per-channel mean-free-path in
-    # MaterialX scene units (typically mm). The glTF extension carries
-    # these values verbatim — same per-channel length semantics, no
-    # unit conversion.
-    # subsurface_radius is per-channel mean-free-path in MaterialX scene units.
+    # ``KHR_materials_subsurface`` extension. ``subsurface_radius`` is
+    # per-channel mean-free-path in MaterialX scene units (typically mm).
     subsurface: float | None = None  # <standard_surface>.subsurface
     subsurface_color: list[float] | None = None  # <standard_surface>.subsurface_color (linear RGB)
     subsurface_radius: list[float] | None = None  # <standard_surface>.subsurface_radius
+
+    # KHR_materials_sheen — velvet/satin/fabric retroreflective edge
+    # backscatter (#407 / #405 Phase 3b). Audit at v2026.04.99: polyhaven
+    # authors the defaults on all 757 entries, ambientcg never authors
+    # the inputs, gpuopen 0/454 — schema-add is forward-compatible.
+    sheen: float | None = None  # <standard_surface>.sheen
+    sheen_color: list[float] | None = None  # <standard_surface>.sheen_color, LINEAR RGB
+    sheen_roughness: float | None = None  # <standard_surface>.sheen_roughness
 
 
 def apply_pbr_neutral_multiplier_conventions(

--- a/tests/test_index_builder.py
+++ b/tests/test_index_builder.py
@@ -94,6 +94,10 @@ def test_mat_vis_block_has_stable_key_set() -> None:
         # Emission scalar coverage (#406 / #405 Phase 3a) — additive.
         "emission",
         "emission_color",
+        # KHR_materials_sheen — velvet/satin/fabric (#407 / #405 Phase 3b).
+        "sheen",
+        "sheen_color",
+        "sheen_roughness",
     }
     # Nested AttributionBlock
     assert set(mv["attribution"].keys()) == {"authors", "license_spdx", "source_url"}
@@ -134,6 +138,10 @@ def test_mat_vis_block_defaults_are_null_or_empty() -> None:
     # Emission scalar coverage (#406 / #405 Phase 3a) — additive, default-None.
     assert mv["pbr"]["emission"] is None
     assert mv["pbr"]["emission_color"] is None
+    # KHR_materials_sheen — velvet/satin/fabric (#407 / #405 Phase 3b).
+    assert mv["pbr"]["sheen"] is None
+    assert mv["pbr"]["sheen_color"] is None
+    assert mv["pbr"]["sheen_roughness"] is None
     assert mv["attribution"]["authors"] == []
     assert mv["dates"]["published"] is None
     assert mv["dates"]["updated"] is None

--- a/tests/test_mtlx_scalars.py
+++ b/tests/test_mtlx_scalars.py
@@ -284,16 +284,18 @@ FIXTURE_LOSSY_ZERO_COLOR3 = """<?xml version="1.0"?>
 """
 
 
-def test_lossy_subsurface_and_sheen_logged_at_debug(caplog):
+def test_subsurface_and_sheen_extracted_not_lossy(caplog):
+    """Both subsurface (#409) and sheen (#407) are now extracted to
+    PBRBlock — neither should appear in the lossy-input debug log."""
     with caplog.at_level(logging.DEBUG, logger="mat-vis-baker.gpuopen-scalars"):
         pbr = parse_standard_surface_scalars(FIXTURE_LOSSY_SUBSURFACE_SHEEN, material_id="m-sss")
     msgs = [rec.message for rec in caplog.records]
-    # subsurface is now extracted into pbr.subsurface (#409) — wired
-    # via the draft glTF subsurface extension. No longer lossy.
+    # subsurface → pbr.subsurface (#409 / #405 Phase 3d)
     assert pbr.subsurface == 0.5
     assert not any("subsurface=0.5" in m for m in msgs)
-    # sheen still has no PBRBlock home — logged as lossy.
-    assert any("sheen=0.3" in m for m in msgs)
+    # sheen → pbr.sheen (#407 / #405 Phase 3b)
+    assert pbr.sheen == 0.3
+    assert not any("sheen=0.3" in m for m in msgs)
 
 
 def test_zero_color3_lossy_inputs_do_not_log(caplog):

--- a/tests/test_mtlx_scalars_pbr_coverage.py
+++ b/tests/test_mtlx_scalars_pbr_coverage.py
@@ -1,23 +1,24 @@
-"""Bake-side extraction tests for #340 / #396 / #406 / #409 — full MeshPhysicalMaterial coverage.
+"""Bake-side extraction tests for #340 / #396 / #406 / #407 / #409 — full MeshPhysicalMaterial coverage.
 
 Scalar fields extracted from ``<standard_surface>``:
-- coat                   → clearcoat (float, #396)
-- coat_roughness         → clearcoat_roughness (float, #340)
-- specular               → specular_intensity (float, #340)
-- specular_color         → specular_color (color3, linear, #340)
-- transmission_dispersion → dispersion (float, #340)
-- transmission_depth     → thickness (float, only when transmission > 0, #340)
-- subsurface             → subsurface (float, #409)
-- subsurface_color       → subsurface_color (color3, linear, #409)
-- subsurface_radius      → subsurface_radius (color3, per-channel mfp, #409)
-- emission               → emission (float, #406 / #405 Phase 3a)
-- emission_color         → emission_color (color3, linear, #406 / #405 Phase 3a)
+- coat                   -> clearcoat (float, #396)
+- coat_roughness         -> clearcoat_roughness (float, #340)
+- specular               -> specular_intensity (float, #340)
+- specular_color         -> specular_color (color3, linear, #340)
+- transmission_dispersion -> dispersion (float, #340)
+- transmission_depth     -> thickness (float, only when transmission > 0, #340)
+- subsurface             -> subsurface (float, #409)
+- subsurface_color       -> subsurface_color (color3, linear, #409)
+- subsurface_radius      -> subsurface_radius (color3, per-channel mfp, #409)
+- emission               -> emission (float, #406 / #405 Phase 3a)
+- emission_color         -> emission_color (color3, linear, #406)
+- sheen                  -> sheen (float, #407 / #405 Phase 3b)
+- sheen_color            -> sheen_color (color3, linear, #407)
+- sheen_roughness        -> sheen_roughness (float, #407)
 
-All extracted from <standard_surface> direct `value=` attributes or
-1-hop nodegraph→<constant> chains. Survey of 454 gpuopen materials
-confirms each input is authored ~80-95% of the time; specular_color
-is 94% non-default; coat is 3/454 (Car Paint family); subsurface
-is 13/454 with ``subsurface > 0`` (wax, resin, semi-translucent).
+Audit at v2026.04.99-tst-full-369: coat is 3/454 (Car Paint family);
+subsurface is 13/454 (wax, resin); emission/sheen are 0/3160 today.
+Schema-adds are forward-compatible for future authoring.
 """
 
 from __future__ import annotations
@@ -465,6 +466,126 @@ class TestEmission:
         assert pbr.emission_color == pytest.approx([0.8, 0.4, 0.2])
 
 
+class TestSheen:
+    """``sheen`` factor + ``sheen_color`` + ``sheen_roughness`` extraction
+    (#407) — KHR_materials_sheen for velvet/satin/fabric retroreflective
+    edge backscatter. Audit at v2026.04.99: polyhaven authors the
+    defaults (0/(1,1,1)/0.3) on all 757 entries, ambientcg never authors
+    the inputs, gpuopen 0/454 entries with sheen>0. The schema-add is
+    forward-compatible for fabric collections at higher poly_count and
+    for future MaterialX/standard_surface corpora."""
+
+    def test_sheen_authored_non_default(self) -> None:
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="sheen" type="float" value="0.8"/>')
+        )
+        assert pbr.sheen == pytest.approx(0.8)
+
+    def test_sheen_default_zero_extracted(self) -> None:
+        # 757/757 polyhaven entries author sheen=0.0 — extracting it
+        # confirms provenance. Adapter suppresses the spec-default
+        # KHR_materials_sheen entry.
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="sheen" type="float" value="0.0"/>')
+        )
+        assert pbr.sheen == pytest.approx(0.0)
+
+    def test_sheen_unset_stays_none(self) -> None:
+        pbr = parse_standard_surface_scalars(_wrap())
+        assert pbr.sheen is None
+        assert pbr.sheen_color is None
+        assert pbr.sheen_roughness is None
+
+    def test_sheen_color_authored_tinted(self) -> None:
+        # Author-tinted velvet — e.g. blue velvet with full-magnitude
+        # sheen but a colored sheenColorFactor.
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="sheen_color" type="color3" value="0.2, 0.4, 0.9"/>')
+        )
+        assert pbr.sheen_color == pytest.approx([0.2, 0.4, 0.9])
+
+    def test_sheen_color_default_white(self) -> None:
+        # Polyhaven defaults: sheen_color=(1,1,1). Adapter passes
+        # through (Three.js sheenColor defaults to white anyway).
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="sheen_color" type="color3" value="1, 1, 1"/>')
+        )
+        assert pbr.sheen_color == pytest.approx([1.0, 1.0, 1.0])
+
+    def test_sheen_roughness_authored(self) -> None:
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="sheen_roughness" type="float" value="0.5"/>')
+        )
+        assert pbr.sheen_roughness == pytest.approx(0.5)
+
+    def test_sheen_roughness_default_extracted(self) -> None:
+        # MaterialX default for sheen_roughness is 0.3 (polyhaven ships
+        # this value on all 757 entries). Extracted as authored.
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="sheen_roughness" type="float" value="0.3"/>')
+        )
+        assert pbr.sheen_roughness == pytest.approx(0.3)
+
+    def test_all_three_sheen_fields_together(self) -> None:
+        # Fabric-class author: sheen=1.0, blue tint, soft halo.
+        pbr = parse_standard_surface_scalars(
+            _wrap(
+                '<input name="sheen" type="float" value="1.0"/>',
+                '<input name="sheen_color" type="color3" value="0.3, 0.5, 1.0"/>',
+                '<input name="sheen_roughness" type="float" value="0.7"/>',
+            )
+        )
+        assert pbr.sheen == pytest.approx(1.0)
+        assert pbr.sheen_color == pytest.approx([0.3, 0.5, 1.0])
+        assert pbr.sheen_roughness == pytest.approx(0.7)
+
+    def test_sheen_texture_bound_stays_none(self) -> None:
+        # When ``sheen`` is graph-bound to an <image> (procedural mask),
+        # the rigorous scalar is None — consistent with metalness/coat
+        # texture-bound handling. The baker carries texture paths
+        # separately; the field stays None.
+        mtlx = """<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="NG_SHEEN">
+    <image name="sheen_img" type="float">
+      <input name="file" type="filename" value="sheen.png"/>
+    </image>
+    <output name="sheen_out" type="float" nodename="sheen_img"/>
+  </nodegraph>
+  <standard_surface name="SR_T" type="surfaceshader">
+    <input name="sheen" type="float" output="sheen_out" nodegraph="NG_SHEEN"/>
+  </standard_surface>
+  <surfacematerial name="T" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_T"/>
+  </surfacematerial>
+</materialx>
+"""
+        pbr = parse_standard_surface_scalars(mtlx)
+        assert pbr.sheen is None
+
+    def test_sheen_graph_constant_promoted(self) -> None:
+        # 1-hop nodegraph → <constant> resolution applies to ``sheen``
+        # the same way it does for every other _FLOAT_INPUT.
+        mtlx = """<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="NG_SHEEN">
+    <constant name="sheen_const" type="float">
+      <input name="value" type="float" value="0.6"/>
+    </constant>
+    <output name="sheen_out" type="float" nodename="sheen_const"/>
+  </nodegraph>
+  <standard_surface name="SR_T" type="surfaceshader">
+    <input name="sheen" type="float" output="sheen_out" nodegraph="NG_SHEEN"/>
+  </standard_surface>
+  <surfacematerial name="T" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_T"/>
+  </surfacematerial>
+</materialx>
+"""
+        pbr = parse_standard_surface_scalars(mtlx)
+        assert pbr.sheen == pytest.approx(0.6)
+
+
 class TestPBRBlockFieldsExist:
     def test_new_fields_default_to_none(self) -> None:
         from mat_vis_baker.common import PBRBlock
@@ -484,6 +605,10 @@ class TestPBRBlockFieldsExist:
             # Emission (#406) — additive, default-None.
             "emission",
             "emission_color",
+            # KHR_materials_sheen — velvet/satin/fabric (#407 / #405 Phase 3b).
+            "sheen",
+            "sheen_color",
+            "sheen_roughness",
         ):
             assert getattr(pbr, fname) is None, f"{fname} should default to None"
 
@@ -502,6 +627,9 @@ class TestPBRBlockFieldsExist:
         pbr.subsurface_radius = [1.0, 0.2, 0.1]
         pbr.emission = 2.5
         pbr.emission_color = [1.0, 0.5, 0.0]
+        pbr.sheen = 1.0
+        pbr.sheen_color = [0.3, 0.5, 1.0]
+        pbr.sheen_roughness = 0.7
         assert pbr.clearcoat == 1.0
         assert pbr.clearcoat_roughness == 0.2
         assert pbr.specular_intensity == 0.8
@@ -513,3 +641,6 @@ class TestPBRBlockFieldsExist:
         assert pbr.subsurface_radius == [1.0, 0.2, 0.1]
         assert pbr.emission == 2.5
         assert pbr.emission_color == [1.0, 0.5, 0.0]
+        assert pbr.sheen == 1.0
+        assert pbr.sheen_color == [0.3, 0.5, 1.0]
+        assert pbr.sheen_roughness == 0.7


### PR DESCRIPTION
## Summary

Closes #407 (Phase 3b of the #405 PBR coverage epic).

`<standard_surface>` ``sheen`` / ``sheen_color`` / ``sheen_roughness`` are the KHR_materials_sheen triple — velvet/satin/fabric retroreflective edge backscatter. Today these inputs live in `_LOSSY_INPUTS` and are dropped silently; fabric materials render as matte cloth without the edge halo, diverging from author intent.

Mechanically identical to #400 (`coat` factor extraction):

- Move 3 inputs from `_LOSSY_INPUTS` to `_FLOAT_INPUTS` / `_COLOR3_INPUTS` in `src/mat_vis_baker/_mtlx_scalars.py`.
- Add `PBRBlock.sheen` / `sheen_color` / `sheen_roughness` in `src/mat_vis_baker/common.py`.
- Extend stable-key-set + default-None contract tests in `tests/test_index_builder.py`.
- New `TestSheen` class in `tests/test_mtlx_scalars_pbr_coverage.py` (direct value, default-zero, full-triple, texture-bound stays None, 1-hop graph-constant promotion).
- Update `test_lossy_subsurface_and_sheen_logged_at_debug` — `sheen=0.3` is no longer lossy; it now lands in `pbr.sheen`.

### Adapter wiring

- **Three.js**: `sheen` / `sheenColor` / `sheenRoughness` emitted only when `sheen > 0`. Polyhaven authors `sheen=0` on 757/757 entries — gating on >0 keeps non-fabric MeshPhysicalMaterial dicts lean. MaterialX defaults (`sheen_color=(1,1,1)`, neutral roughness) substituted when factor authored but companions absent.
- **glTF**: `KHR_materials_sheen` extension with `sheenColorFactor = sheen * sheen_color` (premultiplied per spec, linear RGB) + `sheenRoughnessFactor`. Spec-default `sheen=0` suppressed mirroring the existing `ior=1.5` / `transmission=0` / `clearcoat=0` no-op suppression pattern.
- Client (`clients/python/src/mat_vis_client/client.py`) + standalone (`clients/python/mat_vis_client_standalone.py`) `_PBR_SCALAR_PASSTHROUGH` lists extended with the three new keys.
- New `clients/python/tests/test_adapters_sheen.py` covers Three.js + glTF emits with full triple, suppression at default 0, None handling, premultiplied factor, neutral-color fallback.

## P0 audit — `~/.local/bin/hf download gerchowl/mat-vis-tst@v2026.04.99-tst-full-369`

| source     | total | sheen > 0 | sheen_color non-default | sheen_roughness non-default |
|------------|-------|-----------|-------------------------|-----------------------------|
| polyhaven  | 757   | **0**     | 0 (all `(1,1,1)`)       | 0 (all `0.3`)               |
| ambientcg  | 1949  | **0**     | inputs not authored     | inputs not authored         |
| gpuopen    | 454   | **0**     | (pre-existing baseline) | (pre-existing baseline)     |

Polyhaven authors all three inputs at MaterialX defaults on every entry (`sheen=0`, `sheen_color=(1,1,1)`, `sheen_roughness=0.3`); no graph-bound `sheen` inputs either. ambientcg never authors `sheen`. **Real-corpus signal today is zero** — the schema-add is forward-compatible for fabric collections at higher poly_count and for future MaterialX/standard_surface corpora (the issue body called this out: "audit caveat — gpuopen authors sheen at zero in 100% of cases").

The schema-add stickiness is justified: PBRBlock fields are sticky once shipped, and #405 explicitly wants this landed before v0.7 prod cut.

## Test plan

- [x] `uv run --extra baker --extra dev pytest tests/` — 637 passed, 20 skipped
- [x] `cd clients/python && uv run --extra test --extra gltf --extra search pytest tests/` — 602 passed, 29 skipped, 2 xfailed
- [ ] Post-merge: `bake.yml` dispatch on `gerchowl/mat-vis-tst`, HEAD-check substrate for `pbr.sheen` keys present (`null` everywhere — 0/2706 polyhaven+ambientcg entries with sheen>0, confirming audit)

## References

- mat-vis#405 — Phase 3 epic
- mat-vis#400 (#396) — reference mechanical pattern (clearcoat factor)
- KHR_materials_sheen: https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_sheen