### PR TITLE
feat(baker+ci): substrate coverage checker + ambientcg JPG fallback (#293)

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -919,6 +919,62 @@ class MatVisCi:
             argv.extend(["--previous-tag", previous_tag])
         return await ctr.with_exec(argv).stdout()
 
+    @function
+    async def check_substrate_coverage(
+        self,
+        context: Annotated[dagger.Directory, Doc("Project root directory")],
+        release_tag: Annotated[str, Doc("CalVer release tag to check (e.g. v2026.04.99-tst-full-369)")],
+        hf_token: Annotated[
+            dagger.Secret,
+            Doc("HF read token for substrate tree listing"),
+        ],
+        repo_id: Annotated[
+            str, Doc("HF dataset repo (e.g. gerchowl/mat-vis-tst)")
+        ] = "gerchowl/mat-vis-tst",
+        release_line: Annotated[
+            str,
+            Doc("Release line (empty = auto-detect from tag)"),
+        ] = "",
+        include_thumb: Annotated[
+            bool, Doc("Include thumb tier in coverage check")
+        ] = False,
+        upstream_catalog: Annotated[
+            str,
+            Doc("Path to pre-captured upstream-catalog.json (empty = live APIs)"),
+        ] = "",
+        waiver_file: Annotated[
+            str, Doc("Path to waived.yaml (empty = no waivers)")
+        ] = "",
+    ) -> str:
+        """Run scripts/check_substrate_coverage.py — wanted vs actual on HF.
+
+        Compares the canonical release matrix + upstream catalogs against
+        what actually lives on the HF substrate. Returns CLI stdout.
+        Non-zero exit raises ``dagger.ExecError``.
+        """
+        ctr = self._baker_container(context, hf_token=hf_token)
+        argv = [
+            "uv",
+            "run",
+            "--extra",
+            "baker",
+            "python",
+            "scripts/check_substrate_coverage.py",
+            "--release-tag",
+            release_tag,
+            "--repo-id",
+            repo_id,
+        ]
+        if release_line:
+            argv.extend(["--release-line", release_line])
+        if include_thumb:
+            argv.append("--include-thumb")
+        if upstream_catalog:
+            argv.extend(["--upstream-catalog", upstream_catalog])
+        if waiver_file:
+            argv.extend(["--waiver-file", waiver_file])
+        return await ctr.with_exec(argv).stdout()
+
     # ── prod-cut pre-flight (mat-vis#345) ─────────────────────────
     #
     # Three composable gates, each agent-resistant in its own way:

--- a/scripts/check_substrate_coverage.py
+++ b/scripts/check_substrate_coverage.py
@@ -1,0 +1,612 @@
+"""Check substrate coverage — wanted vs actual on HF.
+
+Compares the canonical release matrix (which (source, tier) cells
+should exist) and upstream material catalogs (which material IDs
+each source advertises) against what actually lives on the HF
+substrate at a given release tag.
+
+Two coverage levels:
+
+1. **Tier-level:** does each expected (source, tier) cell exist on
+   HF with the expected material count?
+2. **Material-level:** for each cell, which specific IDs are missing
+   or unexpected?
+
+Usage::
+
+    python -m scripts.check_substrate_coverage \\
+        --release-tag v2026.04.99-tst-full-369 \\
+        --repo-id gerchowl/mat-vis-tst \\
+        [--release-line v2026.04] \\
+        [--include-thumb] \\
+        [--waiver-file waived.yaml] \\
+        [--upstream-catalog PATH] \\
+        [--json]
+
+Reuses existing infrastructure:
+- ``validate_release.baked_ids_from_release_manifest`` (actual IDs on HF)
+- ``validate_release.find_catalog_violations`` (diff logic)
+- ``validate_release.load_waivers`` (approved exceptions)
+- ``release_registry.release_dag`` (canonical tier shape)
+- ``snapshot_upstream_catalog._ids_for_source`` (upstream IDs)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger("check-substrate-coverage")
+
+__all__ = [
+    "CoverageReport",
+    "TierResult",
+    "build_coverage_report",
+    "detect_release_line",
+    "wanted_material_ids",
+    "wanted_tiers",
+]
+
+
+# ── data classes ───────────────────────────────────────────────────
+
+
+@dataclass
+class TierResult:
+    """Coverage result for one (source, tier) cell."""
+
+    source: str
+    tier: str
+    expected_count: int | None  # None for manifest-only checks (scalar)
+    actual_count: int | None  # None if tier missing from HF entirely
+    missing_ids: frozenset[str] = field(default_factory=frozenset)
+    extra_ids: frozenset[str] = field(default_factory=frozenset)
+    status: str = "ok"  # ok | missing_tier | incomplete | manifest_only
+
+    @property
+    def has_violation(self) -> bool:
+        return self.status not in ("ok", "manifest_only")
+
+
+@dataclass
+class CoverageReport:
+    """Aggregated coverage report across all cells."""
+
+    release_tag: str
+    repo_id: str
+    release_line: str
+    results: list[TierResult] = field(default_factory=list)
+    unexpected_tiers: list[tuple[str, str]] = field(default_factory=list)
+
+    @property
+    def total_violations(self) -> int:
+        return sum(1 for r in self.results if r.has_violation) + len(
+            self.unexpected_tiers
+        )
+
+    @property
+    def is_clean(self) -> bool:
+        return self.total_violations == 0
+
+    def to_dict(self) -> dict:
+        return {
+            "release_tag": self.release_tag,
+            "repo_id": self.repo_id,
+            "release_line": self.release_line,
+            "total_violations": self.total_violations,
+            "results": [
+                {
+                    "source": r.source,
+                    "tier": r.tier,
+                    "status": r.status,
+                    "expected_count": r.expected_count,
+                    "actual_count": r.actual_count,
+                    "missing_count": len(r.missing_ids),
+                    "extra_count": len(r.extra_ids),
+                    "missing_ids": sorted(r.missing_ids),
+                    "extra_ids": sorted(r.extra_ids),
+                }
+                for r in self.results
+            ],
+            "unexpected_tiers": [
+                {"source": s, "tier": t} for s, t in self.unexpected_tiers
+            ],
+        }
+
+    def print_summary(self) -> None:
+        hdr = (
+            f"check-substrate-coverage {self.release_tag} "
+            f"(line={self.release_line}, repo={self.repo_id})"
+        )
+        print(hdr)
+        print("=" * len(hdr))
+        print()
+
+        # Tier-level overview
+        print("tier-level coverage:")
+        for r in sorted(self.results, key=lambda r: (r.source, r.tier)):
+            exp = r.expected_count if r.expected_count is not None else "—"
+            act = r.actual_count if r.actual_count is not None else "—"
+            tag = _status_tag(r.status)
+            print(f"  {r.source}/{r.tier:10s}  {exp:>5} expected  {act:>5} actual  {tag}")
+        print()
+
+        # Material-level violations
+        violations = [r for r in self.results if r.has_violation]
+        if violations:
+            print("material-level violations:")
+            for r in sorted(violations, key=lambda r: (r.source, r.tier)):
+                parts = []
+                if r.missing_ids:
+                    parts.append(f"{len(r.missing_ids)} missing")
+                if r.extra_ids:
+                    parts.append(f"{len(r.extra_ids)} extras")
+                print(f"  {r.source}/{r.tier}: {', '.join(parts)}")
+                if r.missing_ids:
+                    ids = sorted(r.missing_ids)
+                    preview = ids[:10]
+                    tail = f" ... and {len(ids) - 10} more" if len(ids) > 10 else ""
+                    print(f"    missing: {preview}{tail}")
+                if r.extra_ids:
+                    ids = sorted(r.extra_ids)
+                    preview = ids[:10]
+                    tail = f" ... and {len(ids) - 10} more" if len(ids) > 10 else ""
+                    print(f"    extras:  {preview}{tail}")
+            print()
+
+        if self.unexpected_tiers:
+            print("unexpected tiers (on HF but not in release matrix):")
+            for s, t in sorted(self.unexpected_tiers):
+                print(f"  {s}/{t}")
+            print()
+
+        # Summary
+        print("summary:")
+        print(f"  cells checked:  {len(self.results)}")
+        print(f"  violations:     {self.total_violations}")
+        print(f"  exit:           {0 if self.is_clean else 1}")
+
+
+def _status_tag(status: str) -> str:
+    return {
+        "ok": "OK",
+        "manifest_only": "OK (manifest-only)",
+        "missing_tier": "MISSING TIER",
+        "incomplete": "INCOMPLETE",
+    }.get(status, status.upper())
+
+
+# ── core logic ─────────────────────────────────────────────────────
+
+
+def detect_release_line(tag: str) -> str:
+    """Extract release line from a tag, e.g. ``v2026.04.3`` -> ``v2026.04``."""
+    from mat_vis_baker.release_registry import known_lines
+
+    parts = tag.split(".")
+    if len(parts) < 2:
+        raise ValueError(f"cannot parse release line from tag {tag!r}")
+    line = ".".join(parts[:2])
+    if line not in known_lines():
+        raise ValueError(
+            f"release line {line!r} (from tag {tag!r}) not in "
+            f"known lines: {known_lines()}"
+        )
+    return line
+
+
+def wanted_tiers(
+    line: str,
+    *,
+    include_thumb: bool = False,
+) -> set[tuple[str, str]]:
+    """Return the set of ``(source, tier)`` cells expected for a release line."""
+    from mat_vis_baker.release_registry import release_dag
+    from mat_vis_baker.sources import KNOWN_SOURCES
+
+    dag = release_dag(line)
+    cells = {(a.source, a.tier) for a in dag.all_artifacts()}
+    if include_thumb:
+        for source in sorted(KNOWN_SOURCES):
+            cells.add((source, "thumb"))
+    return cells
+
+
+def wanted_material_ids(
+    sources: list[str],
+    *,
+    upstream_catalog_path: Path | None = None,
+) -> dict[str, set[str]]:
+    """Return ``{source: {material_id, ...}}`` from upstream.
+
+    If ``upstream_catalog_path`` is given, loads from a pre-captured
+    snapshot JSON (the shape produced by ``snapshot_upstream_catalog``).
+    Otherwise, hits live upstream APIs via ``_ids_for_source``.
+    """
+    if upstream_catalog_path is not None:
+        data = json.loads(upstream_catalog_path.read_text())
+        out: dict[str, set[str]] = {}
+        for src in sources:
+            entry = data.get("sources", {}).get(src)
+            if entry:
+                out[src] = set(entry["ids"])
+            else:
+                log.warning(
+                    "source %s not in upstream catalog %s", src, upstream_catalog_path
+                )
+                out[src] = set()
+        return out
+
+    from scripts.snapshot_upstream_catalog import _ids_for_source
+
+    return {src: set(_ids_for_source(src)) for src in sources}
+
+
+def _manifest_declares_tier(
+    manifest: dict,
+    source: str,
+    tier: str,
+) -> bool:
+    """Check whether release-manifest.json declares a (source, tier) cell."""
+    src_entry = manifest.get("sources", {}).get(source)
+    if not src_entry:
+        return False
+    return tier in (src_entry.get("tiers") or {})
+
+
+def build_coverage_report(
+    *,
+    release_tag: str,
+    repo_id: str,
+    release_line: str,
+    wanted: set[tuple[str, str]],
+    wanted_ids: dict[str, set[str]],
+    actual: dict[tuple[str, str], set[str]],
+    waivers: dict[tuple[str, str], set[str]],
+    manifest: dict | None = None,
+) -> CoverageReport:
+    """Compare wanted vs actual and build the coverage report."""
+    from mat_vis_baker.sources import SCALAR_SOURCES
+
+    report = CoverageReport(
+        release_tag=release_tag,
+        repo_id=repo_id,
+        release_line=release_line,
+    )
+
+    for source, tier in sorted(wanted):
+        # Scalar sources: manifest-only check (no per-file tree)
+        if source in SCALAR_SOURCES and tier != "thumb":
+            declared = False
+            if manifest:
+                declared = _manifest_declares_tier(manifest, source, tier)
+            report.results.append(
+                TierResult(
+                    source=source,
+                    tier=tier,
+                    expected_count=None,
+                    actual_count=None,
+                    status="manifest_only" if declared else "missing_tier",
+                )
+            )
+            continue
+
+        actual_ids = actual.get((source, tier))
+
+        # Tier entirely missing from HF
+        if actual_ids is None:
+            expected_count = len(wanted_ids.get(source, set()))
+            report.results.append(
+                TierResult(
+                    source=source,
+                    tier=tier,
+                    expected_count=expected_count,
+                    actual_count=None,
+                    status="missing_tier",
+                )
+            )
+            continue
+
+        # Material-level diff
+        upstream_for_source = wanted_ids.get(source, set())
+        waived = waivers.get((source, tier), set())
+        expected = upstream_for_source - waived
+        missing = expected - actual_ids
+        extras = actual_ids - upstream_for_source
+
+        expected_count = len(expected)
+        actual_count = len(actual_ids)
+
+        if missing or extras:
+            status = "incomplete"
+        else:
+            status = "ok"
+
+        report.results.append(
+            TierResult(
+                source=source,
+                tier=tier,
+                expected_count=expected_count,
+                actual_count=actual_count,
+                missing_ids=frozenset(missing),
+                extra_ids=frozenset(extras),
+                status=status,
+            )
+        )
+
+    # Unexpected tiers: on HF but not in the wanted set
+    for source, tier in sorted(actual.keys()):
+        if (source, tier) not in wanted:
+            report.unexpected_tiers.append((source, tier))
+
+    return report
+
+
+# ── CLI ────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint. Returns 0 clean, 1 violations, 2 setup error."""
+    p = argparse.ArgumentParser(
+        prog="check-substrate-coverage",
+        description="Compare wanted vs actual substrate coverage on HF.",
+    )
+    p.add_argument("--release-tag", required=True, help="CalVer release tag")
+    p.add_argument(
+        "--repo-id",
+        default="gerchowl/mat-vis-tst",
+        help="HF dataset repo (default: %(default)s)",
+    )
+    p.add_argument(
+        "--release-line",
+        default="",
+        help="Release line (default: auto-detect from tag)",
+    )
+    p.add_argument(
+        "--include-thumb",
+        action="store_true",
+        help="Include thumb tier in coverage check",
+    )
+    p.add_argument(
+        "--waiver-file",
+        type=Path,
+        default=None,
+        help="Path to waived.yaml for approved exceptions",
+    )
+    p.add_argument(
+        "--upstream-catalog",
+        type=Path,
+        default=None,
+        help=(
+            "Path to pre-captured upstream-catalog.json "
+            "(default: hit live upstream APIs)"
+        ),
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output machine-readable JSON",
+    )
+    args = p.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(name)s: %(message)s",
+    )
+
+    # ── resolve release line ──
+    try:
+        line = args.release_line or detect_release_line(args.release_tag)
+    except ValueError as e:
+        log.error("setup error: %s", e)
+        return 2
+
+    # ── wanted tiers ──
+    try:
+        w_tiers = wanted_tiers(line, include_thumb=args.include_thumb)
+    except (KeyError, ValueError) as e:
+        log.error("setup error resolving release matrix: %s", e)
+        return 2
+
+    # ── wanted material IDs ──
+    sources_needed = sorted({s for s, _ in w_tiers})
+    log.info("fetching upstream material IDs for: %s", ", ".join(sources_needed))
+    try:
+        w_ids = wanted_material_ids(
+            sources_needed,
+            upstream_catalog_path=args.upstream_catalog,
+        )
+    except Exception as e:
+        log.error("setup error fetching upstream catalog: %s", e)
+        return 2
+
+    for src, ids in sorted(w_ids.items()):
+        log.info("  %s: %d upstream materials", src, len(ids))
+
+    # ── actual state on HF ──
+    log.info("scanning HF substrate at %s @ %s ...", args.repo_id, args.release_tag)
+    try:
+        actual, manifest = _scan_hf(args.repo_id, args.release_tag)
+    except Exception as e:
+        log.error("setup error scanning HF: %s", e)
+        return 2
+
+    for (src, tier), ids in sorted(actual.items()):
+        log.info("  %s/%s: %d materials on HF", src, tier, len(ids))
+
+    # ── waivers ──
+    waivers = _load_waivers(args.waiver_file) if args.waiver_file else {}
+
+    # ── build report ──
+    report = build_coverage_report(
+        release_tag=args.release_tag,
+        repo_id=args.repo_id,
+        release_line=line,
+        wanted=w_tiers,
+        wanted_ids=w_ids,
+        actual=actual,
+        waivers=waivers,
+        manifest=manifest,
+    )
+
+    # ── output ──
+    if args.json_output:
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        report.print_summary()
+        # Hint for gpuopen failed-material noise
+        gpuopen_missing = [
+            r
+            for r in report.results
+            if r.source == "gpuopen" and r.missing_ids and not args.waiver_file
+        ]
+        if gpuopen_missing:
+            print(
+                "hint: gpuopen has known bake failures. Create a waiver file "
+                "(--waiver-file) to suppress expected missing materials."
+            )
+
+    return 0 if report.is_clean else 1
+
+
+def _load_waivers(path: Path | None) -> dict[tuple[str, str], set[str]]:
+    """Parse ``waived.yaml`` → ``{(source, tier): {id, ...}}``.
+
+    Minimal re-implementation of ``validate_release.load_waivers`` to
+    avoid importing validate_release (which top-level imports pyarrow).
+    """
+    if path is None or not path.exists():
+        return {}
+    raw = path.read_text()
+    if not raw.strip():
+        return {}
+    try:
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(raw) or {}
+    except ImportError:
+        data = _minimal_yaml(raw)
+
+    out: dict[tuple[str, str], set[str]] = {}
+    for source, tiers in (data or {}).items():
+        for tier, ids in (tiers or {}).items():
+            out[(str(source), str(tier))] = set(ids or [])
+    return out
+
+
+def _minimal_yaml(s: str) -> dict:
+    """Bare-bones YAML subset parser (source -> tier -> list)."""
+    out: dict = {}
+    current_source = None
+    current_tier = None
+    for line in s.splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        stripped = line.strip()
+        if indent == 0 and stripped.endswith(":"):
+            current_source = stripped[:-1].strip().strip('"')
+            out[current_source] = {}
+            current_tier = None
+        elif indent == 2 and stripped.endswith(":"):
+            current_tier = stripped[:-1].strip().strip('"')
+            out[current_source][current_tier] = []
+        elif stripped.startswith("- ") and current_tier is not None:
+            out[current_source][current_tier].append(stripped[2:].strip().strip('"'))
+    return out
+
+
+def _scan_hf(
+    repo_id: str,
+    release_tag: str,
+) -> tuple[dict[tuple[str, str], set[str]], dict | None]:
+    """Fetch actual material IDs and manifest from HF.
+
+    Combined entry point so tests can monkeypatch a single function
+    to avoid importing huggingface_hub / pyarrow.
+    """
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+    actual = _actual_ids_from_hf(api, repo_id, release_tag)
+    manifest = _fetch_manifest(api, repo_id, release_tag)
+    return actual, manifest
+
+
+def _actual_ids_from_hf(
+    api: Any,
+    repo_id: str,
+    release_tag: str,
+) -> dict[tuple[str, str], set[str]]:
+    """Fetch ``{(source, tier): {material_id, ...}}`` from HF.
+
+    Reads ``release-manifest.json`` to discover (source, tier) pairs,
+    then enumerates the per-file tree under each. Mirrors the logic in
+    ``validate_release.baked_ids_from_release_manifest`` but avoids
+    importing validate_release (which top-level imports pyarrow).
+    """
+    try:
+        manifest_path = api.hf_hub_download(
+            repo_id=repo_id,
+            repo_type="dataset",
+            revision=release_tag,
+            filename="release-manifest.json",
+        )
+        manifest = json.loads(Path(manifest_path).read_text())
+    except Exception:  # noqa: BLE001
+        return {}
+
+    out: dict[tuple[str, str], set[str]] = {}
+    sources = manifest.get("sources", {}) or {}
+    for source, src_entry in sources.items():
+        tiers = (src_entry or {}).get("tiers", {}) or {}
+        for tier in tiers:
+            prefix = f"{source}/{tier}/"
+            mids: set[str] = set()
+            try:
+                for entry in api.list_repo_tree(
+                    repo_id=repo_id,
+                    repo_type="dataset",
+                    revision=release_tag,
+                    path_in_repo=prefix.rstrip("/"),
+                    recursive=True,
+                ):
+                    path = getattr(entry, "path", None)
+                    if not path or not path.startswith(prefix):
+                        continue
+                    rel = path[len(prefix):]  # noqa: E203
+                    parts = rel.split("/", 1)
+                    if len(parts) == 2 and parts[0] and not parts[0].startswith("."):
+                        mids.add(parts[0])
+            except Exception:  # noqa: BLE001
+                pass
+            out[(source, tier)] = mids
+    return out
+
+
+def _fetch_manifest(
+    api: Any,
+    repo_id: str,
+    release_tag: str,
+) -> dict | None:
+    """Fetch release-manifest.json for scalar tier checks."""
+    try:
+        manifest_path = api.hf_hub_download(
+            repo_id=repo_id,
+            repo_type="dataset",
+            revision=release_tag,
+            filename="release-manifest.json",
+        )
+        return json.loads(Path(manifest_path).read_text())
+    except Exception:  # noqa: BLE001
+        return None
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/snapshot_upstream_catalog.py
+++ b/scripts/snapshot_upstream_catalog.py
@@ -57,6 +57,10 @@ def _ids_for_source(source: str) -> list[str]:
         from mat_vis_baker.sources.gpuopen import discover
 
         return [e.get("id") or e.get("name") for e in discover() if e]
