### PR TITLE
feat(baker+adapter): iridescence scalar coverage (#408 Phase 3c)

### DIFF
--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -1573,6 +1573,9 @@ class MatVisClient:
         "sheen",
         "sheen_color",
         "sheen_roughness",
+        # Iridescence (#408 / #405 Phase 3c) — forward-looking.
+        "iridescence_thickness",
+        "iridescence_ior",
     )
 
     def _scalars_for(self, source: str, material_id: str) -> dict:

--- a/clients/python/src/mat_vis_client/adapters.py
+++ b/clients/python/src/mat_vis_client/adapters.py
@@ -55,11 +55,11 @@ def _to_data_uri(png_bytes: bytes) -> str:
 _KHR_IOR_DEFAULT = 1.5
 _KHR_TRANSMISSION_DEFAULT = 0.0
 _KHR_CLEARCOAT_DEFAULT = 0.0
-# KHR_materials_sheen default — sheenColorFactor magnitude 0.0
-# (= no sheen). Mirrors the clearcoat suppression pattern: emitting a
-# no-op extension entry that matches the spec default just bloats glTF
-# output. #407.
+# KHR_materials_sheen default — sheenColorFactor magnitude 0.0 (#407).
 _KHR_SHEEN_DEFAULT = 0.0
+# KHR_materials_iridescence spec defaults (#408). iridescenceFactor=0.0,
+# iridescenceIor=1.3 (matches Three.js MeshPhysical iridescenceIOR default).
+_KHR_IRIDESCENCE_IOR_DEFAULT = 1.3
 
 
 def _ior_at_default(ior: float | None) -> bool:
