### PR TITLE
refactor(client): retire #284 flat-v2 name fallback; lock v3-nested invariant (#291)

### DIFF
--- a/clients/python/src/mat_vis_client/client.py
+++ b/clients/python/src/mat_vis_client/client.py
@@ -1987,13 +1987,14 @@ class MatVisClient:
         by_id: dict | None = None
         by_name: list[dict] = []
 
-        # Per-entry display name. v3 entries carry it under the
-        # ``mat_vis`` envelope; ambientcg/polyhaven flat-v2 entries
-        # carry it at the top level (#284). Fall back to the canonical
-        # id so the name-list never holds an empty string.
+        # Per-entry display name. All sources emit v3-nested entries that
+        # carry the name under the ``mat_vis`` envelope (#291 — the #284
+        # flat-v2 top-level fallback is retired now that no flat-v2 data
+        # ships). Fall back to the canonical id so the name-list never
+        # holds an empty string.
         def _display_name(entry: dict) -> str:
             envelope = entry.get("mat_vis") or {}
-            return envelope.get("name") or entry.get("name") or entry.get("id", "")
+            return envelope.get("name") or entry.get("id", "")
 
         for entry in idx:
             if not isinstance(entry, dict):

--- a/clients/python/tests/test_errors.py
+++ b/clients/python/tests/test_errors.py
@@ -399,25 +399,43 @@ def test_material_not_staged_error_direct_uuid_unchanged():
     assert "resolved id" not in msg
 
 
-# ── Hotfix #284: ambientCG/polyhaven flat-v2 name addressability ──
+# ── #291: v3-nested name addressability (retires the #284 flat-v2 fallback) ──
 
 
-def test_resolve_name_falls_back_to_top_level_name_field():
-    """ambientcg/polyhaven catalogs use a flat v2 schema with top-level
-    ``name`` (no ``mat_vis`` envelope). Name lookup must hit those too
-    (#284).
-    """
+def test_resolve_name_uses_mat_vis_envelope():
+    """All sources emit v3-nested entries; name lookup resolves via
+    ``mat_vis.name`` (#291). This is the canonical path the #284 hotfix's
+    flat-v2 fallback was bridging to before the migration completed."""
     from unittest.mock import patch
 
     client = _client_with_index(
         rowmap_materials={"Bricks104": {"color": {"offset": 0, "length": 10}}},
-        # NB: no mat_vis envelope; flat top-level name field.
-        index_entries=[{"id": "Bricks104", "name": "Bricks 104"}],
+        index_entries=[{"id": "Bricks104", "mat_vis": {"name": "Bricks 104"}}],
     )
     with patch.object(client, "fetch_texture", return_value=b"\x89PNG") as ft:
         out = client.fetch_all_textures("gpuopen", "Bricks 104", tier="1k")
     assert out == {"color": b"\x89PNG"}
     ft.assert_called_once_with("gpuopen", "Bricks104", "color", "1k")
+
+
+def test_flat_v2_top_level_name_no_longer_resolvable():
+    """#291 retired the flat-v2 top-level ``name`` fallback. A legacy-shaped
+    entry (top-level ``name``, no ``mat_vis`` envelope) is therefore NOT
+    name-addressable — only its id resolves. Guards the intentional behaviour
+    change so it's documented, not a silent surprise."""
+    from unittest.mock import patch
+
+    client = _client_with_index(
+        rowmap_materials={"Bricks104": {"color": {"offset": 0, "length": 10}}},
+        index_entries=[{"id": "Bricks104", "name": "Bricks 104"}],  # flat-v2 shape
+    )
+    with patch.object(client, "fetch_texture", return_value=b"\x89PNG"):
+        # Top-level name no longer matches.
+        with pytest.raises(MatVisError):
+            client.fetch_all_textures("gpuopen", "Bricks 104", tier="1k")
+        # ...but the canonical id still resolves.
+        out = client.fetch_all_textures("gpuopen", "Bricks104", tier="1k")
+    assert out == {"color": b"\x89PNG"}
 
 
 def test_resolve_name_prefers_mat_vis_name_over_top_level():
@@ -514,9 +532,9 @@ def test_ambiguous_material_error_lists_names():
             "uuid-y": {"color": {"offset": 0, "length": 10}},
         },
         index_entries=[
-            # Two distinct flat-v2 entries that normalize to the same name.
-            {"id": "uuid-x", "name": "Brick Wall"},
-            {"id": "uuid-y", "name": "brick wall"},
+            # Two distinct v3-nested entries that normalize to the same name.
+            {"id": "uuid-x", "mat_vis": {"name": "Brick Wall"}},
+            {"id": "uuid-y", "mat_vis": {"name": "brick wall"}},
         ],
     )
     with pytest.raises(AmbiguousMaterialError) as exc:

