### PR TITLE
fix(baker): BaseType import from correct MaterialX submodule

### DIFF
--- a/src/mat_vis_baker/bake.py
+++ b/src/mat_vis_baker/bake.py
@@ -62,6 +62,7 @@ def _bake_mtlx(mtlx_path: Path, output_dir: Path, resolution_px: int) -> dict[st
     """
     try:
         import MaterialX as mx
+        from MaterialX import PyMaterialXRender as mx_base_render
         from MaterialX import PyMaterialXRenderGlsl as mx_render
     except ImportError as exc:
         raise ImportError(
@@ -89,7 +90,7 @@ def _bake_mtlx(mtlx_path: Path, output_dir: Path, resolution_px: int) -> dict[st
     # MaterialXRenderGlsl hardcodes glXChooseVisual/XOpenDisplay.
     # See /falsify review on #438.
     # Third arg is BaseType — UINT8 for 8-bit PNG output (LDR).
-    baker = mx_render.TextureBaker.create(resolution_px, resolution_px, mx.BaseType.UINT8)
+    baker = mx_render.TextureBaker.create(resolution_px, resolution_px, mx_base_render.BaseType.UINT8)
 
     # bakeAllMaterials third arg is an output FILENAME (not a dir).
     # TextureBaker derives the image output path from the filename's


### PR DESCRIPTION
One-liner import fix. BaseType is in PyMaterialXRender, not top-level mx.