@@ -422,14 +422,11 @@ def to_threejs(
     if scalars.get("dispersion") is not None:
         result["dispersion"] = scalars["dispersion"]
 
-    # mat-vis#409: Three.js MeshPhysicalMaterial has no native SSS field.
-    # subsurface / subsurface_color / subsurface_radius land in the
-    # substrate for glTF and future use; the Three.js adapter is
-    # intentionally a no-op here.
+    # mat-vis#409: Three.js MeshPhysicalMaterial has no native SSS field;
+    # substrate carries the fields for glTF only.
 
     # KHR_materials_sheen → MeshPhysicalMaterial.sheen / sheenColor /
-    # sheenRoughness (#407 / #405 Phase 3b). Only emit when sheen > 0 —
-    # default values would otherwise pollute every non-fabric material.
+    # sheenRoughness (#407 / #405 Phase 3b).
     sheen = scalars.get("sheen")
     if not _sheen_at_default(sheen):
         result["sheen"] = sheen
@@ -437,6 +434,18 @@ def to_threejs(
         result["sheenColor"] = list(sheen_color) if sheen_color is not None else [1.0, 1.0, 1.0]
         sheen_roughness = scalars.get("sheen_roughness")
         result["sheenRoughness"] = sheen_roughness if sheen_roughness is not None else 1.0
+
+    # Iridescence — MeshPhysicalMaterial.iridescence / iridescenceIOR /
+    # iridescenceThicknessRange (#408 / #405 Phase 3c). thickness > 0
+    # acts as the on/off switch.
+    iridescence_thickness = scalars.get("iridescence_thickness")
+    iridescence_ior = scalars.get("iridescence_ior")
+    if iridescence_thickness is not None and iridescence_thickness > 0.0:
+        result["iridescence"] = 1.0
+        result["iridescenceThicknessRange"] = [0.0, iridescence_thickness]
+        result["iridescenceIOR"] = (
+            iridescence_ior if iridescence_ior is not None else _KHR_IRIDESCENCE_IOR_DEFAULT
+        )
 
     # Textures as data URIs
     for channel, prop in _THREEJS_TEX_MAP.items():
@@ -595,8 +604,7 @@ def to_gltf(
 
     # KHR_materials_subsurface (#409). Draft / unratified Khronos
     # extension — emit MaterialX-faithful triplet under the canonical
-    # name. Consumers that don't recognize the extension fall back to
-    # opaque-dielectric.
+    # name.
     subsurface = scalars.get("subsurface")
     if subsurface is not None and subsurface > 0.0:
         sss_ext: dict = {"subsurfaceFactor": subsurface}
@@ -609,8 +617,7 @@ def to_gltf(
         material.setdefault("extensions", {})["KHR_materials_subsurface"] = sss_ext
 
     # KHR_materials_sheen — fabric/velvet/satin retroreflective edge
-    # backscatter (#407 / #405 Phase 3b). Emit only when sheen > 0.
-    # sheenColorFactor = sheen * sheen_color per spec convention.
+    # backscatter (#407 / #405 Phase 3b). sheenColorFactor = sheen * sheen_color.
     sheen = scalars.get("sheen")
     if not _sheen_at_default(sheen):
         sheen_color = scalars.get("sheen_color")
@@ -622,6 +629,21 @@ def to_gltf(
         if sheen_roughness is not None:
             sheen_ext["sheenRoughnessFactor"] = sheen_roughness
         material.setdefault("extensions", {})["KHR_materials_sheen"] = sheen_ext
+
+    # KHR_materials_iridescence (#408 / #405 Phase 3c). thickness > 0
+    # = on; ship iridescenceIor only when authored away from spec default 1.3.
+    iridescence_thickness = scalars.get("iridescence_thickness")
+    iridescence_ior = scalars.get("iridescence_ior")
+    if iridescence_thickness is not None and iridescence_thickness > 0.0:
+        ir_ext: dict = {
+            "iridescenceFactor": 1.0,
+            "iridescenceThicknessMaximum": iridescence_thickness,
+        }
+        if iridescence_ior is not None and not math.isclose(
+            iridescence_ior, _KHR_IRIDESCENCE_IOR_DEFAULT, abs_tol=1e-9
+        ):
+            ir_ext["iridescenceIor"] = iridescence_ior
+        material.setdefault("extensions", {})["KHR_materials_iridescence"] = ir_ext
 
     # Opacity texture — glTF 2.0 has no standalone alphaMap slot. Alpha
     # must live in baseColorTexture's alpha channel + alphaMode/alphaCutoff

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -2314,6 +2314,9 @@ class MatVisClient:
         "sheen",
         "sheen_color",
         "sheen_roughness",
+        # Iridescence (#408 / #405 Phase 3c) — forward-looking.
+        "iridescence_thickness",
+        "iridescence_ior",
     )
 
     def _scalars_for(self, source: str, material_id: str) -> dict:

--- a/clients/python/tests/test_adapter_field_passthrough.py
+++ b/clients/python/tests/test_adapter_field_passthrough.py
@@ -126,6 +126,22 @@ EMISSION_HDR_INDEX = [
     ),
 ]
 
+# Iridescent — exercises the iridescence_thickness / iridescence_ior
+# path (mat-vis#408). Soap-bubble regime: ~400 nm thin film with
+# IOR slightly above water.
+IRIDESCENT_INDEX = [
+    _entry(
+        "soap-bubble",
+        name="Soap Bubble",
+        roughness=0.05,
+        metalness=0.0,
+        ior=1.33,
+        iridescence_thickness=400.0,
+        iridescence_ior=1.33,
+        color_rgb=[1.0, 1.0, 1.0],
+    ),
+]
+
 
 # ── Read-side: _scalars_for forwards each new field ────────────
 
@@ -190,15 +206,21 @@ class TestScalarsForFullPbrPassthrough:
         assert scalars["emissive"] == [0.0, 1.0, 0.5]
 
     def test_emission_factor_and_color_pass_through(self):
-        """#406 — ``emission`` factor + ``emission_color`` round-trip from
-        the substrate's mat_vis.pbr block to the adapter scalars dict.
-        The adapter then splits HDR strengths > 1 into the
-        emissiveIntensity / KHR_materials_emissive_strength path."""
+        """#406 — ``emission`` factor + ``emission_color`` round-trip."""
         c = MatVisClient()
         with patch.object(c, "index", return_value=EMISSION_HDR_INDEX):
             scalars = c._scalars_for("physicallybased", "LED Sign")
         assert scalars["emission"] == pytest.approx(4.0)
         assert scalars["emission_color"] == [1.0, 0.4, 0.1]
+
+    def test_iridescence_thickness_passes_through(self):
+        # mat-vis#408 — forward-looking field; substrate carries
+        # ``iridescence_thickness`` in nm and ``iridescence_ior``.
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=IRIDESCENT_INDEX):
+            scalars = c._scalars_for("physicallybased", "Soap Bubble")
+        assert scalars["iridescence_thickness"] == pytest.approx(400.0)
+        assert scalars["iridescence_ior"] == pytest.approx(1.33)
 
     def test_existing_4_field_contract_preserved(self):
         """Regression guard — the original
@@ -232,6 +254,9 @@ class TestScalarsForFullPbrPassthrough:
             # Emission scalar coverage (#406) — additive, defaults to absent.
             "emission",
             "emission_color",
+            # Iridescence (#408) — additive forward-looking fields.
+            "iridescence_thickness",
+            "iridescence_ior",
         ):
             assert k not in scalars, f"{k!r} should not be injected when substrate is None"
 
@@ -271,8 +296,7 @@ class TestEndToEndThreejs:
         assert result["emissive"] == [0.0, 1.0, 0.5]
 
     def test_emission_sdr_emits_emissive_only(self):
-        # #406 SDR end-to-end: factor=1.0 with a green tint → emissive
-        # carries the color, no emissiveIntensity (Three.js default).
+        # #406 SDR end-to-end.
         c = MatVisClient()
         with patch.object(c, "index", return_value=EMISSION_SDR_INDEX):
             scalars = c._scalars_for("physicallybased", "Glowing Decal")
@@ -281,14 +305,23 @@ class TestEndToEndThreejs:
         assert "emissiveIntensity" not in result
 
     def test_emission_hdr_emits_emissive_plus_intensity(self):
-        # #406 HDR end-to-end: factor=4.0 → emissive clamped to SDR
-        # (×1 color), intensity carries the HDR multiplier.
+        # #406 HDR end-to-end.
         c = MatVisClient()
         with patch.object(c, "index", return_value=EMISSION_HDR_INDEX):
             scalars = c._scalars_for("physicallybased", "LED Sign")
         result = to_threejs(scalars)
         assert result["emissive"] == [1.0, 0.4, pytest.approx(0.1)]
         assert result["emissiveIntensity"] == pytest.approx(4.0)
+
+    def test_iridescent_emits_iridescence_keys(self):
+        # mat-vis#408 — Three.js end-to-end.
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=IRIDESCENT_INDEX):
+            scalars = c._scalars_for("physicallybased", "Soap Bubble")
+        result = to_threejs(scalars)
+        assert result["iridescence"] == 1.0
+        assert result["iridescenceThicknessRange"] == [0.0, 400.0]
+        assert result["iridescenceIOR"] == pytest.approx(1.33)
 
 
 class TestEndToEndGltf:
@@ -368,3 +401,14 @@ class TestEndToEndGltf:
         assert result["emissiveFactor"] == [1.0, 0.4, pytest.approx(0.1)]
         ext = result["extensions"]["KHR_materials_emissive_strength"]
         assert ext["emissiveStrength"] == pytest.approx(4.0)
+
+    def test_iridescent_emits_iridescence_extension(self):
+        # mat-vis#408 — glTF end-to-end.
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=IRIDESCENT_INDEX):
+            scalars = c._scalars_for("physicallybased", "Soap Bubble")
+        result = to_gltf(scalars)
+        ext = result["extensions"]["KHR_materials_iridescence"]
+        assert ext["iridescenceFactor"] == 1.0
+        assert ext["iridescenceThicknessMaximum"] == 400.0
+        assert ext["iridescenceIor"] == pytest.approx(1.33)

--- a/clients/python/tests/test_adapters_iridescence.py
+++ b/clients/python/tests/test_adapters_iridescence.py
@@ -1,0 +1,143 @@
+"""Adapter tests for iridescence scalar coverage (#408).
+
+The mat-vis substrate carries two iridescence scalars renamed from
+the MaterialX ``thin_film_*`` author surface:
+
+    | substrate scalar         | unit | source                  |
+    |--------------------------|------|-------------------------|
+    | iridescence_thickness    | nm   | thin_film_thickness     |
+    | iridescence_ior          |  -   | thin_film_IOR           |
+
+Output bindings:
+
+    | adapter    | thickness                                 | ior                                             |
+    |------------|-------------------------------------------|-------------------------------------------------|
+    | to_threejs | iridescenceThicknessRange = [0, thickness]| iridescenceIOR (defaults 1.3)                   |
+    |            | iridescence = 1.0 (on/off via thickness>0)|                                                 |
+    | to_gltf    | KHR_materials_iridescence.                | KHR_materials_iridescence.iridescenceIor        |
+    |            |   iridescenceThicknessMaximum = thickness |   (omit at spec default 1.3)                    |
+    |            |   iridescenceFactor = 1.0                 |                                                 |
+
+Unit contract: nm end to end — MaterialX, glTF, and Three.js all
+agree. No conversion at any boundary. mat-vis#408.
+
+Audit (v2026.04.99 corpus): 0/3160 entries author thin_film_*
+non-default across gpuopen + polyhaven + ambientcg. The schema +
+adapters ship forward-looking per #408 P1.
+"""
+
+from __future__ import annotations
+
+import math
+
+from mat_vis_client.adapters import to_gltf, to_threejs
+
+
+class TestIridescenceToThreejs:
+    def test_thickness_authored_sets_factor_range_and_ior(self):
+        # Soap-bubble / pearl regime: ~400nm thin film. Author provides
+        # both thickness and IOR.
+        result = to_threejs({"iridescence_thickness": 400.0, "iridescence_ior": 1.33})
+        assert result["iridescence"] == 1.0
+        assert result["iridescenceThicknessRange"] == [0.0, 400.0]
+        assert math.isclose(result["iridescenceIOR"], 1.33)
+
+    def test_thickness_only_uses_threejs_default_ior(self):
+        # No IOR authored — Three.js MeshPhysicalMaterial default is 1.3,
+        # matching the glTF KHR_materials_iridescence spec default.
+        result = to_threejs({"iridescence_thickness": 550.0})
+        assert result["iridescence"] == 1.0
+        assert result["iridescenceThicknessRange"] == [0.0, 550.0]
+        assert math.isclose(result["iridescenceIOR"], 1.3)
+
+    def test_thickness_zero_does_not_emit(self):
+        # The on/off switch is thickness>0. A zero thickness is the
+        # spec default — emitting iridescence=1.0 with a zero range
+        # would be a no-op that bloats the material dict.
+        result = to_threejs({"iridescence_thickness": 0.0, "iridescence_ior": 1.4})
+        assert "iridescence" not in result
+        assert "iridescenceThicknessRange" not in result
+        assert "iridescenceIOR" not in result
+
+    def test_unset_does_not_emit(self):
+        result = to_threejs({})
+        assert "iridescence" not in result
+        assert "iridescenceThicknessRange" not in result
+        assert "iridescenceIOR" not in result
+
+    def test_none_does_not_emit(self):
+        result = to_threejs({"iridescence_thickness": None, "iridescence_ior": None})
+        assert "iridescence" not in result
+
+    def test_ior_alone_does_not_emit(self):
+        # IOR without a thickness is meaningless — Three.js needs the
+        # thickness range to compute the interference. No emission.
+        result = to_threejs({"iridescence_ior": 1.4})
+        assert "iridescence" not in result
+        assert "iridescenceIOR" not in result
+
+
+class TestIridescenceToGltf:
+    def test_thickness_authored_emits_extension(self):
+        result = to_gltf({"iridescence_thickness": 400.0, "iridescence_ior": 1.33})
+        ext = result["extensions"]["KHR_materials_iridescence"]
+        assert ext["iridescenceFactor"] == 1.0
+        assert math.isclose(ext["iridescenceThicknessMaximum"], 400.0)
+        assert math.isclose(ext["iridescenceIor"], 1.33)
+
+    def test_ior_at_spec_default_omitted(self):
+        # KHR_materials_iridescence default iridescenceIor is 1.3 —
+        # emitting it is a no-op that bloats glTF. Mirrors the
+        # ior=1.5 / clearcoat=0.0 / transmission=0.0 suppression.
+        result = to_gltf({"iridescence_thickness": 400.0, "iridescence_ior": 1.3})
+        ext = result["extensions"]["KHR_materials_iridescence"]
+        assert "iridescenceIor" not in ext
+        assert ext["iridescenceFactor"] == 1.0
+        assert ext["iridescenceThicknessMaximum"] == 400.0
+
+    def test_thickness_only_uses_spec_default_ior(self):
+        # No IOR authored — glTF default is 1.3; we omit the field per
+        # the no-op-suppression pattern. iridescenceFactor + thickness
+        # still ship.
+        result = to_gltf({"iridescence_thickness": 550.0})
+        ext = result["extensions"]["KHR_materials_iridescence"]
+        assert ext["iridescenceFactor"] == 1.0
+        assert ext["iridescenceThicknessMaximum"] == 550.0
+        assert "iridescenceIor" not in ext
+
+    def test_thickness_zero_omitted(self):
+        result = to_gltf({"iridescence_thickness": 0.0, "iridescence_ior": 1.4})
+        assert "KHR_materials_iridescence" not in result.get("extensions", {})
+
+    def test_unset_omitted(self):
+        result = to_gltf({})
+        assert "KHR_materials_iridescence" not in result.get("extensions", {})
+
+    def test_none_omitted(self):
+        result = to_gltf({"iridescence_thickness": None})
+        assert "KHR_materials_iridescence" not in result.get("extensions", {})
+
+    def test_ior_alone_does_not_emit_extension(self):
+        # IOR without a thickness is meaningless — the extension
+        # requires the thickness signal to be the on/off trigger.
+        result = to_gltf({"iridescence_ior": 1.4})
+        assert "KHR_materials_iridescence" not in result.get("extensions", {})
+
+
+class TestIridescenceUnitContract:
+    """Pin the unit contract (#408 pitfall): nm end to end, no
+    conversion at any boundary. A 400 nm thickness must round-trip
+    verbatim from substrate → Three.js iridescenceThicknessRange max
+    AND → glTF iridescenceThicknessMaximum."""
+
+    def test_thickness_value_unchanged_threejs(self):
+        result = to_threejs({"iridescence_thickness": 387.5})
+        # Three.js iridescenceThicknessRange is [min_nm, max_nm];
+        # 387.5 nm flows through verbatim.
+        assert result["iridescenceThicknessRange"][1] == 387.5
+
+    def test_thickness_value_unchanged_gltf(self):
+        result = to_gltf({"iridescence_thickness": 387.5})
+        ext = result["extensions"]["KHR_materials_iridescence"]
+        # glTF iridescenceThicknessMaximum is in nm; 387.5 nm verbatim.
+        assert ext["iridescenceThicknessMaximum"] == 387.5

--- a/src/mat_vis_baker/_mtlx_scalars.py
+++ b/src/mat_vis_baker/_mtlx_scalars.py
@@ -59,10 +59,15 @@ _FLOAT_INPUTS: dict[str, str] = {
     # Subsurface (#409) + emission (#406 / #405 Phase 3a).
     "subsurface": "subsurface",
     "emission": "emission",  # KHR_materials_emissive_strength.emissiveStrength (factor)
-    # Sheen factor + roughness (#407 / #405 Phase 3b). KHR_materials_sheen
-    # — velvet/satin/fabric backscatter.
+    # Sheen factor + roughness (#407 / #405 Phase 3b). KHR_materials_sheen.
     "sheen": "sheen",  # KHR_materials_sheen.sheenColorFactor magnitude
     "sheen_roughness": "sheen_roughness",  # KHR_materials_sheen.sheenRoughnessFactor
+    # Iridescence (#408 / #405 Phase 3c). MaterialX's ``thin_film_*``
+    # inputs renamed to ``iridescence_*`` per consumer-facing naming
+    # (same convention as coat → clearcoat). Units: nm — matches glTF
+    # KHR_materials_iridescence and Three.js iridescenceThicknessRange.
+    "thin_film_thickness": "iridescence_thickness",
+    "thin_film_IOR": "iridescence_ior",  # uppercase IOR — case-aware lookup
 }
 
 # Color3 inputs. Same direct value=/1-hop graph→constant promotion as
@@ -85,7 +90,6 @@ _COLOR3_INPUTS: dict[str, str] = {
 _LOSSY_INPUTS: tuple[str, ...] = (
     "coat_IOR",
     "coat_color",
-    "thin_film_thickness",
 )
 
 

--- a/src/mat_vis_baker/common.py
+++ b/src/mat_vis_baker/common.py
@@ -490,6 +490,25 @@ class PBRBlock:
     sheen_color: list[float] | None = None  # <standard_surface>.sheen_color, LINEAR RGB
     sheen_roughness: float | None = None  # <standard_surface>.sheen_roughness
 
+    # Iridescence (#408). The wavelength-dependent interference layer
+    # — oil-on-water, soap bubble, pearl, butterfly wing, polished
+    # optical coating. ``thin_film_*`` in MaterialX, ``iridescence_*``
+    # in the substrate (same consumer-facing rename convention #340
+    # used for coat → clearcoat).
+    #
+    # Units: ``iridescence_thickness`` is in **nanometers (nm)** end
+    # to end — MaterialX ``thin_film_thickness``, glTF
+    # ``KHR_materials_iridescence.iridescenceThicknessMaximum``, and
+    # Three.js ``iridescenceThicknessRange`` all agree on nm. No
+    # conversion at any adapter boundary.
+    #
+    # Audit (v2026.04.99 corpus, #408): 0/3160 entries author either
+    # field non-default across gpuopen / polyhaven / ambientcg. Schema
+    # ships forward-looking — once authors do, the substrate carries
+    # them without a new bump.
+    iridescence_thickness: float | None = None  # <standard_surface>.thin_film_thickness, nm
+    iridescence_ior: float | None = None  # <standard_surface>.thin_film_IOR
+
 
 def apply_pbr_neutral_multiplier_conventions(
     pbr: PBRBlock,

--- a/tests/test_index_builder.py
+++ b/tests/test_index_builder.py
@@ -98,6 +98,9 @@ def test_mat_vis_block_has_stable_key_set() -> None:
         "sheen",
         "sheen_color",
         "sheen_roughness",
+        # Iridescence (#408 / #405 Phase 3c) — additive, forward-looking.
+        "iridescence_thickness",
+        "iridescence_ior",
     }
     # Nested AttributionBlock
     assert set(mv["attribution"].keys()) == {"authors", "license_spdx", "source_url"}
@@ -142,6 +145,9 @@ def test_mat_vis_block_defaults_are_null_or_empty() -> None:
     assert mv["pbr"]["sheen"] is None
     assert mv["pbr"]["sheen_color"] is None
     assert mv["pbr"]["sheen_roughness"] is None
+    # Iridescence (#408 / #405 Phase 3c) — additive, default-None.
+    assert mv["pbr"]["iridescence_thickness"] is None
+    assert mv["pbr"]["iridescence_ior"] is None
     assert mv["attribution"]["authors"] == []
     assert mv["dates"]["published"] is None
     assert mv["dates"]["updated"] is None

--- a/tests/test_mtlx_scalars_pbr_coverage.py
+++ b/tests/test_mtlx_scalars_pbr_coverage.py
@@ -1,4 +1,4 @@
-"""Bake-side extraction tests for #340 / #396 / #406 / #407 / #409 — full MeshPhysicalMaterial coverage.
+"""Bake-side extraction tests for #340 / #396 / #406 / #407 / #408 / #409 — full MeshPhysicalMaterial coverage.
 
 Scalar fields extracted from ``<standard_surface>``:
 - coat                   -> clearcoat (float, #396)
@@ -15,10 +15,12 @@ Scalar fields extracted from ``<standard_surface>``:
 - sheen                  -> sheen (float, #407 / #405 Phase 3b)
 - sheen_color            -> sheen_color (color3, linear, #407)
 - sheen_roughness        -> sheen_roughness (float, #407)
+- thin_film_thickness    -> iridescence_thickness (float nm, #408 / #405 Phase 3c)
+- thin_film_IOR          -> iridescence_ior (float, #408)
 
 Audit at v2026.04.99-tst-full-369: coat is 3/454 (Car Paint family);
-subsurface is 13/454 (wax, resin); emission/sheen are 0/3160 today.
-Schema-adds are forward-compatible for future authoring.
+subsurface is 13/454 (wax, resin); emission/sheen/iridescence are
+0/3160 today. Schema-adds are forward-compatible for future authoring.
 """
 
 from __future__ import annotations
@@ -586,6 +588,111 @@ class TestSheen:
         assert pbr.sheen == pytest.approx(0.6)
 
 
+class TestIridescence:
+    """``thin_film_thickness`` + ``thin_film_IOR`` extraction (#408).
+
+    MaterialX's iridescence inputs. Renamed to ``iridescence_thickness``
+    / ``iridescence_ior`` in the substrate per the consumer-facing
+    naming convention #340 used for coat → clearcoat. Audit of the
+    v2026.04.99 corpus shows 0/3160 entries author either field
+    non-default — the schema ships forward-looking so once authors
+    do (oil-on-water, pearl, butterfly wing), the substrate carries
+    them without a new bump.
+
+    Units are nanometers (nm) end to end: MaterialX
+    ``thin_film_thickness``, glTF ``KHR_materials_iridescence.
+    iridescenceThicknessMaximum``, and Three.js
+    ``iridescenceThicknessRange`` all agree on nm.
+    """
+
+    def test_thin_film_thickness_authored(self) -> None:
+        # Soap-bubble / pearl regime: ~400nm thin film.
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="thin_film_thickness" type="float" value="400.0"/>')
+        )
+        assert pbr.iridescence_thickness == pytest.approx(400.0)
+
+    def test_thin_film_IOR_authored(self) -> None:
+        # Note the uppercase-IOR input name in MTLX — case-aware
+        # lookup must hit the renamed substrate field.
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="thin_film_IOR" type="float" value="1.33"/>')
+        )
+        assert pbr.iridescence_ior == pytest.approx(1.33)
+
+    def test_thin_film_pair_authored(self) -> None:
+        # Both fields together, the common authoring pattern.
+        pbr = parse_standard_surface_scalars(
+            _wrap(
+                '<input name="thin_film_thickness" type="float" value="550.0"/>',
+                '<input name="thin_film_IOR" type="float" value="1.45"/>',
+            )
+        )
+        assert pbr.iridescence_thickness == pytest.approx(550.0)
+        assert pbr.iridescence_ior == pytest.approx(1.45)
+
+    def test_thin_film_default_zero_extracted(self) -> None:
+        # 424/454 gpuopen entries author thin_film_thickness=0.0 —
+        # extracting preserves provenance. Adapter suppresses the
+        # spec-default KHR extension entry.
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="thin_film_thickness" type="float" value="0.0"/>')
+        )
+        assert pbr.iridescence_thickness == pytest.approx(0.0)
+
+    def test_thin_film_unset_stays_none(self) -> None:
+        pbr = parse_standard_surface_scalars(_wrap())
+        assert pbr.iridescence_thickness is None
+        assert pbr.iridescence_ior is None
+
+    def test_thin_film_thickness_graph_constant_promoted(self) -> None:
+        # 1-hop nodegraph → <constant> resolution applies to
+        # ``thin_film_thickness`` like every other _FLOAT_INPUT.
+        mtlx = """<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="NG_TF">
+    <constant name="tf_const" type="float">
+      <input name="value" type="float" value="380.0"/>
+    </constant>
+    <output name="tf_out" type="float" nodename="tf_const"/>
+  </nodegraph>
+  <standard_surface name="SR_T" type="surfaceshader">
+    <input name="thin_film_thickness" type="float" output="tf_out" nodegraph="NG_TF"/>
+  </standard_surface>
+  <surfacematerial name="T" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_T"/>
+  </surfacematerial>
+</materialx>
+"""
+        pbr = parse_standard_surface_scalars(mtlx)
+        assert pbr.iridescence_thickness == pytest.approx(380.0)
+
+    def test_thin_film_thickness_texture_bound_stays_none(self) -> None:
+        # Texture-bound (rare per #408 pitfalls) leaves the scalar
+        # field None — consistent with metalness/coat texture-bound
+        # handling. The baker carries the texture path separately;
+        # adapters wire it via iridescenceThicknessMap (Three.js)
+        # if/when supported.
+        mtlx = """<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="NG_TF">
+    <image name="tf_img" type="float">
+      <input name="file" type="filename" value="thickness.png"/>
+    </image>
+    <output name="tf_out" type="float" nodename="tf_img"/>
+  </nodegraph>
+  <standard_surface name="SR_T" type="surfaceshader">
+    <input name="thin_film_thickness" type="float" output="tf_out" nodegraph="NG_TF"/>
+  </standard_surface>
+  <surfacematerial name="T" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_T"/>
+  </surfacematerial>
+</materialx>
+"""
+        pbr = parse_standard_surface_scalars(mtlx)
+        assert pbr.iridescence_thickness is None
+
+
 class TestPBRBlockFieldsExist:
     def test_new_fields_default_to_none(self) -> None:
         from mat_vis_baker.common import PBRBlock
@@ -609,6 +716,9 @@ class TestPBRBlockFieldsExist:
             "sheen",
             "sheen_color",
             "sheen_roughness",
+            # Iridescence (#408 / #405 Phase 3c) — additive, default-None.
+            "iridescence_thickness",
+            "iridescence_ior",
         ):
             assert getattr(pbr, fname) is None, f"{fname} should default to None"
 
