### PR TITLE
chore: add .envrc for anvil-dev fabric integration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,3 +5,8 @@ fi
 
 nix_direnv_manual_reload
 use flake . --no-pure-eval --accept-flake-config
+
+# Substrate-backed model/dataset cache (anvil-dev only) — keeps
+# vm-devs rootfs slim and shares the cache with vm-runner CI.
+# HF_HOME is already exported globally via PAM session vars.
+[[ -d /srv/anvil/caches ]] && export MAT_VIS_CACHE=/srv/anvil/caches/mat-vis


### PR DESCRIPTION
## Why

Lars runs Claude Code agents on `anvil-dev` (NixOS microVM, see [gerchowl/anvil](https://github.com/gerchowl/anvil) ADR-020). The fabric exports a set of env vars via PAM (`STRATA_DATA_DIR`, `SCCACHE_DIR`, `HF_HOME`, …) that every shell on vm-dev inherits — including agent subshells.

This PR adds a `.envrc` so direnv auto-loads project-specific bindings when you `cd` into the repo on vm-dev.

## What changes

Route MAT_VIS_CACHE into anvil-dev substrate (/srv/anvil/caches/mat-vis) so model/dataset downloads dont fill vm-devs rootfs. Guarded — no-op on non-anvil hosts.

## Activation

Run `direnv allow` once per checkout to enable. On non-anvil hosts (Mac, CI), guarded exports stay unset and code falls back to its existing defaults — zero behaviour change for non-anvil users.