### PR TITLE
fix(baker): typed error on tag/branch name collision in push_to_hf (#117)

### DIFF
--- a/src/mat_vis_baker/hf_push.py
+++ b/src/mat_vis_baker/hf_push.py
@@ -20,6 +20,24 @@ from pathlib import Path
 log = logging.getLogger("mat-vis-baker.hf_push")
 
 
+class TagShadowsBranchError(RuntimeError):
+    """A tag shadows the intended branch revision, so HF rejects the commit.
+
+    Our release flow reuses the same calver string for both the mutable
+    working branch (incremental bakes) and the immutable consumer tag. When
+    the tag already exists, ``HfApi.create_commit(revision=<name>)`` resolves
+    the ambiguous revision to the immutable tag and rejects the branch commit
+    with a raw ``BadRequestError``. ``push_to_hf`` converts that into this
+    typed error carrying an actionable recovery hint (issue #117).
+    """
+
+
+def _is_tag_shadow_error(exc: Exception) -> bool:
+    """True if ``exc`` is HF's "tag shadows branch" rejection (#117)."""
+    msg = str(exc).lower()
+    return "tag with the same name" in msg or "cannot commit to this branch" in msg
+
+
 def push_to_hf(
     repo_id: str,
     files: list[tuple[Path, str]],
@@ -55,7 +73,7 @@ def push_to_hf(
         return ""
 
     from huggingface_hub import CommitOperationAdd, CommitOperationDelete, HfApi
-    from huggingface_hub.errors import RevisionNotFoundError
+    from huggingface_hub.errors import HfHubHTTPError, RevisionNotFoundError
 
     resolved_token = token if token is not None else os.environ.get("HF_TOKEN")
     api = HfApi(token=resolved_token)
@@ -79,13 +97,28 @@ def push_to_hf(
     ]
     operations.extend(CommitOperationDelete(path_in_repo=p) for p in delete_paths)
 
-    commit_info = api.create_commit(
-        repo_id=repo_id,
-        repo_type="dataset",
-        operations=operations,
-        commit_message=commit_message,
-        revision=revision,
-    )
+    try:
+        commit_info = api.create_commit(
+            repo_id=repo_id,
+            repo_type="dataset",
+            operations=operations,
+            commit_message=commit_message,
+            revision=revision,
+        )
+    except HfHubHTTPError as exc:
+        if not _is_tag_shadow_error(exc):
+            raise
+        # #117: a tag shadows the intended branch. Fail with an actionable
+        # typed error instead of leaking the raw 400 mid-bake.
+        raise TagShadowsBranchError(
+            f"cannot commit to branch {revision!r} on {repo_id!r}: a tag with the "
+            f"same name shadows it, so Hugging Face resolved the revision to the "
+            f"immutable tag and rejected the commit. Recover by deleting the tag "
+            f"(HfApi.delete_tag(repo_id={repo_id!r}, tag={revision!r}, "
+            f"repo_type='dataset')) before re-running, or target a branch-shaped "
+            f"revision such as 'release/{revision}' and tag at HEAD once the bake "
+            f"matrix completes. See issue #117."
+        ) from exc
 
     sha = getattr(commit_info, "oid", "") or getattr(commit_info, "commit_oid", "")
     log.info(

--- a/tests/test_hf_push.py
+++ b/tests/test_hf_push.py
@@ -5,12 +5,13 @@ All HF API calls are mocked — these tests must not touch the network.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from mat_vis_baker.hf_push import push_to_hf
+from mat_vis_baker.hf_push import TagShadowsBranchError, push_to_hf
 
 
 @pytest.fixture
@@ -147,3 +148,111 @@ def test_no_branch_creation_when_disabled(fake_files: list[tuple[Path, str]]) ->
             )
 
         api.create_branch.assert_not_called()
+
+
+def test_tag_shadow_raises_typed_error(fake_files: list[tuple[Path, str]]) -> None:
+    """#117: a tag shadowing the branch → typed error, not the raw 400."""
+    from huggingface_hub.errors import HfHubHTTPError
+
+    with patch("huggingface_hub.HfApi") as api_cls:
+        api = api_cls.return_value
+        api.list_repo_commits.return_value = [MagicMock()]  # branch exists
+        api.create_commit.side_effect = HfHubHTTPError(
+            "You cannot commit to this branch because a tag with the same "
+            "name exists (Request ID: Root=1-deadbeef)",
+            response=MagicMock(status_code=400),
+        )
+
+        with pytest.raises(TagShadowsBranchError) as ei:
+            push_to_hf(
+                repo_id="gerchowl/mat-vis",
+                files=fake_files,
+                revision="v2026.04.1",
+                commit_message="m",
+                token="t0k",
+            )
+
+    # The typed error must be actionable — name the recovery paths + the issue.
+    msg = str(ei.value)
+    assert "v2026.04.1" in msg
+    assert "delete_tag" in msg
+    assert "release/" in msg
+    assert "#117" in msg
+    # And preserve the underlying HF error as the cause.
+    assert ei.value.__cause__ is not None
+
+
+def test_non_shadow_http_error_propagates(fake_files: list[tuple[Path, str]]) -> None:
+    """An unrelated HF 4xx/5xx is NOT swallowed into the typed error."""
+    from huggingface_hub.errors import HfHubHTTPError
+
+    with patch("huggingface_hub.HfApi") as api_cls:
+        api = api_cls.return_value
+        api.list_repo_commits.return_value = [MagicMock()]
+        api.create_commit.side_effect = HfHubHTTPError(
+            "500 Internal Server Error", response=MagicMock(status_code=500)
+        )
+
+        with pytest.raises(HfHubHTTPError):
+            push_to_hf(
+                repo_id="gerchowl/mat-vis",
+                files=fake_files,
+                revision="v2026.04.1",
+                commit_message="m",
+                token="t0k",
+            )
+
+
+# --- AC3: live-network regression, skipped by default -----------------------
+# Opt in with MAT_VIS_LIVE_HF=1 and a HF_TOKEN carrying WRITE scope on the
+# scratch dataset. Creates a throwaway branch + shadowing tag, asserts
+# push_to_hf raises the typed error (not a raw BadRequestError), and tears
+# everything down. Never touches prod.
+_LIVE_REPO = "gerchowl/mat-vis-tst"
+_LIVE_NAME = "v0.0.0-issue117-pytest"
+
+
+@pytest.mark.skipif(
+    os.environ.get("MAT_VIS_LIVE_HF") != "1" or not os.environ.get("HF_TOKEN"),
+    reason="live HF regression — set MAT_VIS_LIVE_HF=1 + HF_TOKEN (write on scratch repo)",
+)
+def test_tag_shadow_live_regression(tmp_path: Path) -> None:
+    from huggingface_hub import HfApi
+    from huggingface_hub.utils import HfHubHTTPError
+
+    assert _LIVE_REPO != "gerchowl/mat-vis", "refuse to run against prod"
+    api = HfApi(token=os.environ["HF_TOKEN"])
+
+    def _teardown() -> None:
+        for fn, kw in (
+            (api.delete_tag, {"tag": _LIVE_NAME}),
+            (api.delete_branch, {"branch": _LIVE_NAME}),
+        ):
+            try:
+                fn(repo_id=_LIVE_REPO, repo_type="dataset", **kw)
+            except HfHubHTTPError:
+                pass
+
+    payload = tmp_path / "probe.txt"
+    payload.write_text("issue-117 pytest live probe\n")
+
+    _teardown()  # fresh start
+    try:
+        api.create_branch(
+            repo_id=_LIVE_REPO, repo_type="dataset", branch=_LIVE_NAME,
+            revision="main", exist_ok=True,
+        )
+        api.create_tag(
+            repo_id=_LIVE_REPO, repo_type="dataset", tag=_LIVE_NAME,
+            revision="main", exist_ok=True,
+        )
+        with pytest.raises(TagShadowsBranchError):
+            push_to_hf(
+                repo_id=_LIVE_REPO,
+                files=[(payload, "issue117/probe.txt")],
+                revision=_LIVE_NAME,
+                commit_message="issue117 live regression",
+                token=os.environ["HF_TOKEN"],
+            )
+    finally:
+        _teardown()


### PR DESCRIPTION
## What

`hf_push.push_to_hf` now converts HF's raw `BadRequestError` — *"You cannot commit to this branch because a tag with the same name exists"* — into a typed **`TagShadowsBranchError`** carrying an actionable recovery hint. Closes the code half of #117 (**AC1** + **AC3**).

## Why

The release flow reuses the same calver string for both the mutable working **branch** (incremental bakes) and the immutable consumer **tag**. Once the tag exists, `create_commit(revision=<name>)` resolves the ambiguous revision to the immutable tag and rejects the branch commit — surfacing a raw 400 mid-bake (first hit on `v2026.04.1`, per the issue).

## How the fix was chosen (live-probed, not guessed)

I ran a live probe against the scratch dataset `gerchowl/mat-vis-tst`:

| Candidate | Result |
|---|---|
| **A** — `revision="refs/heads/<name>"` to force branch resolution | ❌ HF rejects it too — can't paper over in the client |
| **B** — strip tag → commit → re-create | ✅ works, but the issue explicitly rejects auto-stripping ("the tag might have been valuable") |

So the issue's recommended **option 3 (typed-error safety net)** is the right client behavior. Implemented **reactively** (catch-and-convert) rather than a proactive `list_repo_refs` probe: no extra API call per push, no check-then-commit race, reflects HF's real server verdict.

## Tests

- **Mocked (CI-safe):** typed error raised with recovery hint + preserved `__cause__`; unrelated 4xx/5xx still propagate untouched.
- **Live regression (AC3):** creates a throwaway branch + shadowing tag on `gerchowl/mat-vis-tst`, asserts `push_to_hf` raises `TagShadowsBranchError` (not the raw 400), tears everything down. Gated behind `MAT_VIS_LIVE_HF=1` + `HF_TOKEN`; **verified green** against the scratch repo (2.5s).

## Follow-up (not in this PR)

**AC2** — migrate `bake.yml` to a branch-shaped revision (`release/vYYYY.MM.N`) with a distinct tag-at-HEAD step so the collision is *structurally* impossible. That touches the release pipeline and interacts with `release-validate` / `bake.yml` tag-history lookups, so it gets its own PR + review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)