+    if source == "physicallybased":
+        from mat_vis_baker.sources.physicallybased import fetch
+
+        return [r.id for r in fetch()]
     raise ValueError(f"unknown source: {source!r}")
 
 

--- a/src/mat_vis_baker/bake.py
+++ b/src/mat_vis_baker/bake.py
@@ -88,7 +88,8 @@ def _bake_mtlx(mtlx_path: Path, output_dir: Path, resolution_px: int) -> dict[st
     # creation succeeds. SwiftShader's EGL alone is NOT sufficient —
     # MaterialXRenderGlsl hardcodes glXChooseVisual/XOpenDisplay.
     # See /falsify review on #438.
-    baker = mx_render.TextureBaker.create(resolution_px, resolution_px)
+    # Third arg is BaseType — UINT8 for 8-bit PNG output (LDR).
+    baker = mx_render.TextureBaker.create(resolution_px, resolution_px, mx.BaseType.UINT8)
 
     # bakeAllMaterials third arg is an output FILENAME (not a dir).
     # TextureBaker derives the image output path from the filename's

--- a/src/mat_vis_baker/sources/ambientcg.py
+++ b/src/mat_vis_baker/sources/ambientcg.py
@@ -128,15 +128,20 @@ def discover(*, session: requests.Session | None = None) -> list[dict]:
 
 # ── download + extract ──────────────────────────────────────────
 
-# Sub-1k tiers download 1K and let the bake step resize
-_TIER_ATTRS = {
-    "128": "1K-PNG",
-    "256": "1K-PNG",
-    "512": "1K-PNG",
-    "1k": "1K-PNG",
-    "2k": "2K-PNG",
-    "4k": "4K-PNG",
-    "8k": "8K-PNG",
+# Sub-1k tiers download 1K and let the bake step resize.
+# Each tier maps to a list of candidate attributes tried in order:
+# PNG first, then JPG fallback. The 28 oldest ambientcg materials
+# only ship JPG zips; JPG textures are converted to PNG at
+# extraction time (_extract_maps_from_zip) so the downstream
+# pipeline stays PNG-only.
+_TIER_ATTRS: dict[str, list[str]] = {
+    "128": ["1K-PNG", "1K-JPG"],
+    "256": ["1K-PNG", "1K-JPG"],
+    "512": ["1K-PNG", "1K-JPG"],
+    "1k": ["1K-PNG", "1K-JPG"],
+    "2k": ["2K-PNG", "2K-JPG"],
+    "4k": ["4K-PNG", "4K-JPG"],
+    "8k": ["8K-PNG", "8K-JPG"],
 }
 
 
@@ -145,13 +150,15 @@ def _extract_download_url(entry: dict, tier: str) -> str | None:
 
     Downloads live under downloadFolders.default.downloadFiletypeCategories.zip.downloads[]
     with the tier encoded in the `attribute` field (e.g. "1K-PNG").
+    Tries PNG first, then falls back to JPG for older materials that
+    only ship JPEG textures.
     """
     folders = entry.get("downloadFolders")
     if not folders:
         return None
 
-    target_attr = _TIER_ATTRS.get(tier)
-    if not target_attr:
+    candidates = _TIER_ATTRS.get(tier)
+    if not candidates:
         return None
 
     try:
@@ -159,9 +166,10 @@ def _extract_download_url(entry: dict, tier: str) -> str | None:
     except (KeyError, TypeError):
         return None
 
-    for dl in downloads:
-        if dl.get("attribute", "").upper() == target_attr:
-            return dl.get("fullDownloadPath")
+    for target_attr in candidates:
+        for dl in downloads:
+            if dl.get("attribute", "").upper() == target_attr:
+                return dl.get("fullDownloadPath")
 
     return None
 
@@ -227,6 +235,7 @@ def _extract_maps_from_zip(
             if not m:
                 continue
             raw_channel = m.group(1)
+            src_ext = m.group(2).lower()
             channel = normalize_channel("ambientcg", raw_channel)
             if channel is None:
                 continue
@@ -234,7 +243,15 @@ def _extract_maps_from_zip(
                 continue
 
             out_path = mat_dir / f"{channel}.png"
-            out_path.write_bytes(zf.read(name))
+            raw_bytes = zf.read(name)
+            if src_ext == "jpg" or src_ext == "jpeg":
+                # Convert JPEG → PNG so downstream pipeline stays PNG-only.
+                from PIL import Image
+
+                img = Image.open(io.BytesIO(raw_bytes))
+                img.save(out_path, "PNG")
+            else:
+                out_path.write_bytes(raw_bytes)
             result[channel] = out_path
 
     # Per-material channel set is intentionally non-uniform across the

--- a/tests/test_check_substrate_coverage.py
+++ b/tests/test_check_substrate_coverage.py
@@ -1,0 +1,403 @@
+"""Substrate coverage checker tests (#293).
+
+Covers:
+
+1. ``detect_release_line`` — tag parsing and validation.
+2. ``wanted_tiers`` — release DAG cell extraction, thumb injection.
+3. ``build_coverage_report`` — violation detection, waiver suppression,
+   scalar manifest-only checks.
+4. CLI exit codes — clean → 0, violations → 1, bad tag → 2, JSON flag.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.check_substrate_coverage import (
+    CoverageReport,
+    build_coverage_report,
+    detect_release_line,
+    main,
+    wanted_material_ids,
+    wanted_tiers,
+)
+
+
+# ── detect_release_line ──────────────────────────────────────────
+
+
+def test_detect_release_line_from_full_tst_tag():
+    assert detect_release_line("v2026.04.99-tst-full-369") == "v2026.04"
+
+
+def test_detect_release_line_from_patch_tag():
+    assert detect_release_line("v2026.04.3") == "v2026.04"
+
+
+def test_detect_release_line_from_bare_line():
+    """Just the two-part prefix should work too."""
+    assert detect_release_line("v2026.04") == "v2026.04"
+
+
+def test_detect_release_line_unknown_raises():
+    with pytest.raises(ValueError, match="not in known lines"):
+        detect_release_line("v9999.99.0")
+
+
+def test_detect_release_line_unparseable_raises():
+    with pytest.raises(ValueError, match="cannot parse"):
+        detect_release_line("bad-tag")
+
+
+# ── wanted_tiers ─────────────────────────────────────────────────
+
+
+def test_wanted_tiers_matches_release_dag():
+    """wanted_tiers without thumb must match release_dag().all_artifacts()."""
+    from mat_vis_baker.release_registry import release_dag
+
+    dag = release_dag("v2026.04")
+    expected = {(a.source, a.tier) for a in dag.all_artifacts()}
+    actual = wanted_tiers("v2026.04", include_thumb=False)
+    assert actual == expected
+
+
+def test_wanted_tiers_without_thumb_has_no_thumb():
+    cells = wanted_tiers("v2026.04", include_thumb=False)
+    thumb_cells = {(s, t) for s, t in cells if t == "thumb"}
+    assert thumb_cells == set()
+
+
+def test_wanted_tiers_with_thumb_adds_all_sources():
+    from mat_vis_baker.sources import KNOWN_SOURCES
+
+    cells = wanted_tiers("v2026.04", include_thumb=True)
+    thumb_cells = {s for s, t in cells if t == "thumb"}
+    assert thumb_cells == KNOWN_SOURCES
+
+
+# ── wanted_material_ids ──────────────────────────────────────────
+
+
+def test_wanted_material_ids_from_catalog_json(tmp_path):
+    """Load from a pre-captured upstream-catalog JSON."""
+    catalog = {
+        "release_tag": "v2026.04.0",
+        "sources": {
+            "ambientcg": {"count": 3, "ids": ["Bricks001", "Metal001", "Wood001"]},
+            "gpuopen": {"count": 2, "ids": ["uuid_a", "uuid_b"]},
+        },
+    }
+    p = tmp_path / "upstream-catalog.json"
+    p.write_text(json.dumps(catalog))
+
+    result = wanted_material_ids(["ambientcg", "gpuopen"], upstream_catalog_path=p)
+    assert result["ambientcg"] == {"Bricks001", "Metal001", "Wood001"}
+    assert result["gpuopen"] == {"uuid_a", "uuid_b"}
+
+
+def test_wanted_material_ids_missing_source_in_catalog(tmp_path):
+    """Missing source in the catalog should return empty set + warning."""
+    catalog = {"sources": {"ambientcg": {"count": 1, "ids": ["mat_a"]}}}
+    p = tmp_path / "upstream-catalog.json"
+    p.write_text(json.dumps(catalog))
+
+    result = wanted_material_ids(["ambientcg", "polyhaven"], upstream_catalog_path=p)
+    assert result["ambientcg"] == {"mat_a"}
+    assert result["polyhaven"] == set()
+
+
+# ── build_coverage_report ────────────────────────────────────────
+
+
+def _make_report(
+    *,
+    wanted: set[tuple[str, str]] | None = None,
+    wanted_ids: dict[str, set[str]] | None = None,
+    actual: dict[tuple[str, str], set[str]] | None = None,
+    waivers: dict[tuple[str, str], set[str]] | None = None,
+    manifest: dict | None = None,
+) -> CoverageReport:
+    """Build a report from test data with sensible defaults."""
+    return build_coverage_report(
+        release_tag="v2026.04.99-tst",
+        repo_id="gerchowl/mat-vis-tst",
+        release_line="v2026.04",
+        wanted=wanted or set(),
+        wanted_ids=wanted_ids or {},
+        actual=actual or {},
+        waivers=waivers or {},
+        manifest=manifest,
+    )
+
+
+def test_clean_report():
+    """All materials present → no violations."""
+    ids = {"mat_a", "mat_b", "mat_c"}
+    report = _make_report(
+        wanted={("ambientcg", "1k")},
+        wanted_ids={"ambientcg": ids},
+        actual={("ambientcg", "1k"): ids},
+    )
+    assert report.is_clean
+    assert report.total_violations == 0
+    assert report.results[0].status == "ok"
+
+
+def test_missing_tier_detected():
+    """A tier in the matrix but absent from HF is flagged."""
+    report = _make_report(
+        wanted={("ambientcg", "1k"), ("ambientcg", "512")},
+        wanted_ids={"ambientcg": {"mat_a"}},
+        actual={("ambientcg", "1k"): {"mat_a"}},
+        # ambientcg/512 not in actual → missing_tier
+    )
+    assert not report.is_clean
+    r_512 = next(r for r in report.results if r.tier == "512")
+    assert r_512.status == "missing_tier"
+    assert r_512.actual_count is None
+
+
+def test_missing_materials_detected():
+    """Materials in upstream but not on HF are flagged."""
+    upstream = {"mat_a", "mat_b", "mat_c"}
+    on_hf = {"mat_a"}
+    report = _make_report(
+        wanted={("ambientcg", "1k")},
+        wanted_ids={"ambientcg": upstream},
+        actual={("ambientcg", "1k"): on_hf},
+    )
+    assert not report.is_clean
+    r = report.results[0]
+    assert r.status == "incomplete"
+    assert r.missing_ids == frozenset({"mat_b", "mat_c"})
+    assert r.expected_count == 3
+    assert r.actual_count == 1
+
+
+def test_extra_materials_reported():
+    """Materials on HF but not in upstream are reported."""
+    upstream = {"mat_a"}
+    on_hf = {"mat_a", "mat_extra"}
+    report = _make_report(
+        wanted={("gpuopen", "1k")},
+        wanted_ids={"gpuopen": upstream},
+        actual={("gpuopen", "1k"): on_hf},
+    )
+    r = report.results[0]
+    assert r.extra_ids == frozenset({"mat_extra"})
+    assert r.status == "incomplete"
+
+
+def test_waiver_suppresses_violation():
+    """Waived material IDs do not count as missing."""
+    upstream = {"mat_a", "mat_b", "mat_failed"}
+    on_hf = {"mat_a", "mat_b"}
+    waivers = {("gpuopen", "1k"): {"mat_failed"}}
+    report = _make_report(
+        wanted={("gpuopen", "1k")},
+        wanted_ids={"gpuopen": upstream},
+        actual={("gpuopen", "1k"): on_hf},
+        waivers=waivers,
+    )
+    assert report.is_clean
+    r = report.results[0]
+    assert r.missing_ids == frozenset()
+    assert r.expected_count == 2  # 3 upstream - 1 waived
+
+
+def test_physicallybased_scalar_manifest_only():
+    """Scalar tier for physicallybased uses manifest-only check."""
+    manifest = {
+        "sources": {
+            "physicallybased": {
+                "catalog": "physicallybased.json",
+                "tiers": {"scalar": {"complete": True}},
+            }
+        }
+    }
+    report = _make_report(
+        wanted={("physicallybased", "scalar")},
+        wanted_ids={"physicallybased": {"gold", "silver"}},
+        actual={},  # no per-file tree for scalar
+        manifest=manifest,
+    )
+    r = report.results[0]
+    assert r.status == "manifest_only"
+    assert not r.has_violation
+
+
+def test_physicallybased_scalar_missing_from_manifest():
+    """Scalar tier not declared in manifest → flagged."""
+    manifest = {"sources": {"physicallybased": {"tiers": {}}}}
+    report = _make_report(
+        wanted={("physicallybased", "scalar")},
+        wanted_ids={"physicallybased": {"gold"}},
+        actual={},
+        manifest=manifest,
+    )
+    r = report.results[0]
+    assert r.status == "missing_tier"
+    assert r.has_violation
+
+
+def test_physicallybased_thumb_not_manifest_only():
+    """Thumb tier for physicallybased is NOT scalar → normal material check."""
+    report = _make_report(
+        wanted={("physicallybased", "thumb")},
+        wanted_ids={"physicallybased": {"gold", "silver"}},
+        actual={("physicallybased", "thumb"): {"gold", "silver"}},
+    )
+    r = report.results[0]
+    assert r.status == "ok"
+
+
+def test_unexpected_tiers_reported():
+    """Tiers on HF that aren't in the wanted set are reported."""
+    report = _make_report(
+        wanted={("ambientcg", "1k")},
+        wanted_ids={"ambientcg": {"mat_a"}},
+        actual={
+            ("ambientcg", "1k"): {"mat_a"},
+            ("ambientcg", "2k"): {"mat_a"},  # not in wanted
+        },
+    )
+    assert ("ambientcg", "2k") in report.unexpected_tiers
+
+
+def test_to_dict_is_json_serializable():
+    """Report.to_dict() must produce JSON-serializable output."""
+    report = _make_report(
+        wanted={("ambientcg", "1k")},
+        wanted_ids={"ambientcg": {"mat_a", "mat_b"}},
+        actual={("ambientcg", "1k"): {"mat_a"}},
+    )
+    d = report.to_dict()
+    serialized = json.dumps(d)
+    assert '"missing_count": 1' in serialized
+
+
+# ── CLI (main) ───────────────────────────────────────────────────
+
+
+def _make_scan_hf(baked, manifest=None):
+    """Build a mock ``_scan_hf`` returning the given baked data + manifest."""
+    if manifest is None:
+        manifest = {
+            "sources": {
+                "physicallybased": {"tiers": {"scalar": {"complete": True}}}
+            }
+        }
+
+    def _scan_hf(repo_id, release_tag):
+        return baked, manifest
+
+    return _scan_hf
+
+
+def test_main_clean_exits_zero(tmp_path, monkeypatch):
+    """Clean substrate → exit 0."""
+    ids = {"mat_a", "mat_b"}
+    catalog = {
+        "sources": {
+            "ambientcg": {"count": 2, "ids": sorted(ids)},
+            "polyhaven": {"count": 2, "ids": sorted(ids)},
+            "gpuopen": {"count": 2, "ids": sorted(ids)},
+            "physicallybased": {"count": 2, "ids": sorted(ids)},
+        }
+    }
+    catalog_path = tmp_path / "upstream.json"
+    catalog_path.write_text(json.dumps(catalog))
+
+    # Build actual data covering all cells from the release DAG
+    from mat_vis_baker.release_registry import release_dag
+
+    dag = release_dag("v2026.04")
+    baked = {}
+    for a in dag.all_artifacts():
+        if a.tier == "scalar":
+            continue
+        baked[(a.source, a.tier)] = ids
+
+    import scripts.check_substrate_coverage as mod
+
+    monkeypatch.setattr(mod, "_scan_hf", _make_scan_hf(baked))
+
+    rc = main([
+        "--release-tag", "v2026.04.99-tst",
+        "--repo-id", "gerchowl/mat-vis-tst",
+        "--upstream-catalog", str(catalog_path),
+    ])
+    assert rc == 0
+
+
+def test_main_violations_exit_one(tmp_path, monkeypatch):
+    """Missing materials → exit 1."""
+    catalog = {
+        "sources": {
+            "ambientcg": {"count": 3, "ids": ["a", "b", "c"]},
+            "polyhaven": {"count": 1, "ids": ["x"]},
+            "gpuopen": {"count": 1, "ids": ["y"]},
+            "physicallybased": {"count": 1, "ids": ["z"]},
+        }
+    }
+    catalog_path = tmp_path / "upstream.json"
+    catalog_path.write_text(json.dumps(catalog))
+
+    # Only ambientcg/1k exists and is missing "c"
+    baked = {("ambientcg", "1k"): {"a", "b"}}
+
+    import scripts.check_substrate_coverage as mod
+
+    monkeypatch.setattr(mod, "_scan_hf", _make_scan_hf(baked))
+
+    rc = main([
+        "--release-tag", "v2026.04.99-tst",
+        "--upstream-catalog", str(catalog_path),
+    ])
+    assert rc == 1
+
+
+def test_main_bad_tag_exits_two():
+    """Unknown release line → exit 2."""
+    rc = main(["--release-tag", "v9999.99.0"])
+    assert rc == 2
+
+
+def test_main_json_output(tmp_path, monkeypatch, capsys):
+    """--json flag produces valid JSON to stdout."""
+    catalog = {
+        "sources": {
+            "ambientcg": {"count": 1, "ids": ["a"]},
+            "polyhaven": {"count": 1, "ids": ["a"]},
+            "gpuopen": {"count": 1, "ids": ["a"]},
+            "physicallybased": {"count": 1, "ids": ["a"]},
+        }
+    }
+    catalog_path = tmp_path / "upstream.json"
+    catalog_path.write_text(json.dumps(catalog))
+
+    from mat_vis_baker.release_registry import release_dag
+
+    dag = release_dag("v2026.04")
+    baked = {}
+    for a in dag.all_artifacts():
+        if a.tier == "scalar":
+            continue
+        baked[(a.source, a.tier)] = {"a"}
+
+    import scripts.check_substrate_coverage as mod
+
+    monkeypatch.setattr(mod, "_scan_hf", _make_scan_hf(baked))
+
+    main([
+        "--release-tag", "v2026.04.99-tst",
+        "--upstream-catalog", str(catalog_path),
+        "--json",
+    ])
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert "total_violations" in data
+    assert "results" in data


### PR DESCRIPTION
## Summary

- **Substrate coverage checker** (`scripts/check_substrate_coverage.py`) — compares canonical release matrix + upstream material catalogs against live HF substrate state. Reports per-(source, tier) coverage: missing tiers, missing material IDs, unexpected extras.
- **ambientcg JPG fallback** — `_TIER_ATTRS` now tries PNG first, falls back to JPG. JPG→PNG conversion at extraction time via PIL. Unlocks 28 previously unbakeable materials (1949 → 1977 bakeable).
- **Dagger CI function** — `check_substrate_coverage()` wraps the script for CI pipelines.
- **physicallybased in snapshot_upstream_catalog** — `_ids_for_source()` now handles all 4 sources.
- **24 tests** — full coverage of detection, reporting, waivers, CLI exit codes, JSON output.

## What it found on `gerchowl/mat-vis-tst` @ `v2026.04.99-tst-full-369`

| Issue | Finding |
|-------|---------|
| #436 | ktx2-512 never derived for any source; ambientcg/ktx2-1k missing from manifest |
| #435 | 18 gpuopen procedural materials + 17 ambientcg no-download placeholders are permanent false positives — discover() needs capability classification |
| #437 | Vision: upstream delta detection → auto-PR → bake to tst → preview on Pages → accept via PR merge |

## Test plan

- [x] `uv run pytest tests/test_check_substrate_coverage.py -v` — 24 passed
- [x] `ruff check` — clean
- [x] Live run against `gerchowl/mat-vis-tst` — produces correct coverage report
- [x] JPG fallback E2E: downloaded `Asphalt001` JPG ZIP, extracted 4 channels as PNG (1024x737)
- [x] No regressions in `test_release_registry`, `test_release_matrix`, `test_check_upstream_content_drift` (82 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)