### PR TITLE
feat(ci): testable MaterialX baker — smoke test, Xvfb bake fix (#441), visual-regression, nix checks

### DIFF
--- a/.dagger/dagger.json
+++ b/.dagger/dagger.json
@@ -2,5 +2,6 @@
   "name": "mat-vis-ci",
   "sdk": "python",
   "source": ".",
-  "root": ".."
+  "root": "..",
+  "engineVersion": "v0.20.8"
 }

--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -59,6 +59,16 @@ from mat_vis_ci._bake_cli import bake_argv as _bake_argv
 IMAGE = "ghcr.io/morepet/mat-vis-baker"
 TARGET_PLATFORM = dagger.Platform("linux/amd64")
 
+# MaterialX TextureBaker needs a live GLX/X11 display for the DURATION of
+# the render — glXChooseVisual/XOpenDisplay, not EGL (see /falsify on #438).
+# A backgrounded `Xvfb &` in an earlier build layer does NOT survive into a
+# later render exec: Dagger runs each with_exec() as a fresh process tree, so
+# the daemon is already gone. `xvfb-run` starts the server, waits for it to be
+# ready, exports DISPLAY, runs the wrapped command, and tears the server down —
+# all inside the ONE exec that renders. Prepend to any argv that drives
+# TextureBaker (the gpuopen bake, the materialx smoke test). Fixes #440/#441.
+XVFB_RUN = ["xvfb-run", "-a", "--server-args=-screen 0 1024x1024x24"]
+
 PROBE_SCRIPT = '''\
 """Probe upstream material APIs — one minimal request each."""
 
@@ -271,6 +281,82 @@ class MatVisCi:
         ctr = self.build_materialx(src)
         return await ctr.with_exec(
             ["python", "-c", "import pyarrow; import MaterialX; print('materialx ok')"]
+        ).stdout()
+
+    @function
+    async def test_materialx(
+        self,
+        src: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
+    ) -> str:
+        """Run the MaterialX baker smoke test under a live Xvfb display.
+
+        This is the ONLY CI leg that drives the real ``TextureBaker`` API
+        path end-to-end (``tests/test_bake_mtlx_smoke.py``). It runs in the
+        heavy materialx container, wrapped in ``xvfb-run`` — the SAME display
+        wrapper the gpuopen bake uses — so a ``TextureBaker.create()``
+        signature/``BaseType`` regression (#442/#443/#445) or a broken
+        display wiring fails HERE, in seconds, instead of at bake runtime
+        one CI round-trip at a time.
+
+        ``uv sync --all-extras`` (run by ``_baker_container``) already
+        installs pytest + Pillow (``[dev]``/``[baker]``) and MaterialX
+        (``[materialx]``), so ``uv run pytest`` sees the full env. Under
+        ``xvfb-run`` DISPLAY is exported to a live server, so the two
+        GLX-gated bake tests run for real rather than skipping.
+        """
+        context = src or dag.host().directory(".")
+        ctr = self._baker_container(context, with_materialx=True)
+        return await ctr.with_exec(
+            [*XVFB_RUN, "uv", "run", "pytest", "tests/test_bake_mtlx_smoke.py", "-v"]
+        ).stdout()
+
+    @function
+    async def test_visual(
+        self,
+        context: Annotated[dagger.Directory, Doc("Project root directory")] | None = None,
+        repo_id: Annotated[
+            str, Doc("HF dataset the bernhard grid resolves against")
+        ] = "gerchowl/mat-vis-tst",
+        release_tag: Annotated[
+            str, Doc("Substrate revision with full 4-source bernhard coverage")
+        ] = "v2026.04.99-tst-full-369",
+        hf_token: Annotated[
+            dagger.Secret | None, Doc("HF read token (needed for private scratch repos)")
+        ] = None,
+    ) -> str:
+        """Run the headless visual-regression suite against a live substrate.
+
+        Ungates ``bake/preview/tests/test_visual_regression.py`` — the
+        RMS-vs-baseline renders (30 committed baselines) that catch the
+        transmissive-renders-opaque class (#429/#428) and the #285 scalar
+        regression. Default-skipped via ``MAT_VIS_SKIP_VISUAL=1``; here we
+        flip it to ``0`` and drive headless Chromium (SwiftShader) through
+        Playwright, pinned to the tst full-bake so bernhard's 24 textured +
+        5 scalar materials are actually staged.
+
+        Repo routing: the test constructs ``MatVisClient(tag=...)`` with no
+        ``repo=`` kwarg, so ``MAT_VIS_DATASET=<repo>@<tag>`` steers it at the
+        scratch dataset (client resolver Layer 2; ``repo_kwarg or env_repo``).
+
+        Scheduled (visual-regression.yml), NOT on the PR gate: it hits live
+        HF + downloads a browser, and the repo keeps live-substrate checks
+        off PR CI (#80).
+        """
+        ctx = context or dag.host().directory(".")
+        ctr = self._baker_container(ctx, hf_token=hf_token)
+        # Playwright + Chromium (~300 MB per-job add, same as the thumb
+        # derive leg — not baked into the image while visual is the only
+        # consumer here).
+        ctr = ctr.with_exec(["uv", "pip", "install", "playwright>=1.45"]).with_exec(
+            ["uv", "run", "playwright", "install", "--with-deps", "chromium"]
+        )
+        ctr = (
+            ctr.with_env_variable("MAT_VIS_SKIP_VISUAL", "0")
+            .with_env_variable("MAT_VIS_DATASET", f"{repo_id}@{release_tag}")
+            .with_env_variable("MAT_VIS_TAG", release_tag)
+        )
+        return await ctr.with_exec(
+            ["uv", "run", "pytest", "bake/preview/tests/test_visual_regression.py", "-v"]
         ).stdout()
 
     @function
@@ -610,18 +696,21 @@ class MatVisCi:
             )
 
         if with_materialx:
-            # MaterialX TextureBaker requires GLX/X11 (not EGL). Install
-            # Xvfb + X11 libs + MaterialX. Xvfb must be started before
-            # baking — the with_exec below launches it as a background
-            # daemon. See /falsify review on #438.
+            # MaterialX TextureBaker requires a live GLX/X11 context (not
+            # EGL). Install Xvfb + xauth (xvfb-run needs it for the auth
+            # cookie) + the X11 runtime libs. The display itself is NOT
+            # started here — it is launched per-render via `xvfb-run` (see
+            # XVFB_RUN + the bake / test_materialx call sites), which also
+            # exports DISPLAY, so there is deliberately no static DISPLAY
+            # env to dangle at a dead server. #438/#441.
             ctr = ctr.with_exec(
                 [
                     "sh",
                     "-c",
                     "apt-get install -y -qq "
-                    "xvfb libgl1 libglib2.0-0 libx11-6 libxext6 libxkbcommon0",
+                    "xvfb xauth libgl1 libglib2.0-0 libx11-6 libxext6 libxkbcommon0",
                 ]
-            ).with_env_variable("DISPLAY", ":99")
+            )
 
         ctr = (
             ctr.with_env_variable("PYTHONUNBUFFERED", "1")
@@ -632,12 +721,12 @@ class MatVisCi:
         )
 
         if with_materialx:
-            # Install MaterialX after uv sync so it layers on top of
-            # the project deps. Start Xvfb as a background daemon.
-            ctr = (
-                ctr.with_exec(["uv", "pip", "install", "--system", "materialx>=1.39"])
-                .with_exec(["sh", "-c", "Xvfb :99 -screen 0 1024x1024x24 &"])
-            )
+            # Reinforce the MaterialX install on top of the uv-synced env.
+            # No Xvfb daemon is started here — see the note above; renders
+            # wrap their command in XVFB_RUN so the server lives for the
+            # duration of the render (a background Xvfb in this layer would
+            # not survive into the render exec). #441.
+            ctr = ctr.with_exec(["uv", "pip", "install", "--system", "materialx>=1.39"])
 
         if hf_token is not None:
             ctr = ctr.with_secret_variable("HF_TOKEN", hf_token)
@@ -706,8 +795,9 @@ class MatVisCi:
         self._guard_prod_target(repo_id, allow_prod)
         # gpuopen materials have MTLX nodegraphs that need TextureBaker
         # to resolve packed textures to flat PNGs (#438).
+        needs_display = source == "gpuopen"
         ctr = self._baker_container(
-            context, hf_token=hf_token, with_materialx=(source == "gpuopen"),
+            context, hf_token=hf_token, with_materialx=needs_display,
         )
         argv = _bake_argv(
             source=source,
@@ -723,6 +813,14 @@ class MatVisCi:
             allow_prod=allow_prod,
             force_rebake=force_rebake,
         )
+        if needs_display:
+            # TextureBaker opens a GLX context for the whole render, so the
+            # baker must run under a live Xvfb started in THIS exec. Without
+            # the wrapper the render crashes with "Can't open display" even
+            # though DISPLAY looks set — the root cause of #441. Dry-runs
+            # skip baking, but wrapping is harmless (xvfb-run just execs the
+            # CLI, which exits before touching a display).
+            argv = [*XVFB_RUN, *argv]
         return await ctr.with_exec(argv).stdout()
 
     # ── release matrix (mat-vis#306) ──────────────────────────────

--- a/.github/actions/dagger-call/action.yml
+++ b/.github/actions/dagger-call/action.yml
@@ -48,9 +48,16 @@ inputs:
     required: false
     default: 'call'
   version:
-    description: 'Dagger CLI version. Empty = action default.'
+    # Pin the CLI to the module-compatible engine (matches
+    # .dagger/dagger.json engineVersion). The action installs *latest*
+    # when this is empty, and latest drifted 0.20.8 -> 0.21.7 whose
+    # bundled beartype rejects `Optional[dagger.Directory]` — the
+    # Annotated[dagger.Directory,...] | None pattern used throughout the
+    # module — so every Dagger job fails at module load. Unpin only once
+    # the module is made 0.21+ compatible.
+    description: 'Dagger CLI version (pinned for module compatibility).'
     required: false
-    default: ''
+    default: '0.20.8'
   cloud-token:
     description: 'DAGGER_CLOUD_TOKEN. Empty = no cloud telemetry.'
     required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,21 @@ jobs:
         with:
           args: test-clients --src=. --tag=v2026.04.2 --live=true
 
+  materialx-test:
+    name: MaterialX baker smoke (Xvfb)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Builds the heavy materialx container and runs the TextureBaker
+      # smoke test (tests/test_bake_mtlx_smoke.py) under a live xvfb-run
+      # display. This is the only leg that exercises the real MaterialX
+      # bake API — the class of bug (#442/#443/#445 signature/import, plus
+      # the #441 "no live display during bake" wiring) that previously
+      # slipped every unit gate and only surfaced at bake runtime.
+      - uses: ./.github/actions/dagger-call
+        with:
+          args: test-materialx --src=.
+
   # validate-release lives in promote-data-release.yml (pre-promotion gate)
   # and release-validate.yml (daily drift check). It tests the state of a
   # published GitHub Release, not the code in this PR, so it does not
@@ -77,7 +92,7 @@ jobs:
   push:
     name: Push baker image to GHCR
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [ci, integration, client-tests]
+    needs: [ci, integration, client-tests, materialx-test]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/derive.yml
+++ b/.github/workflows/derive.yml
@@ -266,6 +266,7 @@ jobs:
         with:
           verb: call
           module: .dagger
+          version: '0.20.8'  # module-compatible CLI (0.21+ beartype breaks load)
           args: >-
             ${{ inputs.kind == 'resize' && 'derive' || 'derive-ktx-2' }}
             --context=.
@@ -285,6 +286,7 @@ jobs:
         with:
           verb: call
           module: .dagger
+          version: '0.20.8'  # module-compatible CLI (0.21+ beartype breaks load)
           args: >-
             thumb
             --context=.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           verb: call
           module: .dagger
+          version: '0.20.8'  # module-compatible CLI (0.21+ beartype breaks load)
           args: >-
             test-e-2-e
             --context=.

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,0 +1,104 @@
+---
+# Visual regression — ungates bake/preview/tests/test_visual_regression.py,
+# the headless Three.js RMS-vs-baseline renders that are default-skipped in
+# normal CI (MAT_VIS_SKIP_VISUAL=1). Catches the transmissive-renders-opaque
+# class (#429/#428/#421) and the #285 scalar regression that structural
+# adapter tests can't see — a rough clearcoat vs a smooth one is the same
+# dict, a different pixel.
+#
+# Lives on a schedule (NOT the PR merge gate) for the same reason
+# release-validate.yml and e2e.yml do: it hits the live HF substrate and
+# downloads a browser. Live-substrate checks belong off PR CI (#80). The
+# 30 committed baselines under bake/preview/tests/baselines/ are the
+# reference; regenerate intentionally with MAT_VIS_UPDATE_BASELINES=1.
+#
+# Two trigger paths:
+#   1. Daily cron at 07:00 UTC — 30 min after release-validate (06:30) so
+#      it stacks after e2e (06:00) + validate without contending for the
+#      dagger engine. Cron uses the default tst full-bake substrate.
+#   2. workflow_dispatch — operator-driven run against a specific
+#      repo-id + release tag (e.g. a fresh scratch bake under review).
+
+name: Visual regression
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        description: 'Substrate revision with full bernhard coverage'
+        required: true
+        default: 'v2026.04.99-tst-full-369'
+        type: string
+      repo-id:
+        description: >-
+          HF dataset the bernhard grid resolves against. Scratch:
+          gerchowl/mat-vis-tst (full 4-source coverage). Prod bakes
+          only a subset of the grid, so most materials soft-skip.
+        required: false
+        default: 'gerchowl/mat-vis-tst'
+        type: string
+  schedule:
+    # Daily at 07:00 UTC — after e2e (06:00) and release-validate (06:30).
+    - cron: '0 7 * * *'
+
+permissions:
+  contents: read
+  issues: write          # needed by notify-on-failure composite action
+
+env:
+  DEFAULT_REPO_ID: gerchowl/mat-vis-tst
+  DEFAULT_TAG: v2026.04.99-tst-full-369
+
+jobs:
+  visual:
+    name: visual-regression ${{ inputs.release-tag || 'cron' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve substrate coordinates
+        id: sub
+        env:
+          INPUT_TAG: ${{ inputs.release-tag }}
+          INPUT_REPO_ID: ${{ inputs.repo-id }}
+        run: |
+          set -euo pipefail
+          tag="${INPUT_TAG:-${DEFAULT_TAG}}"
+          repo_id="${INPUT_REPO_ID:-${DEFAULT_REPO_ID}}"
+          {
+            echo "tag=${tag}"
+            echo "repo_id=${repo_id}"
+          } >>"${GITHUB_OUTPUT}"
+          echo "Resolved: tag=${tag} repo_id=${repo_id}"
+
+      # Builds the baker container, installs Playwright + Chromium, flips
+      # MAT_VIS_SKIP_VISUAL=0, and runs the RMS-vs-baseline suite pinned
+      # to the resolved substrate. See MatVisCi.test_visual.
+      - name: Visual regression against HF substrate
+        uses: ./.github/actions/dagger-call
+        with:
+          args: >-
+            test-visual
+            --context=.
+            --repo-id=${{ steps.sub.outputs.repo_id }}
+            --release-tag=${{ steps.sub.outputs.tag }}
+            --hf-token=env:HF_TOKEN
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-on-failure
+        with:
+          label-prefix: "[visual-failed]"
+          workflow-name: "visual-regression"
+          target: "${{ steps.sub.outputs.tag }} @ ${{ steps.sub.outputs.repo_id }}"
+          context: >-
+            test_visual_regression.py tripped an RMS-vs-baseline diff. A
+            render diverged from its committed baseline under
+            bake/preview/tests/baselines/ — most often a transmissive
+            material rendering opaque (#429-class) or a scalar/adapter
+            regression (#285). Inspect the pytest log for the material +
+            RMS delta; if the change is intentional, regenerate baselines
+            with MAT_VIS_UPDATE_BASELINES=1.

--- a/flake.nix
+++ b/flake.nix
@@ -27,8 +27,85 @@
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+
+        # ── nix-native baker toolchain (hybrid POC) ───────────────────
+        # nixpkgs materialx 1.39.4 ships the FULL render module
+        # (PyMaterialXRender.BaseType + PyMaterialXRenderGlsl.TextureBaker)
+        # and imports cleanly — no manylinux-wheel / LD_LIBRARY_PATH hack.
+        # This is the reproducible, rootless (no engine, no bridge network)
+        # tier: what `nix flake check` runs locally == what CI runs.
+        pyEnv = pkgs.python3.withPackages (
+          ps: with ps; [
+            materialx
+            pillow
+            pytest
+            requests
+            pyarrow
+            huggingface-hub
+            pyyaml
+          ]
+        );
+
+        # A pytest check derivation. Copies the tracked flake source (no
+        # .venv/.git — flakes only see git-tracked files) into a writable
+        # build dir and runs `testPath`. The sandbox has NO DISPLAY, so the
+        # GLX-bound bake tests skip cleanly; the display-free MaterialX
+        # API-contract tests (guarding the #442/#443/#445 signature+import
+        # regressions) run for real. Headless GLX stays in Dagger's
+        # `test-materialx` (Debian libgl1 wires mesa GLX; a bare nix X
+        # server does not — the one thing the container does more easily).
+        pytestCheck =
+          name: testPath: extraArgs:
+          pkgs.runCommand name { nativeBuildInputs = [ pyEnv ]; } ''
+            export HOME=$TMPDIR PYTHONDONTWRITEBYTECODE=1
+            cp -r ${./.} work && chmod -R u+w work && cd work
+            # repo root on PYTHONPATH so tests importing `scripts.*` resolve
+            export PYTHONPATH=$PWD/src:$PWD/clients/python/src:$PWD
+            python -m pytest ${testPath} -v -p no:cacheprovider ${extraArgs} \
+              --basetemp="$TMPDIR/pt" 2>&1 | tee "$out"
+          '';
       in
       {
+        # `nix flake check` runs these; also `nix build .#checks.<sys>.<name>`.
+        checks = {
+          materialx-smoke = pytestCheck "materialx-smoke" "tests/test_bake_mtlx_smoke.py" "";
+          # test_client_runtime_version_matches_pyproject reads the client
+          # version via importlib.metadata, which only resolves for an
+          # INSTALLED distribution. This check runs from the source tree, so
+          # that invariant belongs to the Dagger/pip `test` job (which does
+          # `pip install -e ./clients/python`), not here.
+          unit = pytestCheck "unit" "tests/" (
+            "--deselect tests/test_version_sync.py::test_client_runtime_version_matches_pyproject"
+          );
+        };
+
+        # Reproducible OCI baker base, built entirely by Nix (cache.nixos.org,
+        # no image pulls / podman bridge). `nix build .#baker-base` produces a
+        # tarball that `podman load < result` accepts ROOTLESS — the
+        # community-standard "Nix packages, podman runs" path (skopeo/
+        # containers-storage is podman's native stack). Feed this to Dagger's
+        # `_baker_container` via `from_()` to kill the unpinned-apt base and
+        # pin the toolchain.
+        packages.baker-base = pkgs.dockerTools.buildLayeredImage {
+          name = "mat-vis-baker-base";
+          tag = "nix";
+          contents = [
+            pyEnv
+            pkgs.xvfb-run
+            pkgs.xvfb
+            pkgs.mesa
+            pkgs.bashInteractive
+            pkgs.coreutils
+          ];
+          config = {
+            Env = [
+              "LIBGL_ALWAYS_SOFTWARE=1"
+              "PYTHONDONTWRITEBYTECODE=1"
+            ];
+            Entrypoint = [ "${pyEnv}/bin/python" ];
+          };
+        };
+
         devShells.default = devenv.lib.mkShell {
           inherit inputs pkgs;
           modules = [
@@ -45,10 +122,16 @@
                 pkgs.gh
                 pkgs.podman
                 pkgs.ruff
+                # headless-render toolchain, so the MaterialX smoke test can
+                # be attempted locally (`nix build .#checks.<sys>.materialx-smoke`
+                # is the canonical reproducible runner).
+                pkgs.xvfb-run
+                pkgs.mesa
+                pkgs.skopeo # load nix-built images into rootless podman
               ];
 
               enterShell = ''
-                echo "mat-vis dev shell — Python, uv, dagger, podman, ruff"
+                echo "mat-vis dev shell — Python, uv, dagger, podman, ruff, xvfb, skopeo"
               '';
 
               git-hooks.hooks = {

--- a/tests/test_bake_mtlx_smoke.py
+++ b/tests/test_bake_mtlx_smoke.py
@@ -1,0 +1,193 @@
+"""MaterialX baker smoke test — exercises the real ``TextureBaker`` API path.
+
+This is the ONLY test that drives :func:`mat_vis_baker.bake._bake_mtlx`
+end-to-end. It exists because the MaterialX bake path has repeatedly broken at
+the *API boundary* — ``TextureBaker.create()`` gained a required ``BaseType``
+third arg (#442/#443), and ``BaseType`` moved to the ``PyMaterialXRender``
+submodule (#444/#445). Every one of those regressions was caught only at CI
+*bake* runtime, one round-trip at a time, because a green ``pytest`` says
+nothing about calls that no test makes. This closes that gap.
+
+Two skip tiers keep it honest without penalising the slim path:
+
+* **``requires_mtlx``** — MaterialX + its render submodules must import. In the
+  slim CI image (no ``[materialx]`` extra) every test here skips cleanly, so the
+  default ``test-all`` job is unaffected. The API-contract test (below) runs
+  whenever MaterialX imports — no GPU/display needed.
+* **``requires_gl``** — the actual bake needs a live GLX/X11 context.
+  ``TextureBaker`` calls ``glXChooseVisual``/``XOpenDisplay``; EGL/SwiftShader
+  alone is insufficient (see ``/falsify`` on #438). The heavy Dagger image must
+  run ``Xvfb`` (``DISPLAY=:99``) first. Absent a display we skip the render
+  tests rather than fail flakily.
+
+Wired into CI via the ``test-materialx`` Dagger function (see
+``.dagger/src/mat_vis_ci/main.py``) and the ``materialx-test`` job in
+``ci.yml``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from mat_vis_baker.common import MaterialRecord
+
+
+def _materialx_importable() -> bool:
+    try:
+        import MaterialX  # noqa: F401
+        from MaterialX import PyMaterialXRender  # noqa: F401
+        from MaterialX import PyMaterialXRenderGlsl  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+MATERIALX = _materialx_importable()
+HAS_DISPLAY = bool(os.environ.get("DISPLAY"))
+
+requires_mtlx = pytest.mark.skipif(
+    not MATERIALX,
+    reason="MaterialX not installed — heavy [materialx] image / Dagger test-materialx only",
+)
+requires_gl = pytest.mark.skipif(
+    not HAS_DISPLAY,
+    reason="no DISPLAY — TextureBaker needs a live GLX context (Xvfb :99)",
+)
+
+
+# ── self-contained material fixture ────────────────────────────────────
+
+# A minimal, hermetic gpuopen-shaped MaterialX document. Mirrors the
+# production shape (a nodegraph feeding a standard_surface exposed via
+# <surfacematerial>) but depends on nothing outside its own directory:
+# base_color reads a PNG we generate at fixture time, roughness is a
+# procedural left-right ramp. Constant-only inputs can be folded to
+# uniforms and skipped by the baker, so at least one input is a real
+# texture (base_color) to guarantee TextureBaker emits a PNG.
+_SMOKE_MTLX = """<?xml version="1.0" encoding="utf-8"?>
+<materialx version="1.38">
+  <nodegraph name="NG_smoke">
+    <image name="base_img" type="color3">
+      <input name="file" type="filename" value="smoke_color.png" />
+    </image>
+    <ramplr name="rough_ramp" type="float">
+      <input name="valuel" type="float" value="0.1" />
+      <input name="valuer" type="float" value="0.9" />
+    </ramplr>
+    <output name="color_out" type="color3" nodename="base_img" />
+    <output name="rough_out" type="float" nodename="rough_ramp" />
+  </nodegraph>
+  <standard_surface name="SR_smoke" type="surfaceshader">
+    <input name="base_color" type="color3" output="color_out" nodegraph="NG_smoke" />
+    <input name="specular_roughness" type="float" output="rough_out" nodegraph="NG_smoke" />
+  </standard_surface>
+  <surfacematerial name="Smoke_Material" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_smoke" />
+  </surfacematerial>
+</materialx>
+"""
+
+
+@pytest.fixture
+def smoke_mtlx(tmp_path: Path) -> Path:
+    """Write the hermetic smoke material + its backing PNG to a tmpdir.
+
+    Returns the path to the ``.mtlx`` file. ``_bake_mtlx`` appends the
+    file's parent to the MaterialX search path, so the relative
+    ``smoke_color.png`` reference resolves.
+    """
+    mat_dir = tmp_path / "smoke_material"
+    mat_dir.mkdir()
+    # A small non-uniform gradient so the baked output is a genuine texture.
+    img = Image.new("RGB", (8, 8))
+    img.putdata([(x * 32, y * 32, 128) for y in range(8) for x in range(8)])
+    img.save(mat_dir / "smoke_color.png", "PNG")
+
+    mtlx_path = mat_dir / "smoke.mtlx"
+    mtlx_path.write_text(_SMOKE_MTLX)
+    return mtlx_path
+
+
+# ── API-contract tests (no GL context needed) ──────────────────────────
+
+
+@requires_mtlx
+def test_basetype_lives_in_render_submodule() -> None:
+    """Guards #444/#445: ``bake.py`` imports ``BaseType`` from
+    ``PyMaterialXRender``. If a MaterialX release ever moves it, this fails
+    at pytest time instead of at CI bake time."""
+    from MaterialX import PyMaterialXRender as mx_base_render
+
+    assert hasattr(mx_base_render, "BaseType"), (
+        "BaseType missing from PyMaterialXRender — bake.py import site is stale"
+    )
+    assert hasattr(mx_base_render.BaseType, "UINT8"), (
+        "BaseType.UINT8 missing — bake.py passes it as the TextureBaker LDR base type"
+    )
+
+
+@requires_mtlx
+def test_texturebaker_create_rejects_two_arg_call() -> None:
+    """Guards #442/#443: ``TextureBaker.create()`` requires a third
+    ``BaseType`` arg. The pre-fix two-arg call must not be a valid overload
+    — that regression shipped twice and was only caught at bake runtime.
+
+    This check is display-free: pybind resolves the (missing) overload and
+    raises ``TypeError`` *before* the C++ body runs, so no GLX context is
+    touched. The valid three-arg construction opens a display and is
+    exercised by ``test_bake_mtlx_produces_flat_pngs`` under ``requires_gl``.
+    """
+    from MaterialX import PyMaterialXRenderGlsl as mx_render
+
+    with pytest.raises(TypeError):
+        mx_render.TextureBaker.create(64, 64)
+
+
+# ── end-to-end bake (needs Xvfb / GLX) ─────────────────────────────────
+
+
+@requires_mtlx
+@requires_gl
+def test_bake_mtlx_produces_flat_pngs(smoke_mtlx: Path) -> None:
+    """The whole ``_bake_mtlx`` path: load doc + stdlib, create the baker
+    with the correct signature, bake all materials, map outputs to canonical
+    channels. Asserts real PNG bytes land on disk."""
+    from mat_vis_baker.bake import _bake_mtlx
+
+    out_dir = smoke_mtlx.parent / "baked"
+    baked = _bake_mtlx(smoke_mtlx, out_dir, resolution_px=64)
+
+    assert baked, "TextureBaker produced no channels — bake API path is broken"
+    # base_color -> 'color' via bake.py's channel_map.
+    assert "color" in baked, f"expected a color channel, got {sorted(baked)}"
+    for channel, path in baked.items():
+        assert path.exists(), f"{channel}: baked path missing"
+        assert path.stat().st_size > 0, f"{channel}: empty PNG"
+        with Image.open(path) as im:
+            assert im.format == "PNG", f"{channel}: not a PNG ({im.format})"
+
+
+@requires_mtlx
+@requires_gl
+def test_bake_material_routes_mtlx_records(smoke_mtlx: Path, tmp_path: Path) -> None:
+    """Higher-level guard: a ``needs_mtlx_bake`` record flows through
+    ``bake_material`` — the branch that swallows ``ImportError``/
+    ``NotImplementedError`` and flips ``status='failed'``. A green result
+    here proves the record wiring (``maps`` populated, status preserved),
+    not just the low-level bake."""
+    from mat_vis_baker.bake import bake_material
+
+    record = MaterialRecord(
+        id="Smoke_Material",
+        source="gpuopen",
+        needs_mtlx_bake=True,
+        texture_paths={"_mtlx": smoke_mtlx},
+    )
+    out = bake_material(record, tmp_path / "out", tier="1k")
+
+    assert out.status != "failed", "mtlx bake failed through bake_material()"
+    assert "color" in out.maps, f"expected color in maps, got {out.maps}"


### PR DESCRIPTION
Makes the MaterialX bake path — our recurring bug surface — actually testable, and adds a reproducible nix tier. All of it validated on real Dagger (`dagger call test-materialx` → **4 passed**, including the live GLX bake).

## What's here
- **`tests/test_bake_mtlx_smoke.py`** — the first test to drive the real `TextureBaker`. Two display-free API-contract tests guard the `BaseType` import location (#445) and `create()` signature (#443); two GLX bake tests run the actual render under a live display. Skips cleanly where MaterialX/display absent, so the slim `test-all` is unaffected.
- **Fix #441 root cause** — `TextureBaker` needs a live GLX display for the *whole* render, but the backgrounded `Xvfb &` from a prior `with_exec` layer is already dead by bake time (Dagger runs each exec as a fresh process tree). New `XVFB_RUN` wraps the gpuopen bake + the smoke test so the server lives inside the render exec. Removes the dead Xvfb start + misleading static `DISPLAY`; adds `xauth`.
- **CI gates** — `test-materialx` Dagger fn + `materialx-test` job (blocks the image `push`); `test-visual` fn + scheduled **`visual-regression.yml`** that ungates the RMS-vs-baseline suite (catches the transmissive-renders-opaque class, #429).
- **nix hybrid POC** — `flake.nix` gains `checks.{materialx-smoke,unit}` + a `baker-base` OCI image (`dockerTools`), reproducible and rootless (nixpkgs `materialx` ships the full render module — no wheel hack).
- **`.dagger/dagger.json`** — pin `engineVersion: v0.20.8` (latest 0.21.7's beartype rejects `Optional[dagger.Directory]` and fails module load).

## Closes / relates
- Closes #441 (bake had no live display — root cause fixed + validated)
- Relates #429 (visual-regression now gates the transmissive class), #443/#445 (now guarded by tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