--- a/tests/test_index_nested_name_invariant.py
+++ b/tests/test_index_nested_name_invariant.py
@@ -1,0 +1,73 @@
+"""Lock the v3-nested schema invariant at the serializer (#291).
+
+Every source (ambientcg, polyhaven, gpuopen, physicallybased) must emit a
+material's display name under the ``mat_vis`` envelope and **never** as a
+top-level ``name`` field. This was the flat-v2 vs v3-nested inconsistency the
+#284 client hotfix papered over; #291 confirms the migration is complete and
+guards it from silently regressing.
+
+These tests run against ``build_index`` — the single serialization choke point
+every source funnels through — so the invariant holds for all sources at once,
+hermetically, in every CI run. If a future change reintroduces a top-level
+``name`` (or drops ``mat_vis.name``), this fails loudly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mat_vis_baker.common import MaterialRecord, MatVisBlock
+from mat_vis_baker.index_builder import build_index
+
+# The four production sources — the invariant is source-independent, but
+# parametrizing documents that it is asserted for all of them.
+ALL_SOURCES = ["ambientcg", "polyhaven", "gpuopen", "physicallybased"]
+
+
+def _record(mid: str, name: str, source: str) -> MaterialRecord:
+    return MaterialRecord(
+        id=mid,
+        source=source,
+        mat_vis=MatVisBlock(name=name, category="stone"),
+        available_tiers=["1k"],
+        maps=["color"],
+    )
+
+
+@pytest.mark.parametrize("source", ALL_SOURCES)
+def test_name_is_nested_never_top_level(source: str) -> None:
+    """The display name lives at ``entry['mat_vis']['name']`` and there is
+    NO top-level ``name`` key — for every source."""
+    entries = build_index([_record("Mat001", "Polished Marble", source)], source)
+    assert len(entries) == 1
+    entry = entries[0]
+
+    # Nested name is present and carries the value.
+    assert entry["mat_vis"]["name"] == "Polished Marble"
+    # The flat-v2 shape must never reappear.
+    assert "name" not in entry, (
+        f"{source}: top-level 'name' leaked into the catalog entry — the v3 "
+        f"migration (#291) requires the name under mat_vis only"
+    )
+
+
+@pytest.mark.parametrize("source", ALL_SOURCES)
+def test_stable_top_level_key_set_has_no_name(source: str) -> None:
+    """Freeze the top-level key set so a stray ``name`` (or any flat-v2
+    scalar) can't slip back in unnoticed."""
+    entries = build_index([_record("Mat001", "Slate", source)], source)
+    top_keys = set(entries[0].keys())
+    # id/source/mat_vis/maps/available_tiers are the always-present core;
+    # texture_hashes/upstream/status are conditional and absent here.
+    assert top_keys == {"id", "source", "mat_vis", "maps", "available_tiers"}
+    assert "name" not in top_keys
+    assert "category" not in top_keys  # another flat-v2 field that must stay nested
+
+
+def test_empty_name_still_nested_not_promoted() -> None:
+    """A record with an empty name (extractor had none) keeps the nested
+    slot — it must not fall back to synthesizing a top-level ``name``."""
+    entries = build_index([_record("Mat001", "", "gpuopen")], "gpuopen")
+    entry = entries[0]
+    assert entry["mat_vis"]["name"] == ""
+    assert "name" not in entry


### PR DESCRIPTION
## What

Closes out #291's actual intent — *stop paying the dual-shape (flat-v2 vs v3-nested) tax* — now that the fetcher migration it tracked is verified complete.

## Key finding (verified against live data)

#291 was filed to "migrate ambientcg/polyhaven flat-v2 fetchers to v3 nested." Inspecting the **published v2026.04.2** catalogs shows all four sources **already emit v3-nested** entries:

| source | top-level `name`? | `mat_vis.name` |
|---|---|---|
| ambientcg | ❌ none | ✅ `Acoustic Foam 001` |
| polyhaven | ❌ none | ✅ `Aerial Asphalt 01` |
| gpuopen | ❌ none | ✅ `Red Brick Wall Weathered` |
| physicallybased | ❌ none | ✅ (nested) |

The migration landed in ADR-0011 Phase C (after the issue was filed). So there's nothing to migrate — what remained is retiring the now-**dead** #284 client fallback.

## Changes

- **client** — drop the dead top-level `name` fallback in `_display_name` (`client.py:1996`). No flat-v2 data ships anywhere (prod has only v3-nested v2026.04.2), so the #284 bridge is dead code. Names resolve via `mat_vis.name` → id.
- **test (baker, hermetic)** — `tests/test_index_nested_name_invariant.py` locks the invariant at `build_index`, the single serializer every source funnels through: name is nested, top-level key set never contains `name`/`category`. Reintroducing a flat-v2 field fails loudly in **every CI run** — the "don't let future versions bite us" guard.
- **test (client)** — repurpose the #284 flat-fallback tests → canonical-envelope path + a test documenting the intentional behaviour change (flat-only entries resolve by id, not top-level name). Migrate the #286 ambiguous-name fixtures to v3-nested.

Kept the harmless `entry.get("mat_vis") or {}` defensive reads — this retires **only** the genuinely-dead top-level-name fallback (conservative scope, per owner sign-off).

## Not in scope

No data re-publish needed (already v3-nested). This is the whole of #291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)