### PR TITLE
fix(baker): skip status=failed materials in thumb publish (#428)

### DIFF
--- a/src/mat_vis_baker/hf_thumb_publish.py
+++ b/src/mat_vis_baker/hf_thumb_publish.py
@@ -178,9 +178,20 @@ def publish_thumb_tier(
 
     log.info("found %d local thumbs for %s", len(locals_), source)
 
+    # #428: skip materials marked status="failed" in the catalog — their
+    # thumbs are the renderer's default white sphere (no baseColor applied)
+    # and ship as broken-looking placeholder cards in the gallery (#423).
+    # Fetch the catalog once here for the status filter and reuse it for the
+    # catalog + manifest update below (previously fetched only post-loop).
+    catalog = _fetch_catalog(repo_id, release_tag, source, hf_token)
+    failed_ids = {e["id"] for e in (catalog or []) if e.get("status") == "failed" and e.get("id")}
+    if failed_ids:
+        log.info("thumb: skipping %d status=failed materials for %s", len(failed_ids), source)
+
     n_ok = 0
     n_failed = 0
     n_skipped = 0
+    n_skipped_failed = 0
     derived_ids: set[str] = set()
     last_commit_sha = ""
 
@@ -226,6 +237,9 @@ def publish_thumb_tier(
         return sha or last_commit_sha
 
     for i, (mid, png_path) in enumerate(locals_):
+        if mid in failed_ids:  # #428 — don't publish default-sphere thumbs
+            n_skipped_failed += 1
+            continue
         target_path = f"{source}/{THUMB_TIER}/{mid}/{THUMB_CHANNEL}.png"
         target_url = _resolve_url(repo_id, release_tag, target_path)
 
@@ -272,15 +286,20 @@ def publish_thumb_tier(
         pending_bytes = 0
 
     if n_ok == 0 and n_skipped == 0:
-        return {
-            "error": "no thumbs published",
+        out = {
             "ok": 0,
             "failed": n_failed,
             "skipped_preflight": 0,
+            "skipped_failed": n_skipped_failed,
         }
+        # All-failed (everything status=failed and correctly skipped) is a
+        # valid no-op, not a failure — only flag when nothing was filtered.
+        if n_skipped_failed == 0:
+            out["error"] = "no thumbs published"
+        return out
 
     # ── catalog + manifest update (CAS-retried) ──────────────────
-    catalog = _fetch_catalog(repo_id, release_tag, source, hf_token)
+    # catalog was fetched once up front (for the #428 status filter) — reuse it
     if catalog:
         _extend_available_tiers(catalog, derived_ids, THUMB_TIER)
         _extend_maps_for_thumb(catalog, derived_ids)
@@ -369,11 +388,13 @@ def publish_thumb_tier(
         )
 
     log.info(
-        "PERF thumb publish: %.1fs, %d ok / %d failed / %d skipped (preflight)",
+        "PERF thumb publish: %.1fs, %d ok / %d failed / %d skipped-preflight / "
+        "%d skipped-failed (#428)",
         time.monotonic() - t0,
         n_ok,
         n_failed,
         n_skipped,
+        n_skipped_failed,
     )
 
     return {
@@ -381,5 +402,6 @@ def publish_thumb_tier(
         "ok": n_ok,
         "failed": n_failed,
         "skipped_preflight": n_skipped,
+        "skipped_failed": n_skipped_failed,
         "materials": len(locals_),
     }

--- a/tests/test_hf_thumb_publish.py
+++ b/tests/test_hf_thumb_publish.py
@@ -151,6 +151,46 @@ def test_publish_sentinel_is_last_commit(tmp_path: Path):
     assert ops[0].path_in_repo == "ambientcg/thumb/.tier_complete"
 
 
+def test_publish_skips_status_failed_materials(tmp_path: Path):
+    """#428: materials marked status=failed in the catalog must not get a
+    published thumb — the renderer ships a default white sphere for them."""
+    for mid in ("Good_A", "Bad_B", "Good_C"):
+        _make_png(tmp_path / "gpuopen" / mid / "thumb.png")
+    catalog = [
+        {"id": "Good_A", "status": "ok", "maps": ["color"]},
+        {"id": "Bad_B", "status": "failed"},
+        {"id": "Good_C", "status": "ok", "maps": ["color"]},
+    ]
+    fake_api = MagicMock()
+    with (
+        patch("mat_vis_baker.hf_thumb_publish.HfApi", return_value=fake_api),
+        patch("mat_vis_baker.hf_thumb_publish._http_head_ok", return_value=False),
+        patch("mat_vis_baker.hf_thumb_publish._fetch_catalog", return_value=catalog),
+        patch(
+            "mat_vis_baker.hf_thumb_publish._fetch_manifest_with_parent",
+            return_value=({}, "parent"),
+        ),
+        patch("mat_vis_baker.hf_thumb_publish._create_commit_with_backoff") as mock_commit,
+    ):
+        mock_commit.return_value.oid = "x"
+        result = publish_thumb_tier(
+            source="gpuopen",
+            release_tag="v0.0.0-tst",
+            thumbs_dir=tmp_path,
+            repo_id="gerchowl/mat-vis-tst",
+        )
+    committed = [
+        op.path_in_repo
+        for call in mock_commit.call_args_list
+        for op in call.kwargs.get("operations", [])
+    ]
+    assert any(p == "gpuopen/thumb/Good_A/thumb.png" for p in committed)
+    assert any(p == "gpuopen/thumb/Good_C/thumb.png" for p in committed)
+    assert not any("Bad_B" in p for p in committed), "status=failed thumb must not be published"
+    assert result["ok"] == 2
+    assert result["skipped_failed"] == 1
+
+
 def test_publish_skips_bad_png_bytes(tmp_path: Path):
     # Write a non-PNG file as thumb.png — magic-byte verify must reject.
     bad = tmp_path / "ambientcg" / "Bad" / "thumb.png"


### PR DESCRIPTION
Closes #428 (P0).

`status=failed` gpuopen materials render as the default white sphere (no baseColor) but were still published as thumbs — a duplicate-byte cluster of 8 identical 14573B white spheres on tst, all 18 failed records with a published thumb. #423 gallery would render these as broken cards.

`publish_thumb_tier` now fetches the catalog once up front, builds the `status==failed` id set, and skips those materials before write — reported as `skipped_failed`. The up-front catalog fetch is reused for the manifest update (one fetch, not two). All-failed is a valid no-op (no error). New unit test `test_publish_skips_status_failed_materials`; full thumb-publish suite green (10 passed, locally validated).

P1 (status=null policy, `_bake_complete` count #385) + the tst re-bake cleanup stay as follow-ups on #428.

Note: CI is red until #450 merges (dagger-drift #451); logic validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)