### PR TITLE
refactor(baker): parallelize per-channel derive transcoding (#418)

### DIFF
--- a/src/mat_vis_baker/hf_derive_per_file.py
+++ b/src/mat_vis_baker/hf_derive_per_file.py
@@ -37,9 +37,11 @@ and ``shard_utils`` entirely, and ADR-0012 forbids reintroducing them.
 
 from __future__ import annotations
 
+import concurrent.futures
 import io
 import json
 import logging
+import os
 import subprocess
 import tempfile
 import time
@@ -325,6 +327,70 @@ def _all_target_files_present(
     return True
 
 
+def _derive_one_channel(
+    *,
+    repo_id: str,
+    release_tag: str,
+    source: str,
+    source_tier: str,
+    target_tier: str,
+    material_id: str,
+    channel: str,
+    transform: Callable[[bytes], bytes],
+    target_ext: str,
+    token: str | None,
+) -> CommitOperationAdd | None:
+    """Fetch + verify + transform + verify a single channel. Returns the
+    ``CommitOperationAdd`` op on success, or ``None`` on any per-channel
+    failure (the caller treats ``None`` as "skip this channel"). Errors
+    are logged at WARNING — preserving the contract that one bad channel
+    never kills its siblings.
+
+    Extracted from :func:`_derive_one_material` in #418 so the
+    ``ThreadPoolExecutor`` worker has a clean per-channel unit of work.
+    Threads are safe here: ``toktx`` runs as a 1-core subprocess (no GIL
+    contention during the wait) and PIL releases the GIL inside the C
+    extension for resize / encode."""
+    src_url = _resolve_url(
+        repo_id, release_tag, f"{source}/{source_tier}/{material_id}/{channel}.png"
+    )
+    try:
+        raw = _http_get(src_url, token=token)
+    except Exception as e:  # noqa: BLE001
+        log.warning("%s/%s/%s: source GET failed: %s", source, material_id, channel, e)
+        return None
+
+    # Magic-byte verify the source bytes — catches HTML 404 pages
+    # served as 200 on misconfigured tags.
+    try:
+        _verify_png(raw, where=f"source {source}/{source_tier}/{material_id}/{channel}.png")
+    except RuntimeError as e:
+        log.warning("%s", e)
+        return None
+
+    try:
+        out = transform(raw)
+    except Exception as e:  # noqa: BLE001
+        log.warning("%s/%s/%s: transform failed: %s", source, material_id, channel, e)
+        return None
+
+    # Magic-byte verify the produced bytes (PNG for resize, KTX2 for
+    # transcode). Refuses to commit malformed output.
+    try:
+        if target_ext == "png":
+            _verify_png(out, where=f"derived {source}/{target_tier}/{material_id}/{channel}.png")
+        elif target_ext == "ktx2":
+            _verify_ktx2(out, where=f"derived {source}/{target_tier}/{material_id}/{channel}.ktx2")
+    except RuntimeError as e:
+        log.warning("%s", e)
+        return None
+
+    return CommitOperationAdd(
+        path_in_repo=f"{source}/{target_tier}/{material_id}/{channel}.{target_ext}",
+        path_or_fileobj=out,
+    )
+
+
 def _derive_one_material(
     *,
     repo_id: str,
@@ -338,51 +404,58 @@ def _derive_one_material(
     target_ext: str,
     token: str | None,
 ) -> list[CommitOperationAdd]:
-    """Fetch + transform every channel. Returns the list of
+    """Fetch + transform every channel in parallel. Returns the list of
     ``CommitOperationAdd`` ops for this material; empty if every channel
-    fetch or transform failed (caller treats as material-level failure)."""
+    fetch or transform failed (caller treats as material-level failure).
+
+    #418: channels are processed concurrently via
+    :class:`concurrent.futures.ThreadPoolExecutor` — each worker does
+    the full per-channel fetch → verify → transform → verify sequence.
+    ``toktx`` is a 1-core subprocess so threads (rather than processes)
+    suffice: while one channel waits on ``toktx``/HTTP the others can
+    make progress. ``max_workers`` is capped at ``os.cpu_count()`` so
+    we don't fork-bomb a 4-core GHA runner with 7 simultaneous
+    ``toktx`` invocations.
+
+    Ops are sorted by ``path_in_repo`` before return — finish order is
+    non-deterministic under parallelism, but downstream content-drift
+    and ordering tests benefit from a stable commit shape."""
+    if not channels:
+        return []
+
+    max_workers = min(os.cpu_count() or 4, len(channels))
     ops: list[CommitOperationAdd] = []
-    for ch in channels:
-        src_url = _resolve_url(
-            repo_id, release_tag, f"{source}/{source_tier}/{material_id}/{ch}.png"
-        )
-        try:
-            raw = _http_get(src_url, token=token)
-        except Exception as e:  # noqa: BLE001
-            log.warning("%s/%s/%s: source GET failed: %s", source, material_id, ch, e)
-            continue
-
-        # Magic-byte verify the source bytes — catches HTML 404 pages
-        # served as 200 on misconfigured tags.
-        try:
-            _verify_png(raw, where=f"source {source}/{source_tier}/{material_id}/{ch}.png")
-        except RuntimeError as e:
-            log.warning("%s", e)
-            continue
-
-        try:
-            out = transform(raw)
-        except Exception as e:  # noqa: BLE001
-            log.warning("%s/%s/%s: transform failed: %s", source, material_id, ch, e)
-            continue
-
-        # Magic-byte verify the produced bytes (PNG for resize, KTX2 for
-        # transcode). Refuses to commit malformed output.
-        try:
-            if target_ext == "png":
-                _verify_png(out, where=f"derived {source}/{target_tier}/{material_id}/{ch}.png")
-            elif target_ext == "ktx2":
-                _verify_ktx2(out, where=f"derived {source}/{target_tier}/{material_id}/{ch}.ktx2")
-        except RuntimeError as e:
-            log.warning("%s", e)
-            continue
-
-        ops.append(
-            CommitOperationAdd(
-                path_in_repo=f"{source}/{target_tier}/{material_id}/{ch}.{target_ext}",
-                path_or_fileobj=out,
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = [
+            pool.submit(
+                _derive_one_channel,
+                repo_id=repo_id,
+                release_tag=release_tag,
+                source=source,
+                source_tier=source_tier,
+                target_tier=target_tier,
+                material_id=material_id,
+                channel=ch,
+                transform=transform,
+                target_ext=target_ext,
+                token=token,
             )
-        )
+            for ch in channels
+        ]
+        for fut in concurrent.futures.as_completed(futures):
+            # Per-channel errors are swallowed inside _derive_one_channel
+            # (logged + return None). Any exception bubbling here would
+            # be a programmer error, not a per-channel failure — let it
+            # propagate so we don't silently commit partial materials.
+            op = fut.result()
+            if op is not None:
+                ops.append(op)
+
+    # Deterministic ordering: sort by path_in_repo so the committed
+    # batch is independent of which worker finished first. Downstream
+    # content-drift tests pin path order; the sort costs O(k log k)
+    # for k≤7 channels — negligible vs. a single toktx invocation.
+    ops.sort(key=lambda op: op.path_in_repo)
     return ops
 
 

--- a/tests/test_hf_derive_per_file.py
+++ b/tests/test_hf_derive_per_file.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import io
 import json
+import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -25,6 +26,7 @@ import pytest
 from PIL import Image
 
 from mat_vis_baker.hf_derive_per_file import (
+    _derive_one_material,
     _extend_available_tiers,
     _resize_png,
     derive_ktx2_tier,
@@ -783,4 +785,130 @@ class TestDeriveBytesAwareBatching:
         # 3 unskipped → batch_size=2 → 2+1 → 2 texture commits.
         assert len(texture_calls) == 2, (
             f"expected 2 texture commits across 3 unskipped materials; got {len(texture_calls)}"
+        )
+
+
+# ── #418: parallel per-channel transcoding ─────────────────────────
+
+
+class TestDeriveOneMaterialParallel:
+    """#418 — :func:`_derive_one_material` runs channels concurrently
+    via :class:`concurrent.futures.ThreadPoolExecutor` and sorts ops by
+    ``path_in_repo`` before returning. Threads collect ops or ``None``;
+    a per-channel failure does not propagate to siblings."""
+
+    _COMMON_KW = dict(
+        repo_id="gerchowl/mat-vis-tst",
+        release_tag="v0.0.0-test",
+        source="polyhaven",
+        source_tier="1k",
+        target_tier="512",
+        material_id="mat_0",
+        target_ext="png",
+        token=None,
+    )
+
+    def test_derive_one_material_parallel_ordering(self) -> None:
+        """Channels with randomised per-channel sleep finish in arbitrary
+        order, but the returned ops MUST be sorted by ``path_in_repo``
+        for deterministic batch shape downstream."""
+        import random
+        import threading
+
+        channels = ["color", "normal", "roughness", "metalness", "ao"]
+
+        # Distinct PNG bytes per channel — magic-byte verify expects PNG;
+        # we let transform return KTX2-bytes-shaped output isn't needed
+        # because target_ext='png' triggers the PNG re-verify path.
+        png_per_channel = {ch: _make_png(8 + i) for i, ch in enumerate(channels)}
+
+        def _get(url, *, token=None, timeout=120):  # noqa: ARG001
+            # URL ends in /<channel>.png — extract.
+            ch = url.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+            return png_per_channel[ch]
+
+        finish_order: list[str] = []
+        finish_lock = threading.Lock()
+
+        def _transform(raw: bytes) -> bytes:
+            # Random per-channel sleep guarantees non-deterministic
+            # finish order. Bounded so the suite stays fast.
+            time.sleep(random.uniform(0.01, 0.05))
+            # Return PNG-magic bytes so the post-transform verify passes.
+            with finish_lock:
+                finish_order.append(raw[:1].hex())
+            return PNG_MAGIC + raw[:8]
+
+        with patch("mat_vis_baker.hf_derive_per_file._http_get", side_effect=_get):
+            ops = _derive_one_material(channels=channels, transform=_transform, **self._COMMON_KW)
+
+        # All 5 channels produced an op.
+        assert len(ops) == 5
+        # Path order: sorted by path_in_repo regardless of worker finish order.
+        paths = [op.path_in_repo for op in ops]
+        assert paths == sorted(paths), (paths, finish_order)
+        # And specifically these are the canonical sorted paths.
+        expected = sorted(f"polyhaven/512/mat_0/{ch}.png" for ch in channels)
+        assert paths == expected
+
+    def test_derive_one_material_per_channel_failure_isolated(self) -> None:
+        """One channel's GET raises → that op is dropped, the other
+        N-1 channels still produce ops. Exception must NOT propagate."""
+        import time as _time
+
+        channels = ["color", "normal", "roughness", "metalness", "ao"]
+        png = _make_png(16)
+
+        def _get(url, *, token=None, timeout=120):  # noqa: ARG001
+            if url.endswith("/normal.png"):
+                raise RuntimeError("simulated source GET failure for normal")
+            return png
+
+        def _transform(raw: bytes) -> bytes:
+            _time.sleep(0.005)
+            return PNG_MAGIC + raw[:8]
+
+        with patch("mat_vis_baker.hf_derive_per_file._http_get", side_effect=_get):
+            ops = _derive_one_material(channels=channels, transform=_transform, **self._COMMON_KW)
+
+        # 5 channels, 1 failed → 4 ops.
+        assert len(ops) == 4
+        paths = {op.path_in_repo for op in ops}
+        assert "polyhaven/512/mat_0/normal.png" not in paths
+        # Siblings landed.
+        assert "polyhaven/512/mat_0/color.png" in paths
+        assert "polyhaven/512/mat_0/roughness.png" in paths
+
+    def test_derive_one_material_parallel_wall_time(self) -> None:
+        """Sanity bench (P1 from #418): N=5 channels × 0.3s per channel
+        runs in sub-linear wall time. With 4 workers we expect ~2 waves
+        (4 + 1) ≈ 0.6s + overhead — comfortably under the 5 × 0.3 = 1.5s
+        serial baseline. Asserts wall < N×t/2 with generous margin."""
+        import time as _time
+
+        channels = ["color", "normal", "roughness", "metalness", "ao"]
+        png = _make_png(16)
+        per_channel_sleep = 0.3
+
+        def _get(url, *, token=None, timeout=120):  # noqa: ARG001
+            return png
+
+        def _transform(raw: bytes) -> bytes:
+            _time.sleep(per_channel_sleep)
+            return PNG_MAGIC + raw[:8]
+
+        with patch("mat_vis_baker.hf_derive_per_file._http_get", side_effect=_get):
+            t0 = _time.monotonic()
+            ops = _derive_one_material(channels=channels, transform=_transform, **self._COMMON_KW)
+            wall = _time.monotonic() - t0
+
+        assert len(ops) == 5
+        serial_baseline = len(channels) * per_channel_sleep  # 1.5s
+        # Sub-linear bar: parallel run must be strictly under half the
+        # serial baseline. On a typical >=2-core machine this clears
+        # easily (~0.6-0.7s). If CI runs on a single-core container the
+        # margin may bite — bump max_workers logic, not this assertion.
+        assert wall < serial_baseline / 2, (
+            f"wall={wall:.3f}s, serial baseline={serial_baseline:.3f}s — "
+            f"expected sub-linear (<{serial_baseline / 2:.3f}s)"
         )


### PR DESCRIPTION
Closes #418.

## Summary

- Wrap the per-channel loop in `_derive_one_material` with a `concurrent.futures.ThreadPoolExecutor` so the ~5 channels per material fetch + verify + transform + verify concurrently instead of serially.
- `toktx` is a 1-core subprocess and PIL releases the GIL inside its C extensions, so threads (no process pool) suffice; `max_workers = min(os.cpu_count(), len(channels))` keeps us off the fork-bomb path on 4-core GHA runners.
- Extracted `_derive_one_channel` helper as the worker unit — preserves the existing per-channel `try/except` semantics by swallowing + logging errors and returning `None`; the parent merges only surviving ops.
- Ops are sorted by `path_in_repo` before return so the committed batch shape is independent of which worker finished first (downstream content-drift / ordering tests pin path order).
- Outer `_derive_driver` material loop stays serial-by-design — #228 batching invariants live there.

## Wall-time bench

5 channels x 0.3s synthetic transform (14-core mac, `test_derive_one_material_parallel_wall_time`):

| variant            | wall   | speedup |
|--------------------|--------|---------|
| serial baseline    | 1.500s | 1.0x    |
| parallel (this PR) | 0.307s | 4.9x    |

On 4-core GHA runners the worker count caps at CPU count, so expected speedup is ~3.5-4x — matching #418's projection. Extrapolating from the production numbers in #418, ambientcg ktx2-1k drops from ~14h (timeout @ 5h51m) to ~3.5h, comfortably under the 350-min job budget.

## Test plan

- [x] `tests/test_hf_derive_per_file.py` — 24/24 pass (3 new tests).
- [x] Full `tests/` suite — 667 passed, 20 skipped.
- New tests:
  - `test_derive_one_material_parallel_ordering` — random per-channel sleeps guarantee non-deterministic finish order; asserts returned ops are sorted by `path_in_repo`.
  - `test_derive_one_material_per_channel_failure_isolated` — one channel's GET raises; siblings' ops still land (N-1 returned, no propagated exception).
  - `test_derive_one_material_parallel_wall_time` — sanity bench, asserts wall time is strictly under half the serial baseline.
- [ ] Re-dispatch `bake.yml` ktx2-1k for ambientcg on a tst tag; expect completion ~3.5h.

## Notes

- Branch named `refactor/...` because the repo's `branch-name` pre-commit hook does not include `perf` in its allowlist (the task brief proposed `perf/` but the hook rejected it; `refactor` is the closest semantic match in the allowlist).