### PR TITLE
feat(baker+adapter): emission scalar coverage (#406 / #405 Phase 3a)

### DIFF
--- a/clients/python/mat_vis_client_standalone.py
+++ b/clients/python/mat_vis_client_standalone.py
@@ -1452,6 +1452,11 @@ class MatVisClient:
         "subsurface",
         "subsurface_color",
         "subsurface_radius",
+        # Emission scalar coverage (#406 / #405 Phase 3a) — factor +
+        # linear-RGB tint. Adapter splits HDR strengths > 1 into
+        # emissiveIntensity / KHR_materials_emissive_strength.
+        "emission",
+        "emission_color",
     )
 
     def _scalars_for(self, source: str, material_id: str) -> dict:

--- a/clients/python/src/mat_vis_client/adapters.py
+++ b/clients/python/src/mat_vis_client/adapters.py
@@ -77,6 +77,55 @@ def _clearcoat_at_default(c: float | None) -> bool:
     return c is None or math.isclose(c, _KHR_CLEARCOAT_DEFAULT, abs_tol=1e-9)
 
 
+def _resolve_emission_split(
+    scalars: dict,
+) -> tuple[list[float], float] | None:
+    """Resolve ``emission`` factor + ``emission_color`` into the
+    (color, strength) pair Three.js/glTF HDR emission needs (#406).
+
+    Returns ``None`` when the material is non-emissive — neither
+    ``emission`` nor ``emission_color`` is authored, OR ``emission``
+    is authored at the spec default 0.0. The caller suppresses the
+    output field entirely in that case.
+
+    Otherwise returns ``(emissive_color, strength)`` where:
+
+    - ``emissive_color`` is ``emission_color * min(emission, 1)``, clamped
+      to [0, 1]. Falls back to white (``[1, 1, 1]``) when emission_color
+      is unauthored — matches MaterialX 1.38 ``<standard_surface>``
+      defaults. Goes into Three.js ``emissive`` / glTF ``emissiveFactor``.
+    - ``strength`` is ``max(emission, 1.0)`` — the HDR multiplier. Equal
+      to 1.0 for SDR cases (caller suppresses), > 1 for HDR (caller
+      emits Three.js ``emissiveIntensity`` / glTF
+      KHR_materials_emissive_strength).
+
+    Adapter contract: ``emission`` is the canonical scalar HDR factor
+    on the substrate (PBRBlock.emission, #406). The legacy ``emissive``
+    key (RGB triple, no factor) is read elsewhere — when both arrive
+    in the scalars dict, ``emission`` wins because it carries the HDR
+    information the legacy key cannot express.
+    """
+    emission = scalars.get("emission")
+    emission_color = scalars.get("emission_color")
+    if emission is None and emission_color is None:
+        return None
+    # Treat a None factor with an authored color as "factor=1.0" — the
+    # color was authored intentionally; ignoring it because the factor
+    # is None would silently drop authored intent.
+    factor = 1.0 if emission is None else float(emission)
+    if factor <= 0.0:
+        return None
+    color = list(emission_color) if emission_color is not None else [1.0, 1.0, 1.0]
+    if len(color) < 3:
+        return None
+    # Clamp color to [0,1]; multiply by min(factor, 1) so the SDR
+    # component lives inside Three.js Color / glTF emissiveFactor.
+    sdr = min(factor, 1.0)
+    emissive_color = [max(0.0, min(1.0, float(c) * sdr)) for c in color[:3]]
+    strength = max(factor, 1.0)
+    return emissive_color, strength
+
+
 def _color_hex_to_int(hex_str: str) -> int:
     """Convert '#RRGGBB' hex string to an integer (Three.js color format).
 
@@ -345,6 +394,19 @@ def to_threejs(
         result["transmission"] = scalars["transmission"]
     if scalars.get("emissive") is not None:
         result["emissive"] = list(scalars["emissive"])
+    # Emission factor + color split (#406). When ``emission`` (scalar
+    # HDR factor) is authored, route it through Three.js's HDR
+    # mechanism: ``emissive`` carries the SDR-clamped color factor;
+    # ``emissiveIntensity`` carries the HDR multiplier. ``emission``
+    # wins over the legacy ``emissive`` key when both arrive.
+    emission_split = _resolve_emission_split(scalars)
+    if emission_split is not None:
+        emissive_color, strength = emission_split
+        result["emissive"] = emissive_color
+        # Three.js's default emissiveIntensity is 1.0; emit it only for
+        # HDR cases so the SDR path stays a single-key write.
+        if strength > 1.0:
+            result["emissiveIntensity"] = strength
     if scalars.get("clearcoat") is not None:
         result["clearcoat"] = scalars["clearcoat"]
     if scalars.get("clearcoat_roughness") is not None:
@@ -459,6 +521,25 @@ def to_gltf(
     emissive = scalars.get("emissive")
     if emissive is not None:
         material["emissiveFactor"] = list(emissive)
+    # Emission factor + color split (#406). When ``emission`` (scalar
+    # HDR factor) is authored, route it through glTF's HDR mechanism:
+    # ``emissiveFactor`` (core) carries the SDR-clamped color factor;
+    # KHR_materials_emissive_strength carries the HDR multiplier > 1.
+    # ``emission`` wins over the legacy ``emissive`` key when both
+    # arrive in the scalars dict (it carries HDR info the legacy key
+    # cannot express).
+    emission_split = _resolve_emission_split(scalars)
+    if emission_split is not None:
+        emissive_color, strength = emission_split
+        material["emissiveFactor"] = emissive_color
+        # The KHR_materials_emissive_strength extension defaults to 1.0;
+        # emit only for HDR cases so SDR materials don't ship a no-op
+        # extension entry (mirrors the IOR/transmission suppression
+        # pattern). Spec: https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_emissive_strength
+        if strength > 1.0:
+            material.setdefault("extensions", {})["KHR_materials_emissive_strength"] = {
+                "emissiveStrength": strength
+            }
 
     # Clearcoat extension — omit when zero/None (spec default), mirrors
     # the KHR_materials_ior / _transmission suppression pattern. The

--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -2139,6 +2139,11 @@ class MatVisClient:
         "subsurface",
         "subsurface_color",
         "subsurface_radius",
+        # Emission scalar coverage (#406 / #405 Phase 3a) — factor +
+        # linear-RGB tint. Adapter splits HDR strengths > 1 into
+        # emissiveIntensity / KHR_materials_emissive_strength.
+        "emission",
+        "emission_color",
     )
 
     def _scalars_for(self, source: str, material_id: str) -> dict:

--- a/clients/python/tests/test_adapter_field_passthrough.py
+++ b/clients/python/tests/test_adapter_field_passthrough.py
@@ -98,6 +98,34 @@ EMISSIVE_INDEX = [
     ),
 ]
 
+# Emission factor + color (#406) — exercises the MTLX-derived split
+# emission scalar coverage. SDR case: factor in [0, 1].
+EMISSION_SDR_INDEX = [
+    _entry(
+        "glowing-decal",
+        name="Glowing Decal",
+        roughness=0.5,
+        metalness=0.0,
+        emission=1.0,
+        emission_color=[0.0, 1.0, 0.5],
+        color_rgb=[0.1, 0.1, 0.1],
+    ),
+]
+
+# Emission HDR — factor > 1, exercises the emissiveIntensity /
+# KHR_materials_emissive_strength split on the adapter side.
+EMISSION_HDR_INDEX = [
+    _entry(
+        "led-sign",
+        name="LED Sign",
+        roughness=0.5,
+        metalness=0.0,
+        emission=4.0,
+        emission_color=[1.0, 0.4, 0.1],
+        color_rgb=[0.1, 0.1, 0.1],
+    ),
+]
+
 
 # ── Read-side: _scalars_for forwards each new field ────────────
 
@@ -161,6 +189,17 @@ class TestScalarsForFullPbrPassthrough:
             scalars = c._scalars_for("physicallybased", "LED Strip")
         assert scalars["emissive"] == [0.0, 1.0, 0.5]
 
+    def test_emission_factor_and_color_pass_through(self):
+        """#406 — ``emission`` factor + ``emission_color`` round-trip from
+        the substrate's mat_vis.pbr block to the adapter scalars dict.
+        The adapter then splits HDR strengths > 1 into the
+        emissiveIntensity / KHR_materials_emissive_strength path."""
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=EMISSION_HDR_INDEX):
+            scalars = c._scalars_for("physicallybased", "LED Sign")
+        assert scalars["emission"] == pytest.approx(4.0)
+        assert scalars["emission_color"] == [1.0, 0.4, 0.1]
+
     def test_existing_4_field_contract_preserved(self):
         """Regression guard — the original
         roughness/metalness/ior/color_hex fields still round-trip
