### PR TITLE
feat(baker): --force-rebake flag to skip preflight tree scan

### DIFF
--- a/.dagger/src/mat_vis_ci/_bake_cli.py
+++ b/.dagger/src/mat_vis_ci/_bake_cli.py
@@ -22,6 +22,7 @@ def bake_argv(
     filter_ids: str = "",
     batch_max_bytes: int = 700 * 1024 * 1024,
     metrics_path: str | None = None,
+    force_rebake: bool = False,
 ) -> list[str]:
     """Build the ``mat-vis-baker hf-bake`` argv list.
 
@@ -71,4 +72,6 @@ def bake_argv(
         argv.append("--allow-prod")
     if metrics_path:
         argv += ["--metrics-path", metrics_path]
+    if force_rebake:
+        argv.append("--force-rebake")
     return argv

--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -655,6 +655,9 @@ class MatVisCi:
             ),
         ] = 700 * 1024 * 1024,
         dry_run: Annotated[bool, Doc("Build locally; skip HF push")] = False,
+        force_rebake: Annotated[
+            bool, Doc("Skip preflight tree scan — re-bake even if files exist on HF")
+        ] = False,
     ) -> str:
         """Bake one (source, tier) into an HF commit (#136 / ADR-0012).
 
@@ -691,6 +694,7 @@ class MatVisCi:
             filter_ids=filter_ids,
             dry_run=dry_run,
             allow_prod=allow_prod,
+            force_rebake=force_rebake,
         )
         return await ctr.with_exec(argv).stdout()
 

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -85,6 +85,11 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: false
         type: boolean
+      force-rebake:
+        description: 'Skip preflight tree scan — re-bake even if files already exist on HF. Does NOT bypass allow-prod.'
+        required: false
+        default: false
+        type: boolean
       repo-id:
         description: 'HF dataset repo'
         required: false
@@ -319,6 +324,7 @@ jobs:
             --batch-size=${{ inputs.batch-size }}
             --batch-max-bytes=${{ inputs.batch-max-bytes }}
             ${{ inputs.dry-run == true && '--dry-run=true' || '' }}
+            ${{ inputs.force-rebake == true && '--force-rebake=true' || '' }}
 
       # ADR-0011 / mat-vis#152 phase-c: lock the Layer-2 upstream mirror
       # against silent schema drift. The baker just pushed the candidate

--- a/src/mat_vis_baker/__main__.py
+++ b/src/mat_vis_baker/__main__.py
@@ -394,6 +394,7 @@ def cmd_hf_bake(args: argparse.Namespace) -> int:
         batch_max_bytes=args.batch_max_bytes,
         dry_run=args.dry_run,
         allow_prod=args.allow_prod,
+        force_rebake=args.force_rebake,
         metrics_path=Path(args.metrics_path) if args.metrics_path else None,
     )
     log.info("hf-bake result: %s", result)
@@ -600,6 +601,17 @@ def main() -> int:
             "Permit writes to non-scratch HF dataset repos. Scratch "
             "repos are named */mat-vis-tst and */mat-vis-*-tst; anything "
             "else requires this flag."
+        ),
+    )
+    p_hf.add_argument(
+        "--force-rebake",
+        action="store_true",
+        help=(
+            "Skip the preflight tree scan that detects already-committed "
+            "materials. Use to re-bake materials whose textures need "
+            "regeneration (e.g. after fixing the MTLX baking pipeline). "
+            "Does NOT bypass the prod guard (--allow-prod is still required "
+            "for non-tst repos)."
         ),
     )
     p_hf.add_argument(

--- a/src/mat_vis_baker/hf_bake.py
+++ b/src/mat_vis_baker/hf_bake.py
@@ -207,6 +207,7 @@ def bake_one(
     allow_prod: bool = False,
     storage_tier: str | None = None,
     metrics_path: Path | None = None,
+    force_rebake: bool = False,
     _pre_manifest_hook=None,
 ) -> dict:
     """Bake one ``(source, tier)`` and commit to HF.
@@ -273,5 +274,6 @@ def bake_one(
         dry_run=dry_run,
         storage_tier=storage_tier,
         metrics_path=metrics_path,
+        force_rebake=force_rebake,
         _pre_manifest_hook=_pre_manifest_hook,
     )

--- a/src/mat_vis_baker/hf_bake_per_file.py
+++ b/src/mat_vis_baker/hf_bake_per_file.py
@@ -386,6 +386,7 @@ def bake_one_per_file(
     dry_run: bool = False,
     storage_tier: str | None = None,
     metrics_path: Path | None = None,
+    force_rebake: bool = False,
     _pre_manifest_hook=None,
 ) -> dict:
     """Bake one (source, tier) into per-file HF commits.
@@ -447,14 +448,20 @@ def bake_one_per_file(
 
     # Pre-flight: which materials are already committed on this tag?
     # Use storage_tier — that's where past runs of THIS bake wrote.
-    already = _already_committed_material_ids(api, repo_id, release_tag, source, storage_tier)
-    if already:
-        log.info(
-            "preflight: %d materials already on %s@%s — skipping",
-            len(already),
-            repo_id,
-            release_tag,
-        )
+    # --force-rebake skips this scan so materials get re-baked even if
+    # their files already exist on HF. Does NOT bypass the prod guard.
+    if force_rebake:
+        already: set[str] = set()
+        log.info("preflight: --force-rebake — skipping tree scan, will re-bake all")
+    else:
+        already = _already_committed_material_ids(api, repo_id, release_tag, source, storage_tier)
+        if already:
+            log.info(
+                "preflight: %d materials already on %s@%s — skipping",
+                len(already),
+                repo_id,
+                release_tag,
+            )
 
     fetch = _get_fetcher(source)
 


### PR DESCRIPTION
## Summary

Adds `--force-rebake` through the full stack (CLI → Dagger → bake.yml) to skip the preflight tree scan that detects already-committed materials.

Needed when the baking pipeline changes (e.g. MTLX TextureBaker fix #438) and existing textures need regeneration. Without this, the preflight says "already done" and skips the material.

**Safety**: does NOT bypass `--allow-prod` (still required for non-tst repos), tag validation, or any other safety rail.

## Test plan

- [ ] Dispatch `bake.yml` with `force-rebake=true` for Concrete Planks
- [ ] Verify material is re-baked (not skipped by preflight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)