@@ -630,6 +740,8 @@ class TestPBRBlockFieldsExist:
         pbr.sheen = 1.0
         pbr.sheen_color = [0.3, 0.5, 1.0]
         pbr.sheen_roughness = 0.7
+        pbr.iridescence_thickness = 400.0
+        pbr.iridescence_ior = 1.3
         assert pbr.clearcoat == 1.0
         assert pbr.clearcoat_roughness == 0.2
         assert pbr.specular_intensity == 0.8
@@ -644,3 +756,5 @@ class TestPBRBlockFieldsExist:
         assert pbr.sheen == 1.0
         assert pbr.sheen_color == [0.3, 0.5, 1.0]
         assert pbr.sheen_roughness == 0.7
+        assert pbr.iridescence_thickness == 400.0
+        assert pbr.iridescence_ior == 1.3


### PR DESCRIPTION
## Summary

Closes #408 — Phase 3c of the #405 PBR coverage sweep.

Moves `thin_film_thickness` + `thin_film_IOR` from `_LOSSY_INPUTS` to `_FLOAT_INPUTS` in `src/mat_vis_baker/_mtlx_scalars.py`, renaming to `iridescence_thickness` (nm) + `iridescence_ior` on the substrate side. This is the same consumer-facing rename convention #340 established for `coat` → `clearcoat`: MaterialX's `thin_film_*` is the author surface, the substrate exposes the glTF / Three.js term every renderer downstream already speaks. Adapter wiring emits Three.js `iridescence*` / glTF `KHR_materials_iridescence`. Mechanically mirrors PR #400 / issue #396.

