### PR TITLE
feat(docs+baker): catalog gallery v2 + transmissive thumb fix + studio HDRI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 bake/preview/assets/*.glb filter=lfs diff=lfs merge=lfs -text
+bake/preview/assets/*.hdr filter=lfs diff=lfs merge=lfs -text

--- a/bake/preview/assets/studio_small_09_2k.hdr
+++ b/bake/preview/assets/studio_small_09_2k.hdr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36724313c0fc66dab126ff90f081b85a0b1ef47be65eda1417bd20b033f0573f
+size 6312947

--- a/bake/preview/run.py
+++ b/bake/preview/run.py
@@ -45,6 +45,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 ASSETS = REPO_ROOT / "bake" / "preview" / "assets"
 THUMB_HTML = REPO_ROOT / "bake" / "preview" / "thumb_render.html"
 SHADER_BALL = ASSETS / "shader_ball.glb"
+STUDIO_HDRI = ASSETS / "studio_small_09_2k.hdr"
 CHECK_THUMBS = REPO_ROOT / "bake" / "preview" / "utils" / "check_thumbs.py"
 
 # Default sources to bake. Order matters only for log readability.
@@ -209,6 +210,7 @@ def main():
         # Serve the renderer + GLB + per-spec JSONs from a single dir.
         shutil.copy(THUMB_HTML, tmpdir / "thumb_render.html")
         shutil.copy(SHADER_BALL, tmpdir / "shader_ball.glb")
+        shutil.copy(STUDIO_HDRI, tmpdir / "studio_small_09_2k.hdr")
 
         with _file_server(tmpdir) as server_url, sync_playwright() as pw:
             browser = pw.chromium.launch(headless=True, args=["--use-gl=swiftshader"])

--- a/bake/preview/tests/layered/conftest.py
+++ b/bake/preview/tests/layered/conftest.py
@@ -42,6 +42,7 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 PREVIEW_DIR = REPO_ROOT / "bake" / "preview"
 THUMB_HTML = PREVIEW_DIR / "thumb_render.html"
 SHADER_BALL = PREVIEW_DIR / "assets" / "shader_ball.glb"
+STUDIO_HDRI = PREVIEW_DIR / "assets" / "studio_small_09_2k.hdr"
 OUTPUT_DIR = Path(__file__).parent / "output"
 
 # Test substrate (CalVer test release, full 4-source coverage). The
@@ -97,6 +98,7 @@ def layered_tmpdir():
         # and ``http://server/shader_ball.glb`` resolve.
         shutil.copy(THUMB_HTML, tmpdir / "thumb_render.html")
         shutil.copy(SHADER_BALL, tmpdir / "shader_ball.glb")
+        shutil.copy(STUDIO_HDRI, tmpdir / "studio_small_09_2k.hdr")
         yield tmpdir
 
 

--- a/bake/preview/tests/layered/render_helpers.py
+++ b/bake/preview/tests/layered/render_helpers.py
@@ -361,7 +361,14 @@ def _renderer_scalars_from_lookup(raw: dict) -> dict:
     spec: dict = {}
     if "color_hex" in raw and raw["color_hex"]:
         spec["color"] = raw["color_hex"]
-    for key in ("metalness", "roughness", "ior", "transmission", "clearcoat"):
+    for key in (
+        "metalness", "roughness", "ior", "transmission", "thickness",
+        "dispersion", "clearcoat", "clearcoat_roughness",
+        "specularIntensity", "specularColor",
+        "sheen", "sheenColor", "sheenRoughness",
+        "iridescence", "iridescenceIOR", "iridescenceThicknessRange",
+        "emissiveIntensity",
+    ):
         if raw.get(key) is not None:
             spec[key] = raw[key]
     if raw.get("emissive") is not None:

--- a/bake/preview/tests/layered/render_helpers.py
+++ b/bake/preview/tests/layered/render_helpers.py
@@ -361,16 +361,29 @@ def _renderer_scalars_from_lookup(raw: dict) -> dict:
     spec: dict = {}
     if "color_hex" in raw and raw["color_hex"]:
         spec["color"] = raw["color_hex"]
+    # Raw scalar keys are snake_case from the substrate; the Three.js
+    # renderer expects camelCase. Map the keys that differ.
+    _RAW_TO_THREEJS = {
+        "clearcoat_roughness": "clearcoatRoughness",
+        "specular_intensity": "specularIntensity",
+        "specular_color": "specularColor",
+        "sheen_color": "sheenColor",
+        "sheen_roughness": "sheenRoughness",
+        "iridescence_ior": "iridescenceIOR",
+        "iridescence_thickness": "iridescenceThicknessRange",
+        "emissive_intensity": "emissiveIntensity",
+    }
     for key in (
         "metalness", "roughness", "ior", "transmission", "thickness",
         "dispersion", "clearcoat", "clearcoat_roughness",
-        "specularIntensity", "specularColor",
-        "sheen", "sheenColor", "sheenRoughness",
-        "iridescence", "iridescenceIOR", "iridescenceThicknessRange",
-        "emissiveIntensity",
+        "specular_intensity", "specular_color",
+        "sheen", "sheen_color", "sheen_roughness",
+        "iridescence", "iridescence_ior", "iridescence_thickness",
+        "emissive_intensity",
     ):
-        if raw.get(key) is not None:
-            spec[key] = raw[key]
+        val = raw.get(key)
+        if val is not None:
+            spec[_RAW_TO_THREEJS.get(key, key)] = val
     if raw.get("emissive") is not None:
         spec["emissive"] = list(raw["emissive"])
     return spec

--- a/bake/preview/tests/test_visual_regression.py
+++ b/bake/preview/tests/test_visual_regression.py
@@ -68,6 +68,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 BAKE_PREVIEW = REPO_ROOT / "bake" / "preview"
 THUMB_HTML = BAKE_PREVIEW / "thumb_render.html"
 SHADER_BALL = BAKE_PREVIEW / "assets" / "shader_ball.glb"
+STUDIO_HDRI = BAKE_PREVIEW / "assets" / "studio_small_09_2k.hdr"
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -175,6 +176,7 @@ def serve_dir(tmp_path_factory):
     d = tmp_path_factory.mktemp("visual_serve")
     shutil.copy(THUMB_HTML, d / "thumb_render.html")
     shutil.copy(SHADER_BALL, d / "shader_ball.glb")
+    shutil.copy(STUDIO_HDRI, d / "studio_small_09_2k.hdr")
     return d
 
 

--- a/bake/preview/thumb_render.html
+++ b/bake/preview/thumb_render.html
@@ -10,13 +10,13 @@
 <script type="module">
 import * as THREE from 'three';
 import {GLTFLoader} from 'three/addons/loaders/GLTFLoader.js';
-import {RoomEnvironment} from 'three/addons/environments/RoomEnvironment.js';
+import {RGBELoader} from 'three/addons/loaders/RGBELoader.js';
 
 // Single-material thumb renderer (mat-vis#361). Matches bernhard's
 // reference scene from mat-vis#285 ("should look like" image):
 //   geometry  = create_shader_ball (vendored shader_ball.glb)
-//   bg        = 0x1a1a2e (dark navy)
-//   IBL       = RoomEnvironment via PMREM
+//   bg        = 0x1a1a2e (dark navy); env bg for transmissive materials
+//   IBL       = studio_small_09_2k.hdr (Poly Haven CC0) via PMREM
 //   tone-map  = ACES Filmic, exposure 1.0
 //   layout    = single shader ball, framed tight for 256² output
 //
@@ -55,10 +55,8 @@ renderer.toneMappingExposure = 1.0;
 renderer.outputColorSpace = THREE.SRGBColorSpace;
 document.body.appendChild(renderer.domElement);
 
-const pmrem = new THREE.PMREMGenerator(renderer);
-scene.environment = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
-
 // Lighting: copied from three-cad-viewer's RENDER_DEFAULTS.
+// Kept alongside the HDRI IBL for fill + specular highlight.
 scene.add(new THREE.AmbientLight(0xffffff, 1.0));
 const dir = new THREE.DirectionalLight(0xffffff, 1.1);
 dir.position.set(20, 30, 20);
@@ -145,13 +143,29 @@ async function main() {
   const threejs = raw.threejs || (raw.items && raw.items[0] && raw.items[0].threejs);
   if (!threejs) throw new Error('spec missing threejs material dict');
 
-  // Load shader ball GLB once. build123d uses meters; scale m→mm.
-  // build123d's export_gltf already converts its Z-up to glTF/Three.js
-  // Y-up convention — DO NOT add a manual rotation (was a bug; matches
-  // pymat's visual_render.html which also only scales without rotating).
-  const gltf = await new Promise((resolve, reject) => {
-    new GLTFLoader().load('shader_ball.glb', resolve, undefined, reject);
-  });
+  // Load HDRI + shader ball GLB in parallel. The HDRI provides
+  // higher-frequency specular content than the procedural RoomEnvironment
+  // (ADR-0014 P1) and is essential for transmissive materials where
+  // the environment is visible through the glass.
+  const pmrem = new THREE.PMREMGenerator(renderer);
+  const [hdrTexture, gltf] = await Promise.all([
+    new Promise((resolve, reject) => {
+      new RGBELoader().load('studio_small_09_2k.hdr', resolve, undefined, reject);
+    }),
+    new Promise((resolve, reject) => {
+      new GLTFLoader().load('shader_ball.glb', resolve, undefined, reject);
+    }),
+  ]);
+
+  const envMap = pmrem.fromEquirectangular(hdrTexture).texture;
+  hdrTexture.dispose();
+  pmrem.dispose();
+  scene.environment = envMap;
+
+  // build123d uses meters; scale m→mm. build123d's export_gltf already
+  // converts its Z-up to glTF/Three.js Y-up convention — DO NOT add a
+  // manual rotation (was a bug; matches pymat's visual_render.html
+  // which also only scales without rotating).
   const shaderBall = gltf.scene;
   shaderBall.scale.set(1000, 1000, 1000);
 
@@ -167,9 +181,9 @@ async function main() {
   // Transmissive materials (glass, water, diamond, etc.) refract what's
   // behind them. With a solid-color background the refraction captures a
   // flat navy square — glass looks opaque. Swap the background to the
-  // PMREM environment texture so there's a room to see through.
+  // HDRI environment so there's a studio to see through.
   if (threejs.transmission != null && threejs.transmission > 0) {
-    scene.background = scene.environment;
+    scene.background = envMap;
   }
 
   // Camera positioning — bernhard's three-cad-viewer formula adapted

--- a/bake/preview/thumb_render.html
+++ b/bake/preview/thumb_render.html
@@ -104,10 +104,25 @@ async function _buildMaterial(spec) {
   if ('roughness' in spec && spec.roughness != null) params.roughness = spec.roughness;
   if ('ior' in spec && spec.ior != null) params.ior = spec.ior;
   if ('transmission' in spec && spec.transmission != null) params.transmission = spec.transmission;
+  if ('thickness' in spec && spec.thickness != null) params.thickness = spec.thickness;
+  if ('dispersion' in spec && spec.dispersion != null) params.dispersion = spec.dispersion;
   if ('clearcoat' in spec && spec.clearcoat != null) params.clearcoat = spec.clearcoat;
+  if ('clearcoatRoughness' in spec && spec.clearcoatRoughness != null) params.clearcoatRoughness = spec.clearcoatRoughness;
+  if ('specularIntensity' in spec && spec.specularIntensity != null) params.specularIntensity = spec.specularIntensity;
+  if ('specularColor' in spec && spec.specularColor != null) params.specularColor = spec.specularColor;
+  if ('sheen' in spec && spec.sheen != null) params.sheen = spec.sheen;
+  if ('sheenColor' in spec && spec.sheenColor != null) {
+    const sc = spec.sheenColor;
+    params.sheenColor = new THREE.Color(sc[0] ?? 1, sc[1] ?? 1, sc[2] ?? 1);
+  }
+  if ('sheenRoughness' in spec && spec.sheenRoughness != null) params.sheenRoughness = spec.sheenRoughness;
+  if ('iridescence' in spec && spec.iridescence != null) params.iridescence = spec.iridescence;
+  if ('iridescenceIOR' in spec && spec.iridescenceIOR != null) params.iridescenceIOR = spec.iridescenceIOR;
+  if ('iridescenceThicknessRange' in spec && spec.iridescenceThicknessRange != null) params.iridescenceThicknessRange = spec.iridescenceThicknessRange;
   if ('emissive' in spec && spec.emissive != null) {
     params.emissive = new THREE.Color(spec.emissive[0] ?? 0, spec.emissive[1] ?? 0, spec.emissive[2] ?? 0);
   }
+  if ('emissiveIntensity' in spec && spec.emissiveIntensity != null) params.emissiveIntensity = spec.emissiveIntensity;
   // Load all texture maps in parallel, await before constructing the material.
   const texEntries = await Promise.all(
     TEXTURE_KEYS
@@ -148,6 +163,14 @@ async function main() {
     if (child.isMesh) child.material = mat;
   });
   scene.add(shaderBall);
+
+  // Transmissive materials (glass, water, diamond, etc.) refract what's
+  // behind them. With a solid-color background the refraction captures a
+  // flat navy square — glass looks opaque. Swap the background to the
+  // PMREM environment texture so there's a room to see through.
+  if (threejs.transmission != null && threejs.transmission > 0) {
+    scene.background = scene.environment;
+  }
 
   // Camera positioning — bernhard's three-cad-viewer formula adapted
   // for our Y-up post-glTF coords:

--- a/docs/site/src/components/MaterialCard.astro
+++ b/docs/site/src/components/MaterialCard.astro
@@ -11,7 +11,7 @@ const base = import.meta.env.BASE_URL;
 const detailHref = `${base}materials/${mat.s}/${mat.id}/`;
 const thumb = thumbUrl(meta, mat);
 ---
-<a class="card" href={detailHref} data-key={`${mat.s}/${mat.id}`} data-source={mat.s} data-category={mat.c ?? ""} data-license={mat.l ?? ""} data-thumb={mat.thumb ? "1" : "0"}>
+<a class="card" href={detailHref} data-key={`${mat.s}/${mat.id}`} data-source={mat.s} data-category={mat.c ?? ""} data-license={mat.l ?? ""} data-thumb={mat.thumb ? "1" : "0"} data-date={mat.d.p ?? ""}>
   <div class="thumb-wrap">
     {thumb ? (
       <img src={thumb} alt={mat.n} loading="lazy" decoding="async" />
@@ -39,11 +39,17 @@ const thumb = thumbUrl(meta, mat);
     text-decoration: none;
     color: inherit;
     transition: transform 0.1s ease, border-color 0.1s ease;
+    content-visibility: auto;
+    contain-intrinsic-size: auto 280px;
   }
   .card:hover {
     transform: translateY(-2px);
     border-color: var(--accent);
     text-decoration: none;
+  }
+  .card:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
   }
   .thumb-wrap {
     aspect-ratio: 1 / 1;

--- a/docs/site/src/layouts/Base.astro
+++ b/docs/site/src/layouts/Base.astro
@@ -4,8 +4,10 @@
 interface Props {
   title: string;
   description?: string;
+  ogImage?: string;
 }
-const { title, description } = Astro.props;
+const { title, description, ogImage } = Astro.props;
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site).href;
 const base = import.meta.env.BASE_URL;
 ---
 <!doctype html>
@@ -16,6 +18,16 @@ const base = import.meta.env.BASE_URL;
     <link rel="icon" type="image/svg+xml" href={`${base}favicon.svg`} />
     <title>{title}</title>
     {description && <meta name="description" content={description} />}
+    <link rel="canonical" href={canonicalUrl} />
+    <meta property="og:title" content={title} />
+    {description && <meta property="og:description" content={description} />}
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={canonicalUrl} />
+    {ogImage && <meta property="og:image" content={ogImage} />}
+    <meta name="twitter:card" content={ogImage ? "summary_large_image" : "summary"} />
+    <meta name="twitter:title" content={title} />
+    {description && <meta name="twitter:description" content={description} />}
+    {ogImage && <meta name="twitter:image" content={ogImage} />}
     <style is:global>
       :root {
         --bg: #0d1117;

--- a/docs/site/src/pages/index.astro
+++ b/docs/site/src/pages/index.astro
@@ -229,6 +229,7 @@ const base = import.meta.env.BASE_URL;
     gap: 1rem;
   }
   .grid :global(.card[hidden]) { display: none !important; }
+  .grid.search-pending :global(.card) { visibility: hidden; }
   .empty-state {
     text-align: center;
     padding: 3rem 1rem;
@@ -333,6 +334,7 @@ const base = import.meta.env.BASE_URL;
         },
       });
       mini.addAll(data.map((m) => ({ ...m, _key: `${m.s}/${m.id}` })));
+      grid.classList.remove("search-pending");
       apply();
     })
     .catch((err) => {
@@ -495,7 +497,11 @@ const base = import.meta.env.BASE_URL;
 
   // Init: restore state from URL on load. If there's a search query,
   // defer the first apply until catalog.json loads (otherwise we'd
-  // flash all cards then re-filter).
+  // flash all cards then re-filter). Hide cards while waiting.
   readUrl();
-  if (!filters.q) apply();
+  if (filters.q) {
+    grid.classList.add("search-pending");
+  } else {
+    apply();
+  }
 </script>

--- a/docs/site/src/pages/index.astro
+++ b/docs/site/src/pages/index.astro
@@ -22,68 +22,106 @@ const licenses = meta.licenses;
 const base = import.meta.env.BASE_URL;
 ---
 <Base title="mat-vis catalog" description="Browse PBR materials from ambientcg, polyhaven, gpuopen, and physicallybased.">
+  <a href="#grid" class="skip-link">Skip to materials</a>
+
   <section class="intro">
     <h1>Material catalog</h1>
     <p class="muted">
       {catalog.length.toLocaleString()} materials from {sources.length} sources.
-      Release tag: <code>{meta.release_tag}</code> ·
+      Release tag: <code>{meta.release_tag}</code> &middot;
       Substrate: <a href={`https://huggingface.co/datasets/${meta.repo_id}/tree/${meta.release_tag}`} target="_blank" rel="noopener"><code>{meta.repo_id}</code></a>
     </p>
   </section>
 
-  <div class="search-wrap">
+  <div class="search-wrap" role="search">
     <input
       id="search-input"
       type="search"
       placeholder="Search by name, tag, or upstream URL…"
       autocomplete="off"
       spellcheck="false"
+      aria-label="Search materials"
     />
-    <span id="result-count" class="muted"></span>
+    <select id="sort-select" aria-label="Sort order">
+      <option value="source-name">Sort: source &rarr; name</option>
+      <option value="name">Sort: name A&ndash;Z</option>
+      <option value="name-desc">Sort: name Z&ndash;A</option>
+      <option value="date-desc">Sort: newest first</option>
+      <option value="date-asc">Sort: oldest first</option>
+    </select>
+    <span id="result-count" class="muted" aria-live="polite" aria-atomic="true"></span>
   </div>
 
   <div class="layout">
-    <aside class="facets">
-      <h3>Source</h3>
-      <div id="facet-source">
-        {sources.map((s) => (
-          <label><input type="checkbox" data-facet="source" value={s} /> {s}</label>
-        ))}
+    <aside class="facets" id="facets-panel">
+      <button id="facets-toggle" type="button" class="facets-toggle" aria-expanded="true" aria-controls="facets-body">
+        Filters
+      </button>
+      <div id="facets-body">
+        <h3>Source</h3>
+        <div id="facet-source">
+          {sources.map((s) => (
+            <label><input type="checkbox" data-facet="source" value={s} /> <span class="facet-label">{s}</span> <span class="facet-count" data-count-facet="source" data-count-value={s}></span></label>
+          ))}
+        </div>
+        {categories.length > 0 && (
+          <>
+            <h3>Category</h3>
+            <div id="facet-category" class="scroll">
+              {categories.map((c) => (
+                <label><input type="checkbox" data-facet="category" value={c} /> <span class="facet-label">{c}</span> <span class="facet-count" data-count-facet="category" data-count-value={c}></span></label>
+              ))}
+            </div>
+          </>
+        )}
+        {licenses.length > 0 && (
+          <>
+            <h3>License</h3>
+            <div id="facet-license">
+              {licenses.map((l) => (
+                <label><input type="checkbox" data-facet="license" value={l} /> <span class="facet-label">{l}</span> <span class="facet-count" data-count-facet="license" data-count-value={l}></span></label>
+              ))}
+            </div>
+          </>
+        )}
+        <h3>Flags</h3>
+        <div>
+          <label><input id="facet-thumb" type="checkbox" /> Has preview thumb</label>
+        </div>
+        <button id="facets-reset" type="button">Reset filters</button>
       </div>
-      {categories.length > 0 && (
-        <>
-          <h3>Category</h3>
-          <div id="facet-category" class="scroll">
-            {categories.map((c) => (
-              <label><input type="checkbox" data-facet="category" value={c} /> {c}</label>
-            ))}
-          </div>
-        </>
-      )}
-      {licenses.length > 0 && (
-        <>
-          <h3>License</h3>
-          <div id="facet-license">
-            {licenses.map((l) => (
-              <label><input type="checkbox" data-facet="license" value={l} /> {l}</label>
-            ))}
-          </div>
-        </>
-      )}
-      <h3>Flags</h3>
-      <div>
-        <label><input id="facet-thumb" type="checkbox" /> Has preview thumb</label>
-      </div>
-      <button id="facets-reset" type="button">Reset filters</button>
     </aside>
 
-    <section class="grid" id="grid">
-      {sorted.map((mat) => <MaterialCard mat={mat} meta={meta} />)}
-    </section>
+    <div class="grid-area">
+      <section class="grid" id="grid">
+        {sorted.map((mat) => <MaterialCard mat={mat} meta={meta} />)}
+      </section>
+      <p id="empty-state" class="empty-state" hidden>No materials match the current filters.</p>
+    </div>
   </div>
 </Base>
 
 <style>
+  .skip-link {
+    position: absolute;
+    left: -999px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    z-index: 100;
+    background: var(--accent);
+    color: white;
+    padding: 0.5rem 1rem;
+    border-radius: 0.3rem;
+  }
+  .skip-link:focus {
+    left: 1rem;
+    top: 0.5rem;
+    width: auto;
+    height: auto;
+    overflow: visible;
+  }
   .intro h1 { margin: 0 0 0.25rem 0; }
   .intro .muted, .muted { color: var(--fg-mute); }
   .search-wrap {
@@ -91,9 +129,11 @@ const base = import.meta.env.BASE_URL;
     align-items: center;
     gap: 0.75rem;
     margin: 1rem 0;
+    flex-wrap: wrap;
   }
   #search-input {
     flex: 1;
+    min-width: 200px;
     padding: 0.6rem 0.8rem;
     font-size: 1rem;
     background: var(--bg-2);
@@ -102,6 +142,16 @@ const base = import.meta.env.BASE_URL;
     border-radius: 0.4rem;
   }
   #search-input:focus { outline: 2px solid var(--accent); outline-offset: -1px; }
+  #sort-select {
+    padding: 0.5rem 0.6rem;
+    font-size: 0.85rem;
+    background: var(--bg-2);
+    color: var(--fg);
+    border: 1px solid var(--border);
+    border-radius: 0.4rem;
+    cursor: pointer;
+  }
+  #sort-select:focus-visible { outline: 2px solid var(--accent); outline-offset: -1px; }
   .layout {
     display: grid;
     grid-template-columns: 220px 1fr;
@@ -109,6 +159,9 @@ const base = import.meta.env.BASE_URL;
   }
   @media (max-width: 720px) {
     .layout { grid-template-columns: 1fr; }
+    .facets { position: static; max-height: none; }
+    #facets-body[data-collapsed] { display: none; }
+    .facets-toggle { display: flex; }
   }
   .facets {
     position: sticky;
@@ -127,11 +180,39 @@ const base = import.meta.env.BASE_URL;
     margin: 1rem 0 0.5rem;
   }
   .facets label {
-    display: block;
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
     cursor: pointer;
     padding: 0.15rem 0;
   }
+  .facet-label { flex: 1; }
+  .facet-count {
+    font-size: 0.75rem;
+    color: var(--fg-mute);
+    font-variant-numeric: tabular-nums;
+  }
   .facets .scroll { max-height: 16rem; overflow-y: auto; }
+  .facets-toggle {
+    display: none;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 0.5rem 0;
+    font-size: 1rem;
+    font-weight: 600;
+    background: none;
+    color: var(--fg);
+    border: none;
+    cursor: pointer;
+  }
+  .facets-toggle::after {
+    content: "▾";
+    transition: transform 0.15s;
+  }
+  .facets-toggle[aria-expanded="false"]::after {
+    transform: rotate(-90deg);
+  }
   #facets-reset {
     margin-top: 1rem;
     padding: 0.4rem 0.7rem;
@@ -147,7 +228,13 @@ const base = import.meta.env.BASE_URL;
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     gap: 1rem;
   }
-  .card[hidden] { display: none !important; }
+  .grid :global(.card[hidden]) { display: none !important; }
+  .empty-state {
+    text-align: center;
+    padding: 3rem 1rem;
+    color: var(--fg-mute);
+    font-size: 1.1rem;
+  }
 </style>
 
 <script>
@@ -162,6 +249,7 @@ const base = import.meta.env.BASE_URL;
     category: Set<string>;
     license: Set<string>;
     thumbOnly: boolean;
+    sort: string;
   };
 
   const filters: Filters = {
@@ -170,17 +258,62 @@ const base = import.meta.env.BASE_URL;
     category: new Set(),
     license: new Set(),
     thumbOnly: false,
+    sort: "source-name",
   };
 
   const input = document.getElementById("search-input") as HTMLInputElement;
   const grid = document.getElementById("grid")!;
   const countEl = document.getElementById("result-count")!;
   const resetBtn = document.getElementById("facets-reset")!;
+  const sortSelect = document.getElementById("sort-select") as HTMLSelectElement;
+  const emptyState = document.getElementById("empty-state")!;
+  const facetsToggle = document.getElementById("facets-toggle")!;
+  const facetsBody = document.getElementById("facets-body")!;
 
   const cards = Array.from(grid.querySelectorAll<HTMLAnchorElement>(".card"));
 
-  // Load catalog + build MiniSearch index in parallel with first paint.
-  // Eager fetch — the JSON is the same file we relied on at build time.
+  // Pre-cache card metadata for sort (avoids repeated DOM reads).
+  const cardMeta = new Map(cards.map((c) => [c, {
+    key: c.dataset.key!,
+    name: c.querySelector(".name")?.textContent ?? "",
+    date: c.dataset.date ?? "",
+  }]));
+
+  // ── URL state ──
+  function readUrl() {
+    const p = new URLSearchParams(window.location.search);
+    filters.q = p.get("q") ?? "";
+    filters.source = new Set(p.getAll("source"));
+    filters.category = new Set(p.getAll("category"));
+    filters.license = new Set(p.getAll("license"));
+    filters.thumbOnly = p.get("thumb") === "1";
+    filters.sort = p.get("sort") ?? "source-name";
+
+    // Sync DOM to restored state
+    input.value = filters.q;
+    sortSelect.value = filters.sort;
+    document.querySelectorAll<HTMLInputElement>("input[data-facet]").forEach((cb) => {
+      const facet = cb.dataset.facet as "source" | "category" | "license";
+      cb.checked = filters[facet].has(cb.value);
+    });
+    const thumbCb = document.getElementById("facet-thumb") as HTMLInputElement;
+    thumbCb.checked = filters.thumbOnly;
+  }
+
+  function writeUrl() {
+    const p = new URLSearchParams();
+    if (filters.q) p.set("q", filters.q);
+    for (const s of filters.source) p.append("source", s);
+    for (const c of filters.category) p.append("category", c);
+    for (const l of filters.license) p.append("license", l);
+    if (filters.thumbOnly) p.set("thumb", "1");
+    if (filters.sort !== "source-name") p.set("sort", filters.sort);
+    const qs = p.toString();
+    const url = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
+    window.history.replaceState(null, "", url);
+  }
+
+  // ── MiniSearch ──
   let mini: MiniSearch<TrimmedMaterial> | null = null;
   let catalog: TrimmedMaterial[] = [];
 
@@ -189,17 +322,10 @@ const base = import.meta.env.BASE_URL;
     .then((data: TrimmedMaterial[]) => {
       catalog = data;
       mini = new MiniSearch<TrimmedMaterial & { _key: string }>({
-        // IDs collide across sources (e.g. `concrete` appears in
-        // both ambientcg and physicallybased), so the search index
-        // is keyed by `<source>/<id>` to match the card's data-key.
         idField: "_key",
         fields: ["n", "t", "u", "c"],
         storeFields: ["_key"],
         searchOptions: {
-          // AND-combine: multi-word queries must match all tokens.
-          // Default OR-combine produces ~500 hits on a 3K-entry corpus
-          // and is unusable as a "search". Fuzzy is enabled only for
-          // tokens long enough that off-by-one is helpful (>= 4 chars).
           combineWith: "AND",
           prefix: true,
           fuzzy: (term: string) => (term.length >= 5 ? 0.2 : false),
@@ -213,6 +339,36 @@ const base = import.meta.env.BASE_URL;
       console.error("[catalog] failed to load catalog.json:", err);
     });
 
+  // ── Sorting ──
+  let lastSort = "";
+  function sortCards() {
+    const order = filters.sort;
+    if (order === lastSort) return;
+    lastSort = order;
+
+    const sorted = [...cards].sort((a, b) => {
+      const am = cardMeta.get(a)!;
+      const bm = cardMeta.get(b)!;
+
+      switch (order) {
+        case "name":
+          return am.name.localeCompare(bm.name);
+        case "name-desc":
+          return bm.name.localeCompare(am.name);
+        case "date-desc":
+          return (bm.date || "0").localeCompare(am.date || "0");
+        case "date-asc":
+          return (am.date || "9999").localeCompare(bm.date || "9999");
+        default: // source-name
+          return am.key.localeCompare(bm.key);
+      }
+    });
+    const frag = document.createDocumentFragment();
+    for (const c of sorted) frag.appendChild(c);
+    grid.appendChild(frag);
+  }
+
+  // ── Apply filters ──
   let pending: number | undefined;
   function debouncedApply() {
     if (pending) window.clearTimeout(pending);
@@ -220,13 +376,16 @@ const base = import.meta.env.BASE_URL;
   }
 
   function apply() {
-    // Determine the set of allowed ids: facet AND (search ∩ facet).
-    // When no search query is active, facet filtering alone drives it.
     let allowed: Set<string> | null = null;
     if (filters.q && mini) {
       const hits = mini.search(filters.q);
       allowed = new Set(hits.map((h) => h.id as string));
     }
+
+    // Facet counts: count materials per facet value (considering other active filters).
+    const counts: Record<string, Record<string, number>> = {
+      source: {}, category: {}, license: {},
+    };
 
     let shown = 0;
     for (const card of cards) {
@@ -244,11 +403,31 @@ const base = import.meta.env.BASE_URL;
       if (show && filters.thumbOnly && !hasThumb) show = false;
 
       card.hidden = !show;
-      if (show) shown++;
+      if (show) {
+        shown++;
+        // Count for facets (only count visible cards)
+        counts.source[src] = (counts.source[src] ?? 0) + 1;
+        if (cat) counts.category[cat] = (counts.category[cat] ?? 0) + 1;
+        if (lic) counts.license[lic] = (counts.license[lic] ?? 0) + 1;
+      }
     }
+
     countEl.textContent = `${shown.toLocaleString()} of ${cards.length.toLocaleString()}`;
+    emptyState.hidden = shown > 0;
+
+    // Update facet counts in DOM
+    document.querySelectorAll<HTMLSpanElement>(".facet-count").forEach((el) => {
+      const facet = el.dataset.countFacet!;
+      const val = el.dataset.countValue!;
+      const n = counts[facet]?.[val] ?? 0;
+      el.textContent = `(${n})`;
+    });
+
+    sortCards();
+    writeUrl();
   }
 
+  // ── Event wiring ──
   input.addEventListener("input", (e) => {
     filters.q = (e.target as HTMLInputElement).value.trim();
     debouncedApply();
@@ -269,19 +448,54 @@ const base = import.meta.env.BASE_URL;
     apply();
   });
 
+  sortSelect.addEventListener("change", () => {
+    filters.sort = sortSelect.value;
+    apply();
+  });
+
   resetBtn.addEventListener("click", () => {
     filters.q = "";
     filters.source.clear();
     filters.category.clear();
     filters.license.clear();
     filters.thumbOnly = false;
+    filters.sort = "source-name";
     input.value = "";
+    sortSelect.value = "source-name";
     document.querySelectorAll<HTMLInputElement>("input[data-facet], #facet-thumb").forEach((cb) => {
       cb.checked = false;
     });
     apply();
   });
 
-  // Initial count display before fetch completes.
-  apply();
+  // Mobile facet toggle
+  facetsToggle.addEventListener("click", () => {
+    const expanded = facetsToggle.getAttribute("aria-expanded") === "true";
+    facetsToggle.setAttribute("aria-expanded", String(!expanded));
+    if (expanded) {
+      facetsBody.setAttribute("data-collapsed", "");
+    } else {
+      facetsBody.removeAttribute("data-collapsed");
+    }
+  });
+
+  // Keyboard: "/" focuses search
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "/" && document.activeElement !== input && !(e.target instanceof HTMLInputElement) && !(e.target instanceof HTMLTextAreaElement)) {
+      e.preventDefault();
+      input.focus();
+    }
+  });
+
+  // Back/forward navigation
+  window.addEventListener("popstate", () => {
+    readUrl();
+    apply();
+  });
+
+  // Init: restore state from URL on load. If there's a search query,
+  // defer the first apply until catalog.json loads (otherwise we'd
+  // flash all cards then re-filter).
+  readUrl();
+  if (!filters.q) apply();
 </script>

--- a/docs/site/src/pages/materials/[source]/[id].astro
+++ b/docs/site/src/pages/materials/[source]/[id].astro
@@ -30,6 +30,38 @@ const tierLinks = mat.tiers.map((tier) => ({
 const thumb = thumbUrl(meta, mat);
 const pbrEntries = Object.entries(mat.p).filter(([, v]) => v !== null && v !== undefined);
 
+// Human-readable PBR key labels
+const pbrLabels: Record<string, string> = {
+  color_rgb: "Color RGB",
+  roughness: "Roughness",
+  metalness: "Metalness",
+  ior: "IOR",
+  specular_f0: "Specular F0",
+  transmission: "Transmission",
+  thickness: "Thickness",
+  clearcoat_roughness: "Clearcoat roughness",
+  specular_intensity: "Specular intensity",
+  specular_color: "Specular color",
+  dispersion: "Dispersion",
+  is_conductor: "Conductor",
+  metalness_mean: "Metalness (mean)",
+  metalness_source: "Metalness source",
+  complex_ior: "Complex IOR",
+};
+
+// Check if a value is an RGB triplet (array of 3 numbers, 0–1 range)
+function isRgbTriplet(k: string, v: unknown): v is [number, number, number] {
+  return (k === "color_rgb" || k === "specular_color") &&
+    Array.isArray(v) && v.length === 3 && v.every((n) => typeof n === "number");
+}
+
+function rgbToCss(rgb: [number, number, number]): string {
+  return `rgb(${Math.round(rgb[0] * 255)}, ${Math.round(rgb[1] * 255)}, ${Math.round(rgb[2] * 255)})`;
+}
+
+// OG image: use thumb if available
+const ogImage = thumb ?? undefined;
+
 const snippet = `from mat_vis_client import MatVisClient
 
 client = MatVisClient(tag="${meta.release_tag}")
@@ -38,7 +70,7 @@ scalars = asset.scalars
 textures = asset.fetch_all_textures(tier="auto")  # post-#374
 `;
 ---
-<Base title={`${mat.n} — mat-vis`} description={`PBR material ${mat.n} from ${mat.s} (${mat.l ?? 'unlicensed'}).`}>
+<Base title={`${mat.n} — mat-vis`} description={`PBR material ${mat.n} from ${mat.s} (${mat.l ?? 'unlicensed'}).`} ogImage={ogImage}>
   <p class="back"><a href={base}>&larr; Catalog</a></p>
 
   <header class="detail-hero">
@@ -83,8 +115,17 @@ textures = asset.fetch_all_textures(tier="auto")  # post-#374
         <tbody>
           {pbrEntries.map(([k, v]) => (
             <tr>
-              <th>{k}</th>
-              <td><code>{typeof v === "object" ? JSON.stringify(v) : String(v)}</code></td>
+              <th>{pbrLabels[k] ?? k}</th>
+              <td>
+                {isRgbTriplet(k, v) ? (
+                  <span class="color-cell">
+                    <span class="color-swatch" style={`background:${rgbToCss(v)}`} title={rgbToCss(v)}></span>
+                    <code>{JSON.stringify(v)}</code>
+                  </span>
+                ) : (
+                  <code>{typeof v === "object" ? JSON.stringify(v) : String(v)}</code>
+                )}
+              </td>
             </tr>
           ))}
         </tbody>
@@ -180,6 +221,16 @@ textures = asset.fetch_all_textures(tier="auto")  # post-#374
     font-size: 0.9rem;
   }
   table.pbr th { color: var(--fg-mute); font-weight: 500; width: 12rem; }
+  .color-cell { display: inline-flex; align-items: center; gap: 0.5rem; }
+  .color-swatch {
+    display: inline-block;
+    width: 1.4rem;
+    height: 1.4rem;
+    border-radius: 0.25rem;
+    border: 1px solid var(--border);
+    vertical-align: middle;
+    flex-shrink: 0;
+  }
   ul.tiers { list-style: none; padding: 0; display: flex; gap: 0.5rem; flex-wrap: wrap; }
   ul.tiers li a {
     display: inline-block;


### PR DESCRIPTION
Supersedes #432 (closed by LFS history rewrite).

## Summary

### Catalog gallery v2 (GH Pages)
- Filter state synced to URL query params (shareable, survives reload)
- Facet counts `(N)` next to each option
- Sort: source→name, name A–Z/Z–A, newest/oldest
- Empty state when zero results match
- Color swatch for `color_rgb` / `specular_color` in PBR table
- Human-readable PBR labels
- OG meta tags (og:title, og:description, og:image, twitter:card)
- Accessibility: `aria-live`, skip-to-content, `focus-visible`, `role="search"`
- Mobile: collapsible facet sidebar
- Keyboard: `/` focuses search
- Performance: `content-visibility: auto`, sort skip, search-pending flash fix

### Transmissive material thumb fix
- Wire `thickness`, `dispersion`, `clearcoatRoughness`, `specularIntensity`, `specularColor`, `sheen*`, `iridescence*`, `emissiveIntensity` through to Three.js renderer
- Swap `scene.background` to environment when `transmission > 0`

### Studio HDRI upgrade (ADR-0014 P1)
- Replace procedural `RoomEnvironment` with Poly Haven `studio_small_09_2k.hdr` (CC0) via `RGBELoader`
- HDRI as `scene.environment` for all materials (better reflections)
- HDRI as `scene.background` only for transmissive materials
- Parallel HDRI + GLB loads, HDRI tracked via Git LFS

## Test plan

- [x] `npm run build` produces 3,247 pages
- [ ] Dispatch `pages.yml` with `kind: tst` to preview gallery
- [ ] Dispatch `bake.yml` for 29 transmissive materials
- [ ] Verify glass/diamond/water thumbs show visible refraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)