@@ -190,6 +229,9 @@ class TestScalarsForFullPbrPassthrough:
             "specular_intensity",
             "specular_color_linear",
             "emissive",
+            # Emission scalar coverage (#406) — additive, defaults to absent.
+            "emission",
+            "emission_color",
         ):
             assert k not in scalars, f"{k!r} should not be injected when substrate is None"
 
@@ -227,6 +269,26 @@ class TestEndToEndThreejs:
             scalars = c._scalars_for("physicallybased", "LED Strip")
         result = to_threejs(scalars)
         assert result["emissive"] == [0.0, 1.0, 0.5]
+
+    def test_emission_sdr_emits_emissive_only(self):
+        # #406 SDR end-to-end: factor=1.0 with a green tint → emissive
+        # carries the color, no emissiveIntensity (Three.js default).
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=EMISSION_SDR_INDEX):
+            scalars = c._scalars_for("physicallybased", "Glowing Decal")
+        result = to_threejs(scalars)
+        assert result["emissive"] == [0.0, 1.0, 0.5]
+        assert "emissiveIntensity" not in result
+
+    def test_emission_hdr_emits_emissive_plus_intensity(self):
+        # #406 HDR end-to-end: factor=4.0 → emissive clamped to SDR
+        # (×1 color), intensity carries the HDR multiplier.
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=EMISSION_HDR_INDEX):
+            scalars = c._scalars_for("physicallybased", "LED Sign")
+        result = to_threejs(scalars)
+        assert result["emissive"] == [1.0, 0.4, pytest.approx(0.1)]
+        assert result["emissiveIntensity"] == pytest.approx(4.0)
 
 
 class TestEndToEndGltf:
