### PR TITLE
feat(baker): implement MaterialX TextureBaker for gpuopen nodegraphs

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -556,6 +556,7 @@ class MatVisCi:
         context: dagger.Directory,
         hf_token: dagger.Secret | None = None,
         with_ktx2: bool = False,
+        with_materialx: bool = False,
     ) -> dagger.Container:
         """Baker container for hf-bake / hf-derive / hf-derive-ktx2 (#135 / #204).
 
@@ -608,6 +609,20 @@ class MatVisCi:
                 ]
             )
 
+        if with_materialx:
+            # MaterialX TextureBaker requires GLX/X11 (not EGL). Install
+            # Xvfb + X11 libs + MaterialX. Xvfb must be started before
+            # baking — the with_exec below launches it as a background
+            # daemon. See /falsify review on #438.
+            ctr = ctr.with_exec(
+                [
+                    "sh",
+                    "-c",
+                    "apt-get install -y -qq "
+                    "xvfb libgl1 libglib2.0-0 libx11-6 libxext6 libxkbcommon0",
+                ]
+            ).with_env_variable("DISPLAY", ":99")
+
         ctr = (
             ctr.with_env_variable("PYTHONUNBUFFERED", "1")
             .with_mounted_cache("/root/.cache/uv", uv_cache)
@@ -615,6 +630,14 @@ class MatVisCi:
             .with_workdir("/app")
             .with_exec(["uv", "sync", "--all-extras"])
         )
+
+        if with_materialx:
+            # Install MaterialX after uv sync so it layers on top of
+            # the project deps. Start Xvfb as a background daemon.
+            ctr = (
+                ctr.with_exec(["uv", "pip", "install", "--system", "materialx>=1.39"])
+                .with_exec(["sh", "-c", "Xvfb :99 -screen 0 1024x1024x24 &"])
+            )
 
         if hf_token is not None:
             ctr = ctr.with_secret_variable("HF_TOKEN", hf_token)
@@ -678,7 +701,11 @@ class MatVisCi:
         through Dagger.
         """
         self._guard_prod_target(repo_id, allow_prod)