## P0 audit finding

Iridescence is the rarest of the Phase 3 children. Surveyed all 3 MTLX sources at `gerchowl/mat-vis-tst@v2026.04.99-tst-full-369` (`physicallybased` is JSON-only, has no `thin_film_*` surface):

| source       | total | `thin_film_thickness` present | non-zero | `thin_film_IOR` present | non-default (≠1.5) |
|--------------|-------|-------------------------------|----------|-------------------------|--------------------|
| gpuopen      | 454   | 424                           | **0**    | 424                     | **0**              |
| polyhaven    | 757   | 0                             | 0        | 0                       | 0                  |
| ambientcg    | 1949  | 0                             | 0        | 0                       | 0                  |
| **combined** | 3160  | 424                           | **0**    | 424                     | **0**              |

**Zero non-default authoring across the entire corpus.** Ships forward-looking per #408 P1 — once oil-on-water / pearl / butterfly-wing / soap-bubble materials author `thin_film_*` (the gpuopen library already wires the inputs, they just default), the substrate carries them without a new schema bump.

## What changed

- `src/mat_vis_baker/_mtlx_scalars.py` — `thin_film_thickness` + `thin_film_IOR` move to `_FLOAT_INPUTS` with the rename mapping (substrate names `iridescence_*`). `thin_film_thickness` drops from `_LOSSY_INPUTS`.
- `src/mat_vis_baker/common.py` — `PBRBlock.iridescence_thickness` + `PBRBlock.iridescence_ior` added with nm-unit docstring.
- `clients/python/src/mat_vis_client/adapters.py` — `to_threejs` emits `iridescence` + `iridescenceThicknessRange` + `iridescenceIOR` when thickness > 0; `to_gltf` emits `KHR_materials_iridescence` with `iridescenceFactor` + `iridescenceThicknessMaximum` + `iridescenceIor`. Spec-default IOR (1.3) suppressed from the glTF extension per the existing ior=1.5 / clearcoat=0.0 pattern.
- `clients/python/src/mat_vis_client/client.py` + `clients/python/mat_vis_client_standalone.py` — `_PBR_SCALAR_PASSTHROUGH` extended.
- `tests/test_index_builder.py` — stable-key-set test pinned to the additive fields.
- `tests/test_mtlx_scalars_pbr_coverage.py` — `TestIridescence` covers direct value, both fields, default-zero, unset, texture-bound (stays None), and 1-hop graph-constant promotion. The naming rename (`thin_film_*` → `iridescence_*`) is exercised through every assertion.
- `clients/python/tests/test_adapters_iridescence.py` — new file. `TestIridescenceToThreejs`, `TestIridescenceToGltf`, `TestIridescenceUnitContract` (pins the nm round-trip — no conversion at any boundary).
- `clients/python/tests/test_adapter_field_passthrough.py` — new `IRIDESCENT_INDEX` fixture + end-to-end substrate → adapter passthrough tests.