@@ -285,3 +347,24 @@ class TestEndToEndGltf:
             scalars = c._scalars_for("physicallybased", "LED Strip")
         result = to_gltf(scalars)
         assert result["emissiveFactor"] == [0.0, 1.0, 0.5]
+
+    def test_emission_sdr_emits_factor_only(self):
+        # #406 SDR end-to-end: factor=1.0 → emissiveFactor carries the
+        # color; KHR_materials_emissive_strength omitted (default).
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=EMISSION_SDR_INDEX):
+            scalars = c._scalars_for("physicallybased", "Glowing Decal")
+        result = to_gltf(scalars)
+        assert result["emissiveFactor"] == [0.0, 1.0, 0.5]
+        assert "KHR_materials_emissive_strength" not in result.get("extensions", {})
+
+    def test_emission_hdr_emits_strength_extension(self):
+        # #406 HDR end-to-end: factor=4.0 → emissiveFactor clamped to
+        # SDR; KHR_materials_emissive_strength carries the multiplier.
+        c = MatVisClient()
+        with patch.object(c, "index", return_value=EMISSION_HDR_INDEX):
+            scalars = c._scalars_for("physicallybased", "LED Sign")
+        result = to_gltf(scalars)
+        assert result["emissiveFactor"] == [1.0, 0.4, pytest.approx(0.1)]
+        ext = result["extensions"]["KHR_materials_emissive_strength"]
+        assert ext["emissiveStrength"] == pytest.approx(4.0)

--- a/clients/python/tests/test_adapters_emissive_clearcoat.py
+++ b/clients/python/tests/test_adapters_emissive_clearcoat.py
@@ -121,6 +121,117 @@ class TestClearcoatToGltf:
         assert "KHR_materials_clearcoat" not in result.get("extensions", {})
 
 
