### PR TITLE
fix(baker): remove transparent/translucent from glass category keywords

### DIFF
--- a/src/mat_vis_baker/common.py
+++ b/src/mat_vis_baker/common.py
@@ -144,7 +144,7 @@ for _cat, _keywords in {
         "terrazzo",
     ],
     "ceramic": ["ceramic", "porcelain", "tile", "terracotta", "clay", "brick", "pottery"],
-    "glass": ["glass", "mirror", "crystal", "window", "translucent", "transparent"],
+    "glass": ["glass", "mirror", "crystal", "window"],
     "organic": [
         "organic",
         "soil",


### PR DESCRIPTION
## Summary

- Remove `transparent` and `translucent` from the glass category keyword list in `normalize_category()`
- These caused false-positive glass categorization for 2 gpuopen materials that are visually see-through but not glass:
  - **Chains** (`eaddbf2b`) — decorative metal panel tagged "transparent"
  - **Perforated Metal** (`625d2246`) — metal with holes tagged "transparent"
- Real glass materials still match via explicit keywords: `glass`, `mirror`, `crystal`, `window`

## Test plan

- [x] `normalize_category('', tags=['architecture', 'decorative', 'paneling', 'transparent'])` → `"other"` (was `"glass"`)
- [x] `normalize_category('', tags=['glass', 'smooth'])` → `"glass"` (unchanged)
- [x] `normalize_category('', tags=['crystal', 'gem'])` → `"glass"` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)