## Unit contract pinned

`iridescence_thickness` is in **nanometers** end to end:
- MaterialX `thin_film_thickness` is nm
- glTF `KHR_materials_iridescence.iridescenceThicknessMaximum` is nm
- Three.js `iridescenceThicknessRange` is `[min_nm, max_nm]`

No conversion at any adapter boundary. `TestIridescenceUnitContract` round-trips 387.5 nm through both adapters verbatim.

## Acceptance criteria

- [x] P0 audit recorded — 0/3160 entries author either field non-default
- [x] `PBRBlock.iridescence_thickness` + `iridescence_ior` fields added (additive — stable key-set contract honored)
- [x] Parser extracts via direct + 1-hop graph-constant
- [x] Adapter routes for Three.js + glTF
- [x] Unit tests with synthesised MTLX (cover the rename `thin_film_*` → `iridescence_*`)
- [x] Stable-key-set test in `test_index_builder.py` updated
- [x] Adapter tests for Three.js + glTF outputs

## Test plan

- [x] `uv run --extra baker --extra dev pytest tests/` — 634 passed, 20 skipped
- [x] `cd clients/python && uv run --extra test --extra gltf --extra search pytest tests/` — 608 passed, 29 skipped, 2 xfailed
- [ ] Post-merge: dispatch `bake.yml` on `gerchowl/mat-vis-tst` and HEAD-check substrate — `pbr.iridescence_thickness` + `pbr.iridescence_ior` should appear as `null` on every entry (per the audit) and the stable-key-set is enforced.

## Pitfalls

- **MaterialX's `IOR` is uppercase** in `thin_film_IOR` — the parser's case-aware `_FLOAT_INPUTS` lookup matches the existing `specular_IOR` pattern.
- **Forward-looking schema**: the corpus is silent today, but pinning `iridescence_*` to nm + KHR-aligned names now means once an upstream author flips a soap-bubble material to thickness=400, the substrate carries it without a new field bump or rename.