+class TestEmissionFactorToThreejs:
+    """Emission scalar coverage (#406 / #405 Phase 3a). ``emission``
+    (factor) + ``emission_color`` (RGB tint) flow from the substrate to
+    Three.js via the HDR split: SDR cases write ``emissive`` alone;
+    HDR cases (factor > 1) add ``emissiveIntensity``. The legacy
+    ``emissive`` key (RGB triple) stays a backward-compat passthrough."""
+
+    def test_emission_sdr_writes_emissive_only(self):
+        # Factor at 0.5 + green tint → emissive = green * 0.5 (clamped to
+        # SDR range). No emissiveIntensity (Three.js default is 1.0).
+        result = to_threejs({"emission": 0.5, "emission_color": [0.0, 1.0, 0.5]})
+        assert result["emissive"] == [0.0, 0.5, 0.25]
+        assert "emissiveIntensity" not in result
+
+    def test_emission_at_unit_writes_emissive_only(self):
+        # Factor = 1.0 → emissive carries the full color; intensity stays
+        # at the Three.js default, so the adapter doesn't emit it.
+        result = to_threejs({"emission": 1.0, "emission_color": [0.8, 0.4, 0.2]})
+        assert result["emissive"] == [0.8, 0.4, 0.2]
+        assert "emissiveIntensity" not in result
+
+    def test_emission_hdr_splits_color_and_intensity(self):
+        # Factor = 3.5 → color clamped to SDR (×1), intensity carries
+        # the HDR multiplier. This is the Three.js HDR mechanism
+        # (intensity * color). Renderer math reconstructs 3.5 × color.
+        result = to_threejs({"emission": 3.5, "emission_color": [1.0, 0.5, 0.0]})
+        assert result["emissive"] == [1.0, 0.5, 0.0]
+        assert result["emissiveIntensity"] == 3.5
+
+    def test_emission_without_color_defaults_to_white(self):
+        # MTLX ``<standard_surface>`` default for emission_color is
+        # (1, 1, 1) — when only the factor is authored, emit a white
+        # emissive at the factor's SDR clamp.
+        result = to_threejs({"emission": 2.0})
+        assert result["emissive"] == [1.0, 1.0, 1.0]
+        assert result["emissiveIntensity"] == 2.0
+
+    def test_emission_zero_suppresses_output(self):
+        # 3160/3160 corpus materials author emission=0 — the SDR-zero
+        # case is a no-op, suppress to keep the Three.js dict clean.
+        result = to_threejs({"emission": 0.0, "emission_color": [1.0, 0.0, 0.0]})
+        assert "emissive" not in result
+        assert "emissiveIntensity" not in result
+
+    def test_emission_none_with_color_none_suppresses(self):
+        # Neither field authored → no emissive output.
+        result = to_threejs({"emission": None, "emission_color": None})
+        assert "emissive" not in result
+        assert "emissiveIntensity" not in result
+
+    def test_emission_factor_wins_over_legacy_emissive(self):
+        # Adapter contract: ``emission`` (HDR factor) carries information
+        # the legacy ``emissive`` key (RGB triple, no factor) cannot
+        # express. When both arrive, ``emission`` wins so HDR substrate
+        # values aren't silently downgraded.
+        result = to_threejs(
+            {
+                "emissive": (0.1, 0.1, 0.1),  # legacy
+                "emission": 5.0,
+                "emission_color": [1.0, 1.0, 1.0],
+            }
+        )
+        assert result["emissive"] == [1.0, 1.0, 1.0]
+        assert result["emissiveIntensity"] == 5.0
+
+
+class TestEmissionFactorToGltf:
+    """glTF emission output for the factor + color split (#406)."""
+
+    def test_emission_sdr_writes_factor_only(self):
+        result = to_gltf({"emission": 0.5, "emission_color": [0.0, 1.0, 0.5]})
+        assert result["emissiveFactor"] == [0.0, 0.5, 0.25]
+        assert "KHR_materials_emissive_strength" not in result.get("extensions", {})
+
+    def test_emission_at_unit_writes_factor_only(self):
+        # SDR boundary (factor = 1.0) — KHR extension omitted (default).
+        result = to_gltf({"emission": 1.0, "emission_color": [0.8, 0.4, 0.2]})
+        assert result["emissiveFactor"] == [0.8, 0.4, 0.2]
+        assert "KHR_materials_emissive_strength" not in result.get("extensions", {})
+
+    def test_emission_hdr_emits_strength_extension(self):
+        # HDR — KHR_materials_emissive_strength carries the factor;
+        # emissiveFactor stays in SDR range. Spec:
+        # https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_emissive_strength
+        result = to_gltf({"emission": 3.5, "emission_color": [1.0, 0.5, 0.0]})
+        assert result["emissiveFactor"] == [1.0, 0.5, 0.0]
+        ext = result["extensions"]["KHR_materials_emissive_strength"]
+        assert ext["emissiveStrength"] == 3.5
+
+    def test_emission_without_color_defaults_to_white(self):
+        result = to_gltf({"emission": 2.0})
+        assert result["emissiveFactor"] == [1.0, 1.0, 1.0]
+        assert result["extensions"]["KHR_materials_emissive_strength"]["emissiveStrength"] == 2.0
+
+    def test_emission_zero_suppresses_output(self):
+        result = to_gltf({"emission": 0.0, "emission_color": [1.0, 0.0, 0.0]})
+        assert "emissiveFactor" not in result
+        assert "KHR_materials_emissive_strength" not in result.get("extensions", {})
+
+    def test_emission_factor_wins_over_legacy_emissive(self):
+        result = to_gltf(
+            {
+                "emissive": (0.1, 0.1, 0.1),
+                "emission": 5.0,
+                "emission_color": [1.0, 1.0, 1.0],
+            }
+        )
+        assert result["emissiveFactor"] == [1.0, 1.0, 1.0]
+        assert result["extensions"]["KHR_materials_emissive_strength"]["emissiveStrength"] == 5.0
+
+
 class TestClearcoatMtlxSkipped:
     """UsdPreviewSurface 1.38 has no clearcoat input — adapter drops it silently
     with no error. (Future MaterialX shaders may; revisit then.)"""

