### PR TITLE
feat(bake): cross-thumb md5 duplicate-bytes detector (closes #385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `bake/preview/utils/check_thumbs.py`: cross-thumb md5 duplicate-bytes
+  detector (#385). Catches scalar-collapse, orchestrator closure-mixup,
+  and texture-binding regressions where many distinct materials produce
+  byte-identical PNGs (the original #385 trigger). Ships with a YAML
+  allow-list at `bake/preview/utils/thumb_check_allow.yml`, a structured
+  JSON report (`thumb-check.json`), an exit-code taxonomy
+  (0/1/2/3/4 for ok/duplicate/fingerprint/no-sentinel/cli-error), and
+  an operator runbook (`thumb_check_runbook.md`). `bake/preview/run.py`
+  now writes a `_bake_complete.json` sentinel after a successful bake;
+  the gate refuses to validate without it.
+
 ### Changed
 
 ### Deprecated

--- a/bake/preview/run.py
+++ b/bake/preview/run.py
@@ -5,9 +5,13 @@ material via mat-vis-client, drives Playwright + headless Chromium
 through `thumb_render.html`, writes one PNG per material under
 ``<out_dir>/<source>/<material_id>/thumb.png``.
 
-After the loop, runs ``check_thumbs.py`` against ``<out_dir>`` as a
-CI gate to catch silently-broken bakes (default-grey fingerprints,
-empty material specs).
+After the loop, writes a ``_bake_complete.json`` sentinel under
+``<out_dir>`` and runs ``check_thumbs.py`` as a CI gate to catch
+silently-broken bakes (default-grey fingerprints, empty material specs,
+byte-identical cross-material renders #385). The sentinel is what tells
+the gate the directory represents a *completed* bake — without it the
+gate refuses to validate (#385 exit code 3) so a crashed-mid-bake
+directory can't pass for a clean one.
 
 Usage:
     uv run python bake/preview/run.py --out /tmp/thumbs
@@ -209,6 +213,7 @@ def main():
             browser = pw.chromium.launch(headless=True, args=["--use-gl=swiftshader"])
             try:
                 totals = {"ok": 0, "skipped": 0, "errors": 0}
+                source_results: dict[str, dict[str, int]] = {}
                 for source in sources:
                     log.info("baking source: %s", source)
                     t0 = time.monotonic()
@@ -224,6 +229,7 @@ def main():
                         counters["skipped"],
                         counters["errors"],
                     )
+                    source_results[source] = counters
                     for k, v in counters.items():
                         totals[k] += v
             finally:
@@ -236,13 +242,39 @@ def main():
             totals["errors"],
         )
 
+        # #385: drop the sentinel so check_thumbs.py knows this directory
+        # represents a completed bake. Written here (inside the tmpdir
+        # context but after the bake loop) so a crashed bake never lands one.
+        from datetime import datetime, timezone
+
+        sentinel = args.out / "_bake_complete.json"
+        sentinel.write_text(
+            json.dumps(
+                {
+                    "totals": totals,
+                    "source_results": source_results,
+                    "release_tag": client._tag,
+                    "baked_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+
     if not args.skip_check:
-        log.info("running fingerprint check against %s", args.out)
+        log.info("running thumb-check (#385 + fingerprint) against %s", args.out)
         rc = subprocess.run(
-            [sys.executable, str(CHECK_THUMBS), str(args.out)], check=False
+            [
+                sys.executable,
+                str(CHECK_THUMBS),
+                str(args.out),
+                "--release-tag",
+                client._tag,
+            ],
+            check=False,
         ).returncode
         if rc != 0:
-            log.error("fingerprint check failed (rc=%d) — see above", rc)
+            log.error("thumb-check failed (rc=%d) — see above + thumb-check.json", rc)
             return rc
 
     return 0 if totals["errors"] == 0 else 1

--- a/bake/preview/tests/test_check_thumbs.py
+++ b/bake/preview/tests/test_check_thumbs.py
@@ -1,0 +1,348 @@
+"""Tests for the duplicate-bytes detector + allow-list + sentinel gate (#385).
+
+All synthetic — no network, no Playwright. Each test scaffolds a tmpdir
+that mimics a bake output (`<src>/<material>/thumb.png`) and drives
+``check_thumbs.check`` with explicit overrides.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+# bake/ is not a Python package (no top-level __init__.py); load
+# check_thumbs.py directly by file path to avoid forcing a package layout
+# the rest of the repo doesn't use.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CHECK_THUMBS_PATH = _REPO_ROOT / "bake" / "preview" / "utils" / "check_thumbs.py"
+_spec = importlib.util.spec_from_file_location("check_thumbs", _CHECK_THUMBS_PATH)
+assert _spec and _spec.loader
+check_thumbs = importlib.util.module_from_spec(_spec)
+sys.modules["check_thumbs"] = check_thumbs
+_spec.loader.exec_module(check_thumbs)
+
+SENTINEL_NAME = check_thumbs.SENTINEL_NAME
+JSON_REPORT_NAME = check_thumbs.JSON_REPORT_NAME
+
+
+# ---------------------------------------------------------------------------
+# Fixtures.
+# ---------------------------------------------------------------------------
+
+
+def _solid_png(path: Path, color: tuple[int, int, int], size: int = 256) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (size, size), color).save(path, format="PNG", optimize=True)
+
+
+def _drop_sentinel(out_dir: Path, totals: dict | None = None) -> None:
+    payload = {
+        "totals": totals or {"ok": 1, "skipped": 0, "errors": 0},
+        "source_results": {},
+        "baked_at": "2026-05-11T00:00:00Z",
+    }
+    (out_dir / SENTINEL_NAME).write_text(json.dumps(payload))
+
+
+def _make_bake(
+    tmp_path: Path,
+    *,
+    n_unique: int = 5,
+    n_duplicates: int = 0,
+    drop_sentinel: bool = True,
+) -> Path:
+    """Build a fake bake directory.
+
+    - Writes ``n_unique`` distinct solid-color PNGs across one source.
+    - If ``n_duplicates`` > 0, copies the *bytes* of the first PNG that
+      many extra times under different material IDs (so md5 matches).
+    """
+    out = tmp_path / "thumbs"
+    src = out / "fakesrc"
+    paths: list[Path] = []
+    for i in range(n_unique):
+        # Distinct primary colour per i — keeps md5 different and keeps
+        # the bytes well below the fingerprint distance threshold.
+        p = src / f"mat_{i:03d}" / "thumb.png"
+        _solid_png(p, ((i * 37) % 256, (i * 71) % 256, (i * 113) % 256))
+        paths.append(p)
+
+    if n_duplicates and paths:
+        src_bytes = paths[0].read_bytes()
+        for j in range(n_duplicates):
+            dup = src / f"dup_{j:03d}" / "thumb.png"
+            dup.parent.mkdir(parents=True, exist_ok=True)
+            dup.write_bytes(src_bytes)
+
+    if drop_sentinel:
+        _drop_sentinel(out)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Detector unit-test (no orchestration).
+# ---------------------------------------------------------------------------
+
+
+def test_detect_duplicate_renders_finds_byte_identical(tmp_path: Path) -> None:
+    out = _make_bake(tmp_path, n_unique=5, n_duplicates=1)
+    buckets = check_thumbs.detect_duplicate_renders(out)
+    assert len(buckets) == 1
+    digest, paths = buckets[0]
+    assert len(digest) == 32
+    assert len(paths) == 2  # the original + 1 duplicate
+
+
+def test_detect_duplicate_renders_clean_returns_empty(tmp_path: Path) -> None:
+    out = _make_bake(tmp_path, n_unique=6, n_duplicates=0)
+    assert check_thumbs.detect_duplicate_renders(out) == []
+
+
+def test_detect_duplicate_renders_size_prefilter_doesnt_drop_dupes(tmp_path: Path) -> None:
+    """Same-size + same-bytes must still bucket; same-size + different bytes must NOT."""
+    out = tmp_path / "thumbs"
+    src = out / "fakesrc"
+    # Two files with the same dimensions+colour → identical bytes → bucket.
+    _solid_png(src / "a" / "thumb.png", (10, 20, 30))
+    _solid_png(src / "b" / "thumb.png", (10, 20, 30))
+    # Third file, same dimensions, different colour → distinct md5.
+    _solid_png(src / "c" / "thumb.png", (200, 100, 50))
+    _drop_sentinel(out)
+    buckets = check_thumbs.detect_duplicate_renders(out)
+    assert len(buckets) == 1
+    assert len(buckets[0][1]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Top-level check() — exit codes.
+# ---------------------------------------------------------------------------
+
+
+def test_check_clean_returns_exit_ok(tmp_path: Path) -> None:
+    out = _make_bake(tmp_path, n_unique=6)
+    json_out = tmp_path / "report.json"
+    rc = check_thumbs.check(out, allowlist=[], json_out=json_out)
+    assert rc == check_thumbs.EXIT_OK
+    payload = json.loads(json_out.read_text())
+    assert payload["exit_code"] == 0
+    assert payload["duplicate_buckets"] == []
+    assert payload["fingerprint_hits"] == []
+    assert payload["checked"] == 6
+
+
+def test_check_duplicate_returns_exit_duplicate(tmp_path: Path) -> None:
+    out = _make_bake(tmp_path, n_unique=5, n_duplicates=1)
+    json_out = tmp_path / "report.json"
+    rc = check_thumbs.check(out, allowlist=[], json_out=json_out)
+    assert rc == check_thumbs.EXIT_DUPLICATE
+    payload = json.loads(json_out.read_text())
+    assert payload["exit_code"] == 1
+    assert len(payload["duplicate_buckets"]) == 1
+    assert payload["duplicate_buckets"][0]["count"] == 2
+    assert "suggested" in payload["duplicate_buckets"][0]
+
+
+def test_check_fingerprint_hit_returns_exit_fingerprint(tmp_path: Path) -> None:
+    """Drop the real ``blank_default_grey.png`` into the bake — fingerprint
+    matcher must fire and win the exit-code priority."""
+    out = _make_bake(tmp_path, n_unique=5, n_duplicates=0)
+    fp_src = check_thumbs.ASSETS / "blank_default_grey.png"
+    if not fp_src.exists():
+        pytest.skip(f"fingerprint asset missing: {fp_src}")
+    dst = out / "fakesrc" / "leaked_default" / "thumb.png"
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(fp_src, dst)
+    json_out = tmp_path / "report.json"
+    rc = check_thumbs.check(out, allowlist=[], json_out=json_out)
+    assert rc == check_thumbs.EXIT_FINGERPRINT
+    payload = json.loads(json_out.read_text())
+    assert payload["exit_code"] == 2
+    assert len(payload["fingerprint_hits"]) >= 1
+
+
+def test_check_missing_sentinel_returns_exit_no_sentinel(tmp_path: Path) -> None:
+    out = _make_bake(tmp_path, n_unique=3, n_duplicates=0, drop_sentinel=False)
+    json_out = tmp_path / "report.json"
+    rc = check_thumbs.check(out, allowlist=[], json_out=json_out)
+    assert rc == check_thumbs.EXIT_NO_SENTINEL
+    payload = json.loads(json_out.read_text())
+    assert payload["exit_code"] == 3
+    assert payload["exit_reason"] == "missing_sentinel"
+
+
+def test_check_no_sentinel_can_be_disabled(tmp_path: Path) -> None:
+    """``--no-sentinel`` (CLI) / ``require_sentinel=False`` lets ad-hoc
+    audits run against legacy directories without the sentinel."""
+    out = _make_bake(tmp_path, n_unique=4, n_duplicates=0, drop_sentinel=False)
+    rc = check_thumbs.check(out, allowlist=[], require_sentinel=False)
+    assert rc == check_thumbs.EXIT_OK
+
+
+# ---------------------------------------------------------------------------
+# Allow-list.
+# ---------------------------------------------------------------------------
+
+
+def test_check_allowlisted_duplicate_passes(tmp_path: Path) -> None:
+    out = _make_bake(tmp_path, n_unique=5, n_duplicates=1)
+    # Compute the duplicate's md5 the way the detector will see it.
+    buckets = check_thumbs.detect_duplicate_renders(out)
+    assert len(buckets) == 1
+    dup_md5 = buckets[0][0]
+
+    allowlist = [
+        {
+            "md5": dup_md5,
+            "reason": "synthetic test fixture",
+            "ticket": "#385",
+            "until": "v9999.99.0",
+        }
+    ]
+    json_out = tmp_path / "report.json"
+    rc = check_thumbs.check(out, allowlist=allowlist, json_out=json_out)
+    assert rc == check_thumbs.EXIT_OK
+    payload = json.loads(json_out.read_text())
+    assert payload["exit_code"] == 0
+    assert len(payload["allowlisted"]) == 1
+    assert payload["allowlisted"][0]["md5"] == dup_md5
+    assert payload["allowlisted"][0]["ticket"] == "#385"
+
+
+def test_stale_allowlist_entry_logs_warning_no_fail(tmp_path: Path, caplog) -> None:
+    out = _make_bake(tmp_path, n_unique=4, n_duplicates=0)
+    allowlist = [
+        {
+            "md5": "0" * 32,
+            "reason": "expired",
+            "ticket": "#999",
+            "until": "v2026.01.0",
+        }
+    ]
+    with caplog.at_level("WARNING", logger="check-thumbs"):
+        rc = check_thumbs.check(
+            out,
+            allowlist=allowlist,
+            release_tag="v2026.05.0",
+        )
+    assert rc == check_thumbs.EXIT_OK
+    assert any("stale allow-list entry" in rec.message for rec in caplog.records)
+
+
+def test_load_allowlist_validates_required_fields(tmp_path: Path) -> None:
+    p = tmp_path / "allow.yml"
+    p.write_text(
+        "allowed:\n"
+        '  - md5: "deadbeefdeadbeefdeadbeefdeadbeef"\n'
+        '    reason: "missing ticket and until"\n'
+    )
+    with pytest.raises(check_thumbs.AllowlistError, match="missing required field"):
+        check_thumbs.load_allowlist(p)
+
+
+def test_load_allowlist_validates_md5_format(tmp_path: Path) -> None:
+    p = tmp_path / "allow.yml"
+    p.write_text(
+        "allowed:\n"
+        '  - md5: "NOT_A_HEX_DIGEST"\n'
+        '    reason: "bad format"\n'
+        '    ticket: "#1"\n'
+        '    until: "v2026.05.0"\n'
+    )
+    with pytest.raises(check_thumbs.AllowlistError, match="32-char lowercase hex"):
+        check_thumbs.load_allowlist(p)
+
+
+def test_load_allowlist_round_trip(tmp_path: Path) -> None:
+    p = tmp_path / "allow.yml"
+    p.write_text(
+        "# leading comment\n"
+        "allowed:\n"
+        '  - md5: "0123456789abcdef0123456789abcdef"\n'
+        '    reason: "two upstream entries are the same material"\n'
+        '    ticket: "#999"\n'
+        '    until: "v2026.05.0"\n'
+    )
+    entries = check_thumbs.load_allowlist(p)
+    assert entries == [
+        {
+            "md5": "0123456789abcdef0123456789abcdef",
+            "reason": "two upstream entries are the same material",
+            "ticket": "#999",
+            "until": "v2026.05.0",
+        }
+    ]
+
+
+def test_load_allowlist_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert check_thumbs.load_allowlist(tmp_path / "nope.yml") == []
+
+
+def test_committed_allowlist_loads(tmp_path: Path) -> None:
+    """The shipped ``thumb_check_allow.yml`` must always parse — guard
+    against `git mv` shenanigans during a refactor."""
+    entries = check_thumbs.load_allowlist(check_thumbs.ALLOWLIST_PATH)
+    # Empty list is fine; the shipped file is `allowed: []` until ops adds one.
+    assert isinstance(entries, list)
+
+
+# ---------------------------------------------------------------------------
+# Suggested-investigation heuristic.
+# ---------------------------------------------------------------------------
+
+
+def test_suggest_root_cause_scalar_collapse(tmp_path: Path) -> None:
+    """All N baked thumbs identical → "scalar collapse"."""
+    out = _make_bake(tmp_path, n_unique=1, n_duplicates=2)  # 3 total, all same bytes
+    buckets = check_thumbs.detect_duplicate_renders(out)
+    assert len(buckets) == 1
+    suggestion = check_thumbs._suggest_root_cause(buckets[0][1], total_baked=3, thumbs_dir=out)
+    assert "scalar collapse" in suggestion
+
+
+def test_suggest_root_cause_orchestrator_closure_three_same_source(tmp_path: Path) -> None:
+    """3 byte-identical thumbs all under one source → "orchestrator closure"."""
+    out = tmp_path / "thumbs"
+    src = out / "ambientcg"
+    # Make three byte-identical thumbs by writing the raw bytes (avoids
+    # any per-file PNG metadata drift that PIL might insert).
+    _solid_png(src / "a" / "thumb.png", (50, 50, 50))
+    raw = (src / "a" / "thumb.png").read_bytes()
+    for sub in ("b", "c"):
+        d = src / sub
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "thumb.png").write_bytes(raw)
+    # Plus a few unrelated thumbs so total != 3 (i.e. not scalar collapse).
+    for i in range(20):
+        _solid_png(src / f"mat_{i}" / "thumb.png", ((i * 13) % 256, 0, 0))
+    _drop_sentinel(out)
+    buckets = check_thumbs.detect_duplicate_renders(out)
+    target = next((b for b in buckets if len(b[1]) == 3), None)
+    assert target is not None
+    suggestion = check_thumbs._suggest_root_cause(target[1], total_baked=23, thumbs_dir=out)
+    assert "orchestrator closure bug" in suggestion
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint (round-trip).
+# ---------------------------------------------------------------------------
+
+
+def test_cli_emits_default_json_report_under_thumbs_dir(tmp_path: Path) -> None:
+    out = _make_bake(tmp_path, n_unique=4, n_duplicates=0)
+    rc = check_thumbs.main([str(out)])
+    assert rc == check_thumbs.EXIT_OK
+    assert (out / JSON_REPORT_NAME).is_file()
+
+
+def test_cli_dump_stale_allowlist_runs(tmp_path: Path, capsys) -> None:
+    """`--dump-stale-allowlist` must work without a `thumbs_dir` arg."""
+    rc = check_thumbs.main(["--dump-stale-allowlist", "--release-tag", "v2026.05.0"])
+    assert rc == check_thumbs.EXIT_OK
+    out = capsys.readouterr().out
+    assert "no stale" in out.lower() or "stale" in out.lower()

--- a/bake/preview/utils/check_thumbs.py
+++ b/bake/preview/utils/check_thumbs.py
@@ -1,17 +1,33 @@
-"""CI helper: assert no baked thumb matches a known-failure fingerprint.
+"""CI helper: assert no baked thumb matches a known-failure fingerprint
+AND no two baked thumbs are byte-identical (#385).
 
 Usage:
     uv run python bake/preview/utils/check_thumbs.py <thumbs_dir>
-    # → exits 0 if all clean
-    # → exits 1 with a list of failing thumbs otherwise
+    uv run python bake/preview/utils/check_thumbs.py <thumbs_dir> --release-tag v2026.05.0
+    uv run python bake/preview/utils/check_thumbs.py <thumbs_dir> --json-out path/to/report.json
+    uv run python bake/preview/utils/check_thumbs.py --dump-stale-allowlist --release-tag v2026.05.0
 
-A baked thumb that pixel-matches one of the blank fingerprints means
-the bake silently produced a default-shaded sphere instead of the
-material's actual PBR look — i.e. a bake regression that wouldn't
-surface from per-file sanity checks alone.
+Exit codes:
+    0  pass
+    1  duplicate-bytes bucket survived the allow-list (#385)
+    2  fingerprint hit (existing matcher fired)
+    3  incomplete bake — `_bake_complete.json` sentinel missing
+    4  CLI / IO error (bad args, missing dir, malformed allow-list)
 
-Comparison uses mean per-pixel L2 distance over the 256x256 grid;
-threshold is conservative (≤2 in 0-255 scale ≈ visually identical)
+Two layers of defence:
+
+1. Per-file fingerprint match against ``bake/preview/assets/blank_default.png``
+   and ``blank_default_grey.png`` (the original DISTANCE_THRESHOLD-based check —
+   catches bakes where the renderer fell back to Three.js / pymat defaults).
+2. Cross-thumb md5 bucketing (#385) — catches scalar-collapse,
+   orchestrator closure-mixup, and texture-binding regressions where many
+   distinct materials produce the same bytes. Spike consensus: md5-only,
+   no perceptual layer (a perceptual gate low enough to catch these would
+   false on legitimately-distinct materials measured at L2≈0.08 in the
+   production substrate audit — see #385 spike).
+
+Comparison for layer 1 uses mean per-pixel L2 distance over the 256x256
+grid; threshold is conservative (≤2 in 0-255 scale ≈ visually identical)
 because SwiftShader is byte-deterministic across runs.
 
 Two fingerprints checked (see bake/preview/utils/bake_blanks.py):
@@ -28,7 +44,13 @@ Two fingerprints checked (see bake/preview/utils/bake_blanks.py):
 
 from __future__ import annotations
 
+import argparse
+import hashlib
+import json
+import logging
 import sys
+from collections import defaultdict
+from datetime import datetime, timezone
 from pathlib import Path
 
 import numpy as np
@@ -36,8 +58,26 @@ from PIL import Image
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 ASSETS = REPO_ROOT / "bake" / "preview" / "assets"
+ALLOWLIST_PATH = REPO_ROOT / "bake" / "preview" / "utils" / "thumb_check_allow.yml"
 FINGERPRINTS = ["blank_default.png", "blank_default_grey.png"]
 DISTANCE_THRESHOLD = 2.0  # mean per-pixel L2 in 0-255 scale
+SENTINEL_NAME = "_bake_complete.json"
+JSON_REPORT_NAME = "thumb-check.json"
+JSON_REPORT_VERSION = 1
+
+# Exit codes (kept module-level so tests / GHA gates can refer to them).
+EXIT_OK = 0
+EXIT_DUPLICATE = 1
+EXIT_FINGERPRINT = 2
+EXIT_NO_SENTINEL = 3
+EXIT_CLI = 4
+
+log = logging.getLogger("check-thumbs")
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint layer (existing — untouched semantics).
+# ---------------------------------------------------------------------------
 
 
 def _load_rgb(path: Path) -> np.ndarray:
@@ -53,49 +93,540 @@ def _mean_pixel_distance(a: np.ndarray, b: np.ndarray) -> float:
     return float(np.sqrt((diff * diff).sum(axis=-1)).mean())
 
 
-def check(thumbs_dir: Path) -> int:
+# ---------------------------------------------------------------------------
+# Duplicate-bytes detector (#385).
+# ---------------------------------------------------------------------------
+
+
+def _iter_baked_thumbs(thumbs_dir: Path):
+    """Yield every PNG under ``thumbs_dir`` that should be checked.
+
+    Skips the fingerprint reference assets in ``bake/preview/assets/`` (when
+    they happen to live under the scanned tree, e.g. during in-tree dev runs).
+    """
+    for png in sorted(thumbs_dir.rglob("*.png")):
+        if png.parent == ASSETS and png.name in FINGERPRINTS:
+            continue
+        yield png
+
+
+def detect_duplicate_renders(
+    thumbs_dir: Path,
+) -> list[tuple[str, list[Path]]]:
+    """Return every md5 bucket containing >1 PNG under ``thumbs_dir``.
+
+    Implementation notes:
+
+    - Pre-bucketed by file size first (cheap rejection — md5 is only run
+      against files of the same size, which is the common case for a bake
+      regression).
+    - md5 chosen over sha256 per spike consensus — collision risk is moot
+      for a few-thousand-PNG bake and the speed difference matters at scale.
+    - Allow-list filtering happens at the caller (``check``) so this stays
+      a pure detector.
+    """
+    by_size: dict[int, list[Path]] = defaultdict(list)
+    for png in _iter_baked_thumbs(thumbs_dir):
+        try:
+            by_size[png.stat().st_size].append(png)
+        except OSError as e:
+            log.warning("stat failed for %s: %s", png, e)
+
+    buckets: dict[str, list[Path]] = defaultdict(list)
+    for size, group in by_size.items():
+        if len(group) < 2:
+            # Unique file size → can't collide; skip md5 entirely.
+            continue
+        for png in group:
+            try:
+                digest = hashlib.md5(png.read_bytes()).hexdigest()  # noqa: S324
+            except OSError as e:
+                log.warning("read failed for %s: %s", png, e)
+                continue
+            buckets[digest].append(png)
+
+    return [(digest, sorted(paths)) for digest, paths in sorted(buckets.items()) if len(paths) > 1]
+
+
+def _suggest_root_cause(
+    bucket_paths: list[Path],
+    total_baked: int,
+    thumbs_dir: Path,
+) -> str:
+    """Heuristic hint for the runbook reader.
+
+    See bake/preview/utils/thumb_check_runbook.md for how to act on each.
+    """
+    count = len(bucket_paths)
+    if total_baked > 0 and count == total_baked:
+        return "scalar collapse — check substrate (empty _scalars_for? wrong --repo-id?)"
+    if count == 3:
+        prefixes = {_source_prefix(p, thumbs_dir) for p in bucket_paths}
+        if len(prefixes) == 1:
+            return "orchestrator closure bug — check _build_threejs_for in run.py"
+    if 1 < count <= 5 and total_baked > 0 and count < total_baked / 4:
+        return "texture-binding regression — check renderer / to_threejs scalar+texture merge"
+    return "unknown — see thumb_check_runbook.md"
+
+
+def _source_prefix(path: Path, thumbs_dir: Path) -> str:
+    """Top-level segment under thumbs_dir (the source name in a normal bake)."""
+    try:
+        rel = path.relative_to(thumbs_dir)
+    except ValueError:
+        return ""
+    parts = rel.parts
+    return parts[0] if parts else ""
+
+
+# ---------------------------------------------------------------------------
+# Allow-list (YAML — minimal stdlib parser; constrained schema).
+# ---------------------------------------------------------------------------
+
+REQUIRED_ALLOW_FIELDS = ("md5", "reason", "ticket", "until")
+
+
+class AllowlistError(Exception):
+    """Raised when the allow-list YAML is malformed."""
+
+
+def _parse_simple_yaml(text: str) -> dict:
+    """Minimal YAML parser for the constrained allow-list schema:
+
+        allowed:
+          - md5: "..."
+            reason: "..."
+            ticket: "..."
+            until: "..."
+
+    Supports: top-level mapping with one key whose value is a sequence of
+    mappings of scalar string values. Comments (``# ...``) and blank lines
+    are ignored. Quoted strings (single or double) and bare strings are
+    accepted. Anything else (nested mappings, multiline strings, anchors,
+    flow style) raises ``AllowlistError`` — keep the file boring.
+    """
+    result: dict = {}
+    current_seq: list | None = None
+    current_item: dict | None = None
+    seq_key: str | None = None  # noqa: F841 (tracked for error messages, future-proof)
+
+    def _strip_quotes(v: str) -> str:
+        v = v.strip()
+        if len(v) >= 2 and v[0] == v[-1] and v[0] in ('"', "'"):
+            return v[1:-1]
+        return v
+
+    for raw_lineno, raw_line in enumerate(text.splitlines(), start=1):
+        # Skip comment-only lines.
+        if raw_line.lstrip().startswith("#"):
+            continue
+        line = raw_line.rstrip()
+        if not line.strip():
+            continue
+
+        # Strip trailing inline comments only when no quotes on the line.
+        if "#" in line and '"' not in line and "'" not in line:
+            line = line.split("#", 1)[0].rstrip()
+            if not line.strip():
+                continue
+
+        # Top-level key — supports both forms:
+        #   `key:`        → opens a sequence to be filled by indented `- ...` lines
+        #   `key: []`     → explicit empty sequence (closes immediately)
+        if not line.startswith((" ", "\t")) and ":" in line:
+            top_key, _, top_val = line.partition(":")
+            top_key = top_key.strip()
+            top_val = top_val.strip()
+            if not top_val:
+                seq_key = top_key
+                current_seq = []
+                current_item = None
+                result[seq_key] = current_seq
+                continue
+            if top_val == "[]":
+                seq_key = top_key
+                current_seq = []
+                current_item = None
+                result[seq_key] = []
+                continue
+            # Any other top-level scalar / inline value isn't part of our
+            # constrained schema — be loud rather than silently drop it.
+            raise AllowlistError(
+                f"line {raw_lineno}: top-level key {top_key!r} only accepts "
+                "an empty `[]` or a sequence of mapping items below it"
+            )
+
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+
+        if current_seq is None:
+            raise AllowlistError(f"line {raw_lineno}: content before any top-level key")
+
+        # Sequence item start: "- key: value"
+        if stripped.startswith("- "):
+            current_item = {}
+            current_seq.append(current_item)
+            stripped = stripped[2:]
+            if ":" not in stripped:
+                raise AllowlistError(f"line {raw_lineno}: sequence item must start with key:value")
+            k, _, v = stripped.partition(":")
+            current_item[k.strip()] = _strip_quotes(v)
+            continue
+
+        # Continuation line of current item: "  key: value"
+        if current_item is None:
+            raise AllowlistError(f"line {raw_lineno}: indented content outside a sequence item")
+        if ":" not in stripped:
+            raise AllowlistError(f"line {raw_lineno}: expected key:value")
+        if indent < 2:
+            raise AllowlistError(f"line {raw_lineno}: continuation lines must be indented")
+        k, _, v = stripped.partition(":")
+        current_item[k.strip()] = _strip_quotes(v)
+
+    return result
+
+
+def load_allowlist(path: Path = ALLOWLIST_PATH) -> list[dict]:
+    """Return the validated list of allow-list entries.
+
+    Missing file → empty list (allow-list is optional). Malformed file →
+    AllowlistError (caller maps to exit 4).
+    """
+    if not path.exists():
+        return []
+    try:
+        data = _parse_simple_yaml(path.read_text(encoding="utf-8"))
+    except AllowlistError:
+        raise
+    except Exception as e:  # noqa: BLE001
+        raise AllowlistError(f"{path}: {e}") from e
+
+    entries = data.get("allowed", []) or []
+    if not isinstance(entries, list):
+        raise AllowlistError(f"{path}: top-level `allowed:` must be a sequence")
+
+    validated: list[dict] = []
+    for idx, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise AllowlistError(f"{path}: entry #{idx} is not a mapping")
+        missing = [f for f in REQUIRED_ALLOW_FIELDS if not entry.get(f)]
+        if missing:
+            raise AllowlistError(
+                f"{path}: entry #{idx} missing required field(s): {', '.join(missing)}"
+            )
+        md5 = entry["md5"].lower()
+        if len(md5) != 32 or not all(c in "0123456789abcdef" for c in md5):
+            raise AllowlistError(
+                f"{path}: entry #{idx} md5 must be a 32-char lowercase hex digest, got {md5!r}"
+            )
+        validated.append(
+            {
+                "md5": md5,
+                "reason": entry["reason"],
+                "ticket": entry["ticket"],
+                "until": entry["until"],
+            }
+        )
+    return validated
+
+
+def _is_stale(until: str, current_tag: str | None) -> bool:
+    """True if `until` has been reached or surpassed by `current_tag`.
+
+    Both are calver tags like ``v2026.05.0``; lexicographic compare is
+    correct for that format. When ``current_tag`` is unknown, we never
+    flag entries as stale (warning silently suppressed).
+    """
+    if not current_tag:
+        return False
+    return current_tag >= until
+
+
+# ---------------------------------------------------------------------------
+# Sentinel.
+# ---------------------------------------------------------------------------
+
+
+def _has_sentinel(thumbs_dir: Path) -> bool:
+    return (thumbs_dir / SENTINEL_NAME).is_file()
+
+
+# ---------------------------------------------------------------------------
+# Top-level check + JSON report.
+# ---------------------------------------------------------------------------
+
+
+def check(
+    thumbs_dir: Path,
+    *,
+    allowlist: list[dict] | None = None,
+    release_tag: str | None = None,
+    json_out: Path | None = None,
+    require_sentinel: bool = True,
+) -> int:
+    """Run both gates against ``thumbs_dir`` and (optionally) emit a JSON
+    report. Return one of EXIT_*.
+
+    Order matters: sentinel → fingerprint hits → duplicate buckets. The
+    most-actionable failure wins the exit code so CI logs surface the
+    right thing first.
+    """
+    if require_sentinel and not _has_sentinel(thumbs_dir):
+        msg = (
+            f"FATAL: no {SENTINEL_NAME} sentinel under {thumbs_dir} — "
+            "bake didn't complete (or run.py is older than #385)"
+        )
+        print(msg)
+        if json_out is not None:
+            _write_report(
+                json_out,
+                {
+                    "version": JSON_REPORT_VERSION,
+                    "checked": 0,
+                    "fingerprint_hits": [],
+                    "duplicate_buckets": [],
+                    "allowlisted": [],
+                    "exit_code": EXIT_NO_SENTINEL,
+                    "exit_reason": "missing_sentinel",
+                    "release_tag": release_tag,
+                    "generated_at": _now_iso(),
+                },
+            )
+        return EXIT_NO_SENTINEL
+
+    # ---- Layer 1: fingerprint match ----
     fps: dict[str, np.ndarray] = {}
     for name in FINGERPRINTS:
         p = ASSETS / name
         if not p.exists():
             print(f"FATAL: missing fingerprint {p.relative_to(REPO_ROOT)}")
             print("  run `uv run python bake/preview/utils/bake_blanks.py` to regenerate")
-            return 2
+            return EXIT_CLI
         fps[name] = _load_rgb(p)
 
-    matches: list[tuple[Path, str, float]] = []
+    fingerprint_hits: list[tuple[Path, str, float]] = []
     checked = 0
-    for thumb in sorted(thumbs_dir.rglob("*.png")):
-        # Don't check the fingerprints against themselves
-        if thumb.parent == ASSETS and thumb.name in FINGERPRINTS:
+    for thumb in _iter_baked_thumbs(thumbs_dir):
+        try:
+            thumb_arr = _load_rgb(thumb)
+        except Exception as e:  # noqa: BLE001
+            log.warning("could not load %s: %s", thumb, e)
             continue
-        thumb_arr = _load_rgb(thumb)
         checked += 1
         for fp_name, fp_arr in fps.items():
             d = _mean_pixel_distance(thumb_arr, fp_arr)
             if d <= DISTANCE_THRESHOLD:
-                matches.append((thumb, fp_name, d))
+                fingerprint_hits.append((thumb, fp_name, d))
 
-    if not matches:
-        print(f"OK — {checked} thumbs checked, none match fingerprints")
-        return 0
+    # ---- Layer 2: duplicate-bytes ----
+    raw_buckets = detect_duplicate_renders(thumbs_dir)
 
-    print(f"FAIL — {len(matches)} thumb(s) match a known-failure fingerprint:")
-    for thumb, fp_name, d in matches:
-        rel = thumb.relative_to(thumbs_dir.parent if thumbs_dir.parent.exists() else thumbs_dir)
-        print(f"  {rel}  ←  {fp_name}  (distance={d:.2f})")
-    return 1
+    allow = allowlist if allowlist is not None else load_allowlist()
+    allow_md5s = {e["md5"]: e for e in allow}
+
+    surviving: list[tuple[str, list[Path]]] = []
+    allowlisted_used: list[dict] = []
+    for digest, paths in raw_buckets:
+        entry = allow_md5s.get(digest)
+        if entry is not None:
+            allowlisted_used.append(
+                {
+                    "md5": digest,
+                    "ticket": entry["ticket"],
+                    "until": entry["until"],
+                    "count": len(paths),
+                }
+            )
+        else:
+            surviving.append((digest, paths))
+
+    # Stale-allow-list warnings (non-fatal).
+    for entry in allow:
+        if _is_stale(entry["until"], release_tag):
+            log.warning(
+                "stale allow-list entry md5=%s ticket=%s until=%s (release=%s) — drop or bump",
+                entry["md5"],
+                entry["ticket"],
+                entry["until"],
+                release_tag,
+            )
+
+    # ---- Print human-readable summary ----
+    if fingerprint_hits:
+        print(f"FAIL — {len(fingerprint_hits)} thumb(s) match a known-failure fingerprint:")
+        for thumb, fp_name, d in fingerprint_hits:
+            try:
+                rel = thumb.relative_to(thumbs_dir)
+            except ValueError:
+                rel = thumb
+            print(f"  {rel}  ←  {fp_name}  (distance={d:.2f})")
+
+    if surviving:
+        print(f"FAIL — {len(surviving)} duplicate-bytes bucket(s) detected (#385):")
+        for digest, paths in surviving:
+            suggestion = _suggest_root_cause(paths, checked, thumbs_dir)
+            print(f"  md5={digest}  count={len(paths)}  → {suggestion}")
+            for p in paths:
+                try:
+                    rel = p.relative_to(thumbs_dir)
+                except ValueError:
+                    rel = p
+                print(f"    {rel}")
+
+    if not fingerprint_hits and not surviving:
+        if allowlisted_used:
+            print(
+                f"OK — {checked} thumbs checked, "
+                f"{len(allowlisted_used)} allow-listed bucket(s) ignored, "
+                "no other duplicates or fingerprint hits"
+            )
+        else:
+            print(f"OK — {checked} thumbs checked, no duplicates, no fingerprint hits")
+
+    # ---- JSON report ----
+    if fingerprint_hits:
+        exit_code = EXIT_FINGERPRINT
+        exit_reason = "fingerprint_match"
+    elif surviving:
+        exit_code = EXIT_DUPLICATE
+        exit_reason = "duplicate_bytes"
+    else:
+        exit_code = EXIT_OK
+        exit_reason = "ok"
+
+    if json_out is not None:
+        _write_report(
+            json_out,
+            {
+                "version": JSON_REPORT_VERSION,
+                "checked": checked,
+                "fingerprint_hits": [
+                    {
+                        "path": str(_safe_rel(p, thumbs_dir)),
+                        "matches": fp_name,
+                        "rms": round(d, 4),
+                    }
+                    for p, fp_name, d in fingerprint_hits
+                ],
+                "duplicate_buckets": [
+                    {
+                        "md5": digest,
+                        "count": len(paths),
+                        "paths": [str(_safe_rel(p, thumbs_dir)) for p in paths],
+                        "suggested": _suggest_root_cause(paths, checked, thumbs_dir),
+                    }
+                    for digest, paths in surviving
+                ],
+                "allowlisted": allowlisted_used,
+                "exit_code": exit_code,
+                "exit_reason": exit_reason,
+                "release_tag": release_tag,
+                "generated_at": _now_iso(),
+            },
+        )
+
+    return exit_code
 
 
-def main() -> int:
-    if len(sys.argv) != 2:
-        print(__doc__, file=sys.stderr)
-        return 2
-    thumbs_dir = Path(sys.argv[1]).resolve()
+def _safe_rel(p: Path, base: Path) -> Path:
+    try:
+        return p.relative_to(base)
+    except ValueError:
+        return p
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _write_report(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _dump_stale_allowlist(release_tag: str | None) -> int:
+    try:
+        entries = load_allowlist()
+    except AllowlistError as e:
+        print(f"FATAL: {e}", file=sys.stderr)
+        return EXIT_CLI
+    stale = [e for e in entries if _is_stale(e["until"], release_tag)]
+    if not stale:
+        print(f"OK — no stale allow-list entries (release={release_tag or 'unknown'})")
+        return EXIT_OK
+    print(f"STALE — {len(stale)} allow-list entry(ies) at or past their `until`:")
+    for e in stale:
+        print(f"  md5={e['md5']}  ticket={e['ticket']}  until={e['until']}  reason={e['reason']}")
+    return EXIT_OK  # informational only; not a CI gate.
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("thumbs_dir", nargs="?", type=Path, help="output directory of a thumb bake")
+    parser.add_argument(
+        "--json-out",
+        type=Path,
+        default=None,
+        help=f"write structured JSON report (default: <thumbs_dir>/{JSON_REPORT_NAME})",
+    )
+    parser.add_argument(
+        "--release-tag",
+        default=None,
+        help="current dataset release tag (e.g. v2026.05.0); used to flag stale allow-list entries",
+    )
+    parser.add_argument(
+        "--no-sentinel",
+        action="store_true",
+        help="don't require _bake_complete.json (for ad-hoc audits of legacy directories)",
+    )
+    parser.add_argument(
+        "--dump-stale-allowlist",
+        action="store_true",
+        help="print allow-list entries whose `until` ≤ --release-tag and exit",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    if args.dump_stale_allowlist:
+        return _dump_stale_allowlist(args.release_tag)
+
+    if args.thumbs_dir is None:
+        parser.print_help(sys.stderr)
+        return EXIT_CLI
+
+    thumbs_dir = args.thumbs_dir.resolve()
     if not thumbs_dir.is_dir():
         print(f"FATAL: {thumbs_dir} is not a directory", file=sys.stderr)
-        return 2
-    return check(thumbs_dir)
+        return EXIT_CLI
+
+    json_out = args.json_out if args.json_out is not None else (thumbs_dir / JSON_REPORT_NAME)
+
+    try:
+        allowlist = load_allowlist()
+    except AllowlistError as e:
+        print(f"FATAL: malformed allow-list: {e}", file=sys.stderr)
+        return EXIT_CLI
+
+    return check(
+        thumbs_dir,
+        allowlist=allowlist,
+        release_tag=args.release_tag,
+        json_out=json_out,
+        require_sentinel=not args.no_sentinel,
+    )
 
 
 if __name__ == "__main__":

--- a/bake/preview/utils/derive-step-snippet.yaml
+++ b/bake/preview/utils/derive-step-snippet.yaml
@@ -1,0 +1,35 @@
+# DORMANT — paste into .github/workflows/derive.yml's `kind: thumb` job
+# once PR #403 (feature/402-derive-thumb-kind) lands. Until then, this
+# file is a code-review artefact / paper trail; nothing reads it.
+#
+# Position: AFTER the bake step that produces /tmp/thumbs, BEFORE the
+# HF upload step. The exit codes are deliberately distinct so the
+# workflow log surfaces the right failure mode (see check_thumbs.py
+# module docstring).
+#
+# Tracking issue: #385 (duplicate-bytes detector).
+
+- name: thumb-check (#385 duplicate-bytes + fingerprint gate)
+  if: ${{ inputs.kind == 'thumb' }}
+  shell: bash
+  run: |
+    set -e
+    # The check writes thumb-check.json under the bake out-dir. The
+    # exit code disambiguates failure modes:
+    #   1 = duplicate-bytes survived the allow-list (#385)
+    #   2 = fingerprint hit (default-grey leak / empty material spec)
+    #   3 = _bake_complete.json missing (bake didn't finish)
+    #   4 = CLI / IO error (bad allow-list, missing dir)
+    uv run python bake/preview/utils/check_thumbs.py \
+      /tmp/thumbs/ \
+      --release-tag "${{ inputs.release-tag }}" \
+      --json-out /tmp/thumb-check.json
+
+- name: upload thumb-check report
+  if: ${{ always() && inputs.kind == 'thumb' }}
+  uses: actions/upload-artifact@v4
+  with:
+    name: thumb-check-${{ matrix.source }}
+    path: /tmp/thumb-check.json
+    if-no-files-found: warn
+    retention-days: 30

--- a/bake/preview/utils/thumb_check_allow.yml
+++ b/bake/preview/utils/thumb_check_allow.yml
@@ -1,0 +1,24 @@
+# Duplicate-bytes allow-list for `check_thumbs.py` (#385).
+#
+# When the duplicate-bytes detector flags an md5 bucket that is genuinely
+# legitimate (two upstream entries that ARE the same material, deduped
+# post-bake; or a known scalar-only collapse that ops have triaged and
+# decided to ship), add the digest here so CI can stay green.
+#
+# Each entry MUST have all four fields:
+#
+#   md5     — the exact 32-char lowercase hex digest from the failing CI run
+#   reason  — short prose explaining WHY this dedup is legitimate
+#   ticket  — issue / PR ref where the substrate-side dedup is tracked
+#   until   — release tag at which this entry expires; once `release_tag` ≥
+#             `until`, the gate logs a warning (non-fatal) so ops know to
+#             drop or bump the entry
+#
+# `python check_thumbs.py --dump-stale-allowlist --release-tag v2026.05.0`
+# audits which entries have aged out.
+#
+# Schema is parsed by a constrained YAML subset (see check_thumbs.py
+# ``_parse_simple_yaml``): top-level mapping → sequence → flat mapping of
+# scalar string values. No nesting, no anchors, no flow style.
+
+allowed: []

--- a/bake/preview/utils/thumb_check_runbook.md
+++ b/bake/preview/utils/thumb_check_runbook.md
@@ -1,0 +1,111 @@
+# Thumb-check gate — operator runbook (#385)
+
+When the thumb-check CI gate fails, follow these steps. The gate is
+`bake/preview/utils/check_thumbs.py`. It runs after every thumb bake
+and BEFORE the HF upload step (so a failed gate prevents bad data
+from reaching the dataset).
+
+## 1. Download the JSON artifact
+
+The CI step uploads `thumb-check.json` as an artifact (default name
+`thumb-check-report-<source>`). Download it from the failed run's
+**Summary → Artifacts** section. It looks like:
+
+```json
+{
+  "version": 1,
+  "checked": 5247,
+  "fingerprint_hits": [...],
+  "duplicate_buckets": [...],
+  "allowlisted": [...],
+  "exit_code": 1,
+  "exit_reason": "duplicate_bytes",
+  "release_tag": "v2026.05.0",
+  "generated_at": "2026-05-11T..."
+}
+```
+
+## 2. Branch on `exit_code`
+
+### exit 3 — `_bake_complete.json` missing
+
+Bake didn't complete. The detector refuses to validate a partial
+directory because some byte-duplicates that would otherwise show up
+in a complete bake might be missing.
+
+- Check the bake step logs above the gate step.
+- Common causes: Playwright timeout, OOM in the renderer, a Three.js
+  JS error caught by `main().catch()` in `thumb_render.html`.
+- Fix the bake → re-run.
+
+### exit 2 — fingerprint hit
+
+One or more thumbs match `blank_default.png` or `blank_default_grey.png`:
+
+- `blank_default.png` → renderer ran with an empty material spec
+  (Three.js `MeshPhysicalMaterial` defaults). Likely the substrate is
+  empty for that material → check `client._scalars_for(source, mid)`
+  and confirm `--repo-id` resolved to the expected HF dataset.
+- `blank_default_grey.png` → pymat `_PBR_DEFAULTS` (`#CCCCCC`,
+  metalness=0, roughness=0.5) leaked through. The substrate catalog
+  is stale or pymat is being consulted as a fallback. See #285 / #376.
+
+This is the same gate that has shipped since the original
+`check_thumbs.py`; fix the substrate, re-bake.
+
+### exit 1 — duplicate bytes
+
+Two or more thumbs hashed to the same md5. Read the
+`duplicate_buckets[].suggested` field — the heuristic suggests where
+to look first:
+
+| Suggested string                                   | Likely root cause                                                                                       |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `scalar collapse — check substrate`                | `count == total_baked` — every thumb is identical. `_scalars_for` returns `{}` for every material, or `--repo-id` points at an empty dataset. |
+| `orchestrator closure bug — check _build_threejs_for` | `count == 3` AND all paths share a single source. Closure / loop variable mixup in `bake/preview/run.py`. The original #385 trigger. |
+| `texture-binding regression`                       | Small bucket (2–5) but several distinct buckets across the bake. Renderer scalars differ but textures don't bind, so materials reduce to scalar-only. Check `thumb_render.html` material assembly. |
+| `unknown`                                          | Inspect the paths manually. Often a small natural dedup (e.g. two upstream entries of the same material). If legitimate, allow-list it (step 3 below). |
+
+### exit 0 — pass
+
+Done. No action needed. (If `allowlisted` is non-empty, the gate did
+trip but allow-list entries absorbed the buckets — review them
+periodically with `--dump-stale-allowlist`.)
+
+## 3. Legitimate dedup → add an allow-list entry
+
+Some dedups are real: two upstream entries that ARE the same material
+under different names, an ops-decision to ship a substrate gap as
+scalar-only and ship the same render N times, etc.
+
+Edit `bake/preview/utils/thumb_check_allow.yml`:
+
+```yaml
+allowed:
+  - md5: "<the digest from duplicate_buckets[].md5>"
+    reason: "Two upstream entries gpuopen/Foo and gpuopen/Foo_Variant are the same material; substrate dedup tracked in #999"
+    ticket: "#999"
+    until: "v2026.06.0"   # release tag at which this entry expires
+```
+
+All four fields are required — the loader rejects entries missing any.
+The `until` field is a soft expiry: once the dataset's `release_tag`
+catches up, the gate logs a warning (non-fatal) and ops should drop or
+bump the entry.
+
+## 4. Audit stale allow-list entries
+
+Periodically (e.g. before a release):
+
+```sh
+uv run python bake/preview/utils/check_thumbs.py \
+  --dump-stale-allowlist --release-tag v2026.05.0
+```
+
+Prints (and exits 0) every entry whose `until` is at or below the
+current tag. Drop or bump them.
+
+## 5. Re-run
+
+Once you've fixed the root cause (or added the allow-list entry),
+re-dispatch the failed workflow.


### PR DESCRIPTION
## Summary

Adds a sibling check to `bake/preview/utils/check_thumbs.py` that buckets every baked PNG by md5 (with file-size pre-filter) and fails when any bucket has size > 1 — catches scalar-collapse, orchestrator closure-mixup (the original #385 trigger), and texture-binding regressions that the per-file fingerprint matcher cannot reach.

Spike consensus (3-reviewer): **md5-only, no perceptual layer**. Decisive evidence: the production substrate audit measured `physicallybased/plastic_(pet)` vs `physicallybased/water` at L2 ≈ 0.08 between *distinct* materials — already below the existing `DISTANCE_THRESHOLD = 2.0`. Any cross-thumb perceptual gate low enough to catch the #385 trigger would false on the same pair the per-file gate deems indistinguishable.

## What's in this PR

- `bake/preview/utils/check_thumbs.py` — extended with `detect_duplicate_renders()`, allow-list loader, sentinel gate, JSON report, suggested-cause heuristic, exit-code taxonomy.
- `bake/preview/utils/thumb_check_allow.yml` — empty allow-list with documented schema (md5 / reason / ticket / until required).
- `bake/preview/utils/thumb_check_runbook.md` — operator runbook keyed off the JSON report's `exit_code`.
- `bake/preview/utils/derive-step-snippet.yaml` — **dormant** GHA step (see Coordination below).
- `bake/preview/run.py` — writes `_bake_complete.json` sentinel after a successful bake; passes `--release-tag` through to the checker.
- `bake/preview/tests/test_check_thumbs.py` — 19 synthetic tests covering all four exit codes, allow-list happy / sad paths, stale-entry warning, suggested-cause heuristic, CLI round-trip.

### Exit-code taxonomy

- `0` ok
- `1` duplicate-bytes bucket survived the allow-list (#385)
- `2` fingerprint hit (pre-existing matcher)
- `3` incomplete bake — `_bake_complete.json` sentinel missing
- `4` CLI / IO error (malformed allow-list, missing dir, …)

### Sample report (real data)

`uv run python bake/preview/utils/check_thumbs.py /tmp/thumb-bench/out/random-samples/_flat/ --no-sentinel --release-tag v2026.05.0` against 32 real distinct random samples:

```json
{
  "version": 1,
  "checked": 32,
  "duplicate_buckets": [],
  "fingerprint_hits": [],
  "allowlisted": [],
  "exit_code": 0,
  "exit_reason": "ok",
  "release_tag": "v2026.05.0"
}
```

Zero false positives — meets the acceptance criterion.

## Coordination with #403

PR #403 (`feature/402-derive-thumb-kind`) adds the `kind: thumb` job to `.github/workflows/derive.yml` but hasn't merged. This PR is branched off `dev`, so it can't add a step to a job that doesn't exist yet. The GHA step lives **dormant** at `bake/preview/utils/derive-step-snippet.yaml` and gets pasted into `derive.yml` once #403 lands (separate follow-up commit). This keeps the two PRs independently mergeable.

## Constraints honoured

- Pure stdlib + PIL (no `imagehash`, no `scikit-image`, no new numpy usage in the duplicate detector).
- The existing fingerprint-matching code is untouched (semantics preserved, docstring updated).
- All tests use synthetic PNGs in tmpdirs (no network, no Playwright).

## Test plan

- [x] `pytest bake/preview/tests/test_check_thumbs.py` — 19 passed locally
- [x] `ruff check bake/preview/` — clean
- [x] `ruff format --check bake/preview/utils/check_thumbs.py bake/preview/tests/test_check_thumbs.py bake/preview/run.py` — clean
- [x] CLI exits 1 on synthetic byte-identical PNGs (verified)
- [x] CLI exits 0 against `/tmp/thumb-bench/out/random-samples/_flat/` (32 real distinct samples)
- [ ] CI green on `dev` PR
- [ ] auto-merge fires