-        ctr = self._baker_container(context, hf_token=hf_token)
+        # gpuopen materials have MTLX nodegraphs that need TextureBaker
+        # to resolve packed textures to flat PNGs (#438).
+        ctr = self._baker_container(
+            context, hf_token=hf_token, with_materialx=(source == "gpuopen"),
+        )
         argv = _bake_argv(
             source=source,
             tier=tier,

--- a/Containerfile.materialx
+++ b/Containerfile.materialx
@@ -8,6 +8,13 @@ FROM ghcr.io/morepet/mat-vis-baker:latest
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libgl1 libglib2.0-0 \
+    xvfb libx11-6 libxext6 libxkbcommon0 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN uv pip install --system --no-cache materialx>=1.39 openexr>=3.3
+
+# TextureBaker requires a GLX/X11 context (not EGL). Xvfb provides
+# a virtual framebuffer. Callers must start it before baking:
+#   Xvfb :99 -screen 0 1024x1024x24 &
+#   export DISPLAY=:99
+ENV DISPLAY=:99

--- a/src/mat_vis_baker/bake.py
+++ b/src/mat_vis_baker/bake.py
@@ -52,18 +52,91 @@ def _generate_thumbnail(src_path: Path, thumb_dir: Path, channel: str) -> Path:
 def _bake_mtlx(mtlx_path: Path, output_dir: Path, resolution_px: int) -> dict[str, Path]:
     """Bake a layered MaterialX graph to flat PNGs.
 
-    Requires the [materialx] optional dependency.
+    Uses MaterialX's TextureBaker to evaluate the nodegraph and produce
+    one flat PNG per resolved channel (color, roughness, normal, etc.).
+    Requires the ``[materialx]`` optional dependency — the Dagger CI
+    image (``build-materialx`` variant) ships it.
+
+    Returns a ``{channel: path}`` dict matching the canonical channel
+    names from :func:`~mat_vis_baker.common.normalize_channel`.
     """
     try:
-        import MaterialX as mx  # noqa: F401
+        import MaterialX as mx
+        from MaterialX import PyMaterialXRenderGlsl as mx_render
     except ImportError as exc:
         raise ImportError(
             "MaterialX is required for baking layered gpuopen graphs. "
             "Install with: pip install mat-vis[materialx]"
         ) from exc
 
-    # TODO: implement full MaterialX TextureBaker flow
-    raise NotImplementedError(f"MaterialX baking not yet implemented: {mtlx_path}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Load the document + standard library definitions
+    doc = mx.createDocument()
+    search_path = mx.getDefaultDataSearchPath()
+    library_folders = mx.getDefaultDataLibraryFolders()
+    stdlib = mx.createDocument()
+    mx.loadLibraries(library_folders, search_path, stdlib)
+    doc.importLibrary(stdlib)
+
+    # Read the material MTLX — resolve file paths relative to its dir
+    mx.readFromXmlFile(doc, str(mtlx_path))
+    search_path.append(mx.FilePath(str(mtlx_path.parent)))
+
+    # TextureBaker requires a live GLX/X11 OpenGL context on Linux.
+    # The Dagger CI image must run Xvfb (DISPLAY=:99) so GLX context
+    # creation succeeds. SwiftShader's EGL alone is NOT sufficient —
+    # MaterialXRenderGlsl hardcodes glXChooseVisual/XOpenDisplay.
+    # See /falsify review on #438.
+    baker = mx_render.TextureBaker.create(resolution_px, resolution_px)
+
+    # bakeAllMaterials third arg is an output FILENAME (not a dir).
+    # TextureBaker derives the image output path from the filename's
+    # parent directory. Baked PNGs land alongside the output MTLX.
+    output_mtlx = output_dir / "baked_material.mtlx"
+    baker.bakeAllMaterials(doc, search_path, str(output_mtlx))
+
+    # Map baked output files to canonical channel names. TextureBaker
+    # writes files named ``<material>_<shadingmodel>_<input>.png``,
+    # e.g. ``Concrete_Planks_standard_surface_base_color.png``.
+    # We match on the trailing input name via endswith().
+    channel_map = {
+        "base_color": "color",
+        "basecolor": "color",
+        "diffuse": "color",
+        "normal": "normal",
+        "specular_roughness": "roughness",
+        "roughness": "roughness",
+        "metalness": "metalness",
+        "metallic": "metalness",
+        "emission": "emission",
+        "emissive": "emission",
+        "opacity": "opacity",
+        "occlusion": "ao",
+        "displacement": "displacement",
+    }
+
+    baked: dict[str, Path] = {}
+    for png in output_dir.glob("*.png"):
+        stem = png.stem.lower()
+        for suffix, canonical in channel_map.items():
+            if stem.endswith(suffix) and canonical not in baked:
+                baked[canonical] = png
+                break
+
+    if not baked:
+        raise RuntimeError(
+            f"TextureBaker produced no output PNGs in {output_dir} "
+            f"(mtlx: {mtlx_path})"
+        )
+
+    log.info(
+        "%s: baked %d channels from mtlx (%s)",
+        mtlx_path.stem,
+        len(baked),
+        ", ".join(sorted(baked)),
+    )
+    return baked
 
 
 def bake_material(

--- a/src/mat_vis_baker/sources/gpuopen.py
+++ b/src/mat_vis_baker/sources/gpuopen.py
@@ -395,8 +395,12 @@ def _fetch_one(
         resp = retry_request(dl_url)
         mtlx_path, textures = _extract_from_zip(resp.content, mid, output_dir, mtlx_dir=mtlx_dir)
 
-        # If no flat textures but we have mtlx, flag for baking
-        needs_bake = bool(mtlx_path) and not textures
+        # Always bake when MTLX exists — even materials that ship flat
+        # textures may have nodegraph logic (channel extraction, mix
+        # nodes, UV transforms) that the flat files don't represent.
+        # TextureBaker resolves the full graph to correct flat PNGs.
+        # See #438 for the Concrete Planks packed-roughness example.
+        needs_bake = bool(mtlx_path)
 
         if not textures and not mtlx_path:
             log.warning("%s: no textures or mtlx in ZIP", mid)


### PR DESCRIPTION
## Summary

Implements the `_bake_mtlx()` stub in `bake.py` and fixes the `needs_bake` heuristic in `gpuopen.py`.

### Root cause (#438)

GPUOpen materials ship packed multi-channel textures alongside complex MTLX nodegraphs. Example: Concrete Planks' `roughness.png` is RGB-packed data that the MTLX extracts channel 0 from and mixes between two roughness parameters. Our pipeline was using the raw RGB file as `roughnessMap`, which Three.js reads as green channel — completely wrong data, producing washed-out renders.

### Changes

**`src/mat_vis_baker/bake.py`** — `_bake_mtlx()`:
1. Load MTLX document + MaterialX standard library
2. Create `TextureBaker` instance at target resolution
3. `bakeAllMaterials()` to produce flat per-channel PNGs
4. Map output filenames to canonical channel names (`base_color` → `color`, `specular_roughness` → `roughness`, etc.)

**`src/mat_vis_baker/sources/gpuopen.py`** — `needs_bake` heuristic:
- Was: `bool(mtlx_path) and not textures` (only bake when zero flat textures)
- Now: `bool(mtlx_path)` (always bake when MTLX exists)

### Testing

Can't test locally on NixOS (MaterialX needs libstdc++). The Dagger CI image (`build-materialx` variant) has the full MaterialX + PyMaterialXRenderGlsl stack. Test by dispatching a bake for a known procedural material:

```
gh workflow run bake.yml -f filter-source=gpuopen \
  -f filter-ids=6cd4dfac-0a7b-44c2-81f6-e70ad71d1171 \
  -f filter-tier=1k -f repo-id=gerchowl/mat-vis-tst
```

Then compare the baked `roughness.png` — should be grayscale, not purple/magenta.

Closes #438.

🤖 Generated with [Claude Code](https://claude.com/claude-code)