--- a/src/mat_vis_baker/_mtlx_scalars.py
+++ b/src/mat_vis_baker/_mtlx_scalars.py
@@ -62,6 +62,13 @@ _FLOAT_INPUTS: dict[str, str] = {
     # for glTF via the (draft) subsurface extension; Three.js adapter
     # is intentionally a no-op (MeshPhysicalMaterial has no SSS field).
     "subsurface": "subsurface",
+    # Emission factor (#406 / #405 Phase 3a). Without this, materials
+    # authoring ``emission > 0`` (LED signs, glowing decals, hot metals,
+    # screens) render as inert. Adapter wiring routes values ≤ 1 to
+    # Three.js ``emissive`` / glTF ``emissiveFactor``; values > 1 split
+    # into ``emissiveIntensity`` (Three.js HDR) / KHR_materials_emissive_strength
+    # (glTF HDR) with the color factor clamped to [0, 1].
+    "emission": "emission",  # KHR_materials_emissive_strength.emissiveStrength (factor)
 }
 
 # Color3 inputs. Same direct value=/1-hop graph→constant promotion as
@@ -75,6 +82,10 @@ _COLOR3_INPUTS: dict[str, str] = {
     # decides whether the SSS extension fires (only when subsurface>0).
     "subsurface_color": "subsurface_color",
     "subsurface_radius": "subsurface_radius",
+    # Emission color (#406). Sibling of ``emission`` factor — RGB tint
+    # the emission factor multiplies. Authored linear per MaterialX 1.38;
+    # glTF ``emissiveFactor`` is also linear so no colorspace boundary.
+    "emission_color": "emission_color",  # glTF emissiveFactor RGB (linear)
 }
 
 # Inputs that have no PBRBlock home today. Non-zero values are dropped
@@ -86,8 +97,6 @@ _LOSSY_INPUTS: tuple[str, ...] = (
     "sheen_roughness",
     "sheen_color",
     "thin_film_thickness",
-    "emission",
-    "emission_color",
 )
 
 

--- a/src/mat_vis_baker/common.py
+++ b/src/mat_vis_baker/common.py
@@ -468,6 +468,20 @@ class PBRBlock:
     # transmission > 0; baker emits None for opaque materials.
     thickness: float | None = None  # <standard_surface>.transmission_depth
     dispersion: float | None = None  # <standard_surface>.transmission_dispersion
+    # Emission — Phase 3a of #405 (#406). ``emission`` is the scalar HDR
+    # factor (>= 0; values > 1 emit KHR_materials_emissive_strength on
+    # the glTF side / route through ``emissiveIntensity`` on Three.js).
+    # ``emission_color`` is the linear RGB tint that the factor
+    # multiplies. Both stay None when the material is non-emissive
+    # (the gpuopen+polyhaven+ambientcg corpus authors emission=0 for all
+    # 3160 entries today; schema is sticky pre-v0.7, hence the additive
+    # land). Adapter contract:
+    #   - Three.js: emissive = emission_color * min(emission, 1),
+    #               emissiveIntensity = max(emission, 1)
+    #   - glTF:     emissiveFactor = emission_color * min(emission, 1);
+    #               emission > 1 ⇒ KHR_materials_emissive_strength.emissiveStrength
+    emission: float | None = None  # <standard_surface>.emission
+    emission_color: list[float] | None = None  # <standard_surface>.emission_color, LINEAR RGB
 
     # Subsurface scattering (#409). 13 gpuopen entries author
     # ``subsurface > 0`` (wax, resin, semi-translucent). Three.js

--- a/tests/test_index_builder.py
+++ b/tests/test_index_builder.py
@@ -91,6 +91,9 @@ def test_mat_vis_block_has_stable_key_set() -> None:
         "subsurface",
         "subsurface_color",
         "subsurface_radius",
+        # Emission scalar coverage (#406 / #405 Phase 3a) — additive.
+        "emission",
+        "emission_color",
     }
     # Nested AttributionBlock
     assert set(mv["attribution"].keys()) == {"authors", "license_spdx", "source_url"}
@@ -128,6 +131,9 @@ def test_mat_vis_block_defaults_are_null_or_empty() -> None:
     assert mv["pbr"]["subsurface"] is None
     assert mv["pbr"]["subsurface_color"] is None
     assert mv["pbr"]["subsurface_radius"] is None
+    # Emission scalar coverage (#406 / #405 Phase 3a) — additive, default-None.
+    assert mv["pbr"]["emission"] is None
+    assert mv["pbr"]["emission_color"] is None
     assert mv["attribution"]["authors"] == []
     assert mv["dates"]["published"] is None
     assert mv["dates"]["updated"] is None

--- a/tests/test_mtlx_scalars_pbr_coverage.py
+++ b/tests/test_mtlx_scalars_pbr_coverage.py
@@ -1,4 +1,4 @@
-"""Bake-side extraction tests for #340 / #396 / #409 — full MeshPhysicalMaterial coverage.
+"""Bake-side extraction tests for #340 / #396 / #406 / #409 — full MeshPhysicalMaterial coverage.
 
 Scalar fields extracted from ``<standard_surface>``:
 - coat                   → clearcoat (float, #396)
@@ -10,6 +10,8 @@ Scalar fields extracted from ``<standard_surface>``:
 - subsurface             → subsurface (float, #409)
 - subsurface_color       → subsurface_color (color3, linear, #409)
 - subsurface_radius      → subsurface_radius (color3, per-channel mfp, #409)
+- emission               → emission (float, #406 / #405 Phase 3a)
+- emission_color         → emission_color (color3, linear, #406 / #405 Phase 3a)
 
 All extracted from <standard_surface> direct `value=` attributes or
 1-hop nodegraph→<constant> chains. Survey of 454 gpuopen materials
@@ -328,6 +330,141 @@ class TestThickness:
         assert pbr.thickness is None
 
 
+class TestEmission:
+    """``emission`` factor + ``emission_color`` extraction (#406 / #405
+    Phase 3a). P0 audit of the v2026.04.99 corpus: 0/454 gpuopen,
+    0/757 polyhaven, 0/1949 ambientcg materials author ``emission > 0``.
+    Landing additively pre-v0.7 prod cut keeps the schema clean so
+    future emissive sources (signage/screens/decals) flow through
+    without a major-version bump."""
+
+    def test_emission_authored_non_default(self) -> None:
+        # Typical authored case — emission factor in [0, 1] range.
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="emission" type="float" value="0.8"/>')
+        )
+        assert pbr.emission == pytest.approx(0.8)
+        # emission_color absent → stays None even when emission is set.
+        assert pbr.emission_color is None
+
+    def test_emission_hdr_strength(self) -> None:
+        # HDR strength > 1 — adapter side splits this into intensity +
+        # KHR_materials_emissive_strength. The baker passes the raw
+        # factor through unchanged; the split is an adapter concern.
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="emission" type="float" value="3.5"/>')
+        )
+        assert pbr.emission == pytest.approx(3.5)
+
+    def test_emission_color_authored(self) -> None:
+        # MaterialX 1.38 emission_color is authored linear; round-trips
+        # to glTF emissiveFactor (also linear) without colorspace work.
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="emission_color" type="color3" value="1.0, 0.5, 0.0"/>')
+        )
+        assert pbr.emission_color == pytest.approx([1.0, 0.5, 0.0])
+
+    def test_emission_and_color_authored_together(self) -> None:
+        # Real-world emissive case: glowing decal authors both — the
+        # factor and the tint together describe the emission output.
+        pbr = parse_standard_surface_scalars(
+            _wrap(
+                '<input name="emission" type="float" value="1.0"/>',
+                '<input name="emission_color" type="color3" value="0.0, 1.0, 0.5"/>',
+            )
+        )
+        assert pbr.emission == pytest.approx(1.0)
+        assert pbr.emission_color == pytest.approx([0.0, 1.0, 0.5])
+
+    def test_emission_default_zero_extracted(self) -> None:
+        # 3160/3160 corpus materials default to 0.0 — extracting it
+        # confirms provenance. Adapter suppresses the spec-default
+        # KHR extension entry; Three.js emissive at black is a no-op.
+        pbr = parse_standard_surface_scalars(
+            _wrap('<input name="emission" type="float" value="0.0"/>')
+        )
+        assert pbr.emission == pytest.approx(0.0)
+
+    def test_emission_unset_stays_none(self) -> None:
+        # Neither emission nor emission_color authored → both None, the
+        # PBRBlock default. Stable-key-set test pins this contract.
+        pbr = parse_standard_surface_scalars(_wrap())
+        assert pbr.emission is None
+        assert pbr.emission_color is None
+
+    def test_emission_texture_bound_stays_none(self) -> None:
+        # Texture-bound emission (rare — typical is scalar + per-pixel
+        # emissive map combined). Consistent with metalness-texture-bound
+        # handling: field stays None; the baker carries the texture path
+        # separately. No neutral-multiplier convention for emission
+        # (an emissiveMap with emissiveFactor=0 silently kills emission;
+        # callers must author the factor explicitly).
+        mtlx = """<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="NG_EM">
+    <image name="em_img" type="float">
+      <input name="file" type="filename" value="emission.png"/>
+    </image>
+    <output name="em_out" type="float" nodename="em_img"/>
+  </nodegraph>
+  <standard_surface name="SR_T" type="surfaceshader">
+    <input name="emission" type="float" output="em_out" nodegraph="NG_EM"/>
+  </standard_surface>
+  <surfacematerial name="T" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_T"/>
+  </surfacematerial>
+</materialx>
+"""
+        pbr = parse_standard_surface_scalars(mtlx)
+        assert pbr.emission is None
+        assert pbr.emission_color is None
+
+    def test_emission_graph_constant_promoted(self) -> None:
+        # 1-hop nodegraph → <constant> resolution applies to ``emission``
+        # the same way it does for every other _FLOAT_INPUT.
+        mtlx = """<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="NG_EM">
+    <constant name="em_const" type="float">
+      <input name="value" type="float" value="2.5"/>
+    </constant>
+    <output name="em_out" type="float" nodename="em_const"/>
+  </nodegraph>
+  <standard_surface name="SR_T" type="surfaceshader">
+    <input name="emission" type="float" output="em_out" nodegraph="NG_EM"/>
+  </standard_surface>
+  <surfacematerial name="T" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_T"/>
+  </surfacematerial>
+</materialx>
+"""
+        pbr = parse_standard_surface_scalars(mtlx)
+        assert pbr.emission == pytest.approx(2.5)
+
+    def test_emission_color_graph_constant_promoted(self) -> None:
+        # 1-hop graph→<constant> resolution applies to emission_color
+        # the same way it does for specular_color (the only other
+        # _COLOR3_INPUT today).
+        mtlx = """<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="NG_EMC">
+    <constant name="emc_const" type="color3">
+      <input name="value" type="color3" value="0.8, 0.4, 0.2"/>
+    </constant>
+    <output name="emc_out" type="color3" nodename="emc_const"/>
+  </nodegraph>
+  <standard_surface name="SR_T" type="surfaceshader">
+    <input name="emission_color" type="color3" output="emc_out" nodegraph="NG_EMC"/>
+  </standard_surface>
+  <surfacematerial name="T" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_T"/>
+  </surfacematerial>
+</materialx>
+"""
+        pbr = parse_standard_surface_scalars(mtlx)
+        assert pbr.emission_color == pytest.approx([0.8, 0.4, 0.2])
+
+
 class TestPBRBlockFieldsExist:
     def test_new_fields_default_to_none(self) -> None:
         from mat_vis_baker.common import PBRBlock
@@ -344,6 +481,9 @@ class TestPBRBlockFieldsExist:
             "subsurface",
             "subsurface_color",
             "subsurface_radius",
+            # Emission (#406) — additive, default-None.
+            "emission",
+            "emission_color",
         ):
             assert getattr(pbr, fname) is None, f"{fname} should default to None"
 
@@ -360,6 +500,8 @@ class TestPBRBlockFieldsExist:
         pbr.subsurface = 0.5
         pbr.subsurface_color = [0.9, 0.6, 0.5]
         pbr.subsurface_radius = [1.0, 0.2, 0.1]
+        pbr.emission = 2.5
+        pbr.emission_color = [1.0, 0.5, 0.0]
         assert pbr.clearcoat == 1.0
         assert pbr.clearcoat_roughness == 0.2
         assert pbr.specular_intensity == 0.8
@@ -369,3 +511,5 @@ class TestPBRBlockFieldsExist:
         assert pbr.subsurface == 0.5
         assert pbr.subsurface_color == [0.9, 0.6, 0.5]
         assert pbr.subsurface_radius == [1.0, 0.2, 0.1]
+        assert pbr.emission == 2.5
+        assert pbr.emission_color == [1.0, 0.5, 0.0]


### PR DESCRIPTION
## Summary

Closes #406. Phase 3a of the #405 PBR coverage sweep — `emission` + `emission_color` move from `_LOSSY_INPUTS` to `_FLOAT_INPUTS` / `_COLOR3_INPUTS` so the MTLX parser populates the emissive surface fields. Without this, materials authoring `emission > 0` (LED signs, glowing decals, hot metals, screens) render as inert because the inputs were silently dropped.

Mechanically identical to #400 (coat → clearcoat).

## P0 Audit — `gerchowl/mat-vis-tst@v2026.04.99-tst-full-369`

| source     | total | `emission > 0` | notes                                              |
|------------|-------|----------------|----------------------------------------------------|
| gpuopen    |   454 |              0 | shipped at default per #405 audit caveat           |
| polyhaven  |   757 |              0 | all 757 carry the input authored at MTLX default 0 |
| ambientcg  |  1949 |              0 | input absent entirely                              |
| **total**  |  3160 |          **0** |                                                    |

3160 / 3160 entries authored at default. The MTLX corpus has no emissive materials today. Landing additively pre-v0.7 prod cut keeps the schema clean for future emissive sources (signage / screens / decals) without a major-version bump — same rationale as #405.

## Changes

### Baker (`src/mat_vis_baker/`)
- `_mtlx_scalars.py`: `emission` → `_FLOAT_INPUTS`, `emission_color` → `_COLOR3_INPUTS`; both removed from `_LOSSY_INPUTS`.
- `common.py`: add `PBRBlock.emission: float | None = None` + `PBRBlock.emission_color: list[float] | None = None`.

### Baker tests (`tests/`)
- `test_index_builder.py`: extend stable-key-set + default-None tests.
- `test_mtlx_scalars_pbr_coverage.py`: new `TestEmission` covers direct value, HDR strength > 1, color authored, both fields together, default-zero, unset, texture-bound (stays None), and 1-hop nodegraph→constant promotion for both float and color3 paths.

### Client adapter (`clients/python/`)
- `src/mat_vis_client/adapters.py`: new `_resolve_emission_split` helper.
  - **Three.js**: `emissive = emission_color * min(emission, 1)`; `emissiveIntensity = emission` when `emission > 1` (Three.js HDR mechanism is `intensity * color`).
  - **glTF**: `emissiveFactor = emission_color * min(emission, 1)`; `KHR_materials_emissive_strength.emissiveStrength = emission` when `emission > 1` ([KHR spec](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_emissive_strength)).
  - Legacy `emissive` (RGB triple) key stays a backward-compat passthrough; new `emission` factor wins when both arrive in the same scalars dict.
- `src/mat_vis_client/client.py` + `mat_vis_client_standalone.py`: add `emission` + `emission_color` to `_PBR_SCALAR_PASSTHROUGH`.

### Client tests (`clients/python/tests/`)
- `test_adapters_emissive_clearcoat.py`: new `TestEmissionFactorToThreejs` + `TestEmissionFactorToGltf` cover SDR (factor ≤ 1) and HDR (factor > 1), default-white fallback, zero-suppression, and `emission` winning over the legacy `emissive` key.
- `test_adapter_field_passthrough.py`: new `EMISSION_SDR_INDEX` + `EMISSION_HDR_INDEX` fixtures + end-to-end substrate→adapter tests for both Three.js and glTF.

## Acceptance criteria

- [x] P0 audit recorded above
- [x] `PBRBlock.emission` + `emission_color` fields added (additive — stable key-set contract honored)
- [x] Parser extracts both via direct + 1-hop graph-constant promotion
- [x] Adapter routes both for Three.js + glTF with HDR strength split
- [x] Unit tests: synthesised MTLX fixtures with `emission > 0` + adapter assertions for `<1` and `>1` factors
- [x] All baker tests pass — 636 passed, 20 skipped
- [x] All client tests pass — 608 passed, 29 skipped, 2 xfailed

## Test plan

- [x] `uv run --extra baker --extra dev pytest tests/` — 636 passed
- [x] `cd clients/python && uv run --extra test --extra gltf --extra search pytest tests/` — 608 passed
- [ ] Post-merge: schema is additive + corpus authors 0/3160 emission>0 today, so a fresh bake on `gerchowl/mat-vis-tst` should leave every substrate entry at `pbr.emission=null` / `pbr.emission_color=null` — confirms the additive land is non-destructive.