### PR TITLE
fix(baker): gpuopen — extract textures at mtlx-referenced paths, not renamed (#461)

### DIFF
--- a/src/mat_vis_baker/sources/gpuopen.py
+++ b/src/mat_vis_baker/sources/gpuopen.py
@@ -206,6 +206,25 @@ def _inject_mtlx_comment(mtlx_bytes: bytes, material_id: str, source_url: str) -
     return comment + text
 
 
+def _rel_under_mtlx(member: str, mtlx_prefix: str) -> str:
+    """Path a texture member should occupy under ``mat_dir`` so the mtlx's
+    ``<image file="...">`` refs resolve at bake time (#461).
+
+    The mtlx is flattened to ``mat_dir/material.mtlx``, so its refs (e.g.
+    ``textures/Foo_baseColor.png``) resolve relative to ``mat_dir``. We strip
+    the mtlx's own zip sub-dir prefix and keep the remainder — so a zip laid
+    out as ``Foo/material.mtlx`` + ``Foo/textures/bar.png`` yields
+    ``mat_dir/textures/bar.png``. Members outside the prefix keep their full
+    relative path. Sanitized against zip-slip (drops ``..`` / absolute parts).
+    """
+    if mtlx_prefix and member.startswith(mtlx_prefix):
+        rel = member[len(mtlx_prefix) :]  # noqa: E203
+    else:
+        rel = member  # mtlx at zip root, or member outside its dir
+    parts = [p for p in rel.replace("\\", "/").split("/") if p not in ("", ".", "..")]
+    return "/".join(parts) or "texture"
+
+
 def _extract_from_zip(
     zip_bytes: bytes,
     material_id: str,
@@ -213,7 +232,17 @@ def _extract_from_zip(
     *,
     mtlx_dir: Path | None = None,
 ) -> tuple[Path | None, dict[str, Path]]:
-    """Extract .mtlx and texture files from a ZIP. Returns (mtlx_path, {channel: path})."""
+    """Extract .mtlx and texture files from a ZIP. Returns (mtlx_path, {channel: path}).
+
+    #461: source images are written at the path the mtlx **references** them by
+    (relative to the mtlx's dir), not renamed to a channel name. TextureBaker
+    resolves ``<image file="textures/Foo_baseColor.png">`` relative to the
+    mtlx's parent (``mat_dir``); the pre-#461 behaviour renamed images to
+    ``color.png`` and dropped non-channel images (masks), so every image-based
+    gpuopen bake failed with "Image file not found" → no output PNGs. The
+    ``{channel: path}`` map is still built (for the neutral-multiplier
+    convention and the no-mtlx flat path), now pointing at the preserved paths.
+    """
     mat_dir = output_dir / material_id
     mat_dir.mkdir(parents=True, exist_ok=True)
     mtlx_path: Path | None = None
@@ -222,18 +251,26 @@ def _extract_from_zip(
     source_url = f"https://matlib.gpuopen.com/main/materials/all?material={material_id}"
 
     with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
-        # Validate before any read — rejects decompression bombs. Output
-        # paths are derived from normalized channel names (not member
-        # names), so zip-slip is already avoided; this check covers the
-        # bomb case where a malicious member has huge uncompressed size.
+        # Validate before any read — rejects decompression bombs. Texture
+        # output paths are sanitized in _rel_under_mtlx (drops ``..``), so
+        # zip-slip stays covered even though we now preserve member paths.
         check_zip_safety(zf)
-        for name in zf.namelist():
-            if name.endswith("/"):
-                continue
+        members = [n for n in zf.namelist() if not n.endswith("/")]
+
+        # Locate the mtlx first: texture members are placed relative to its
+        # dir so its <image file="..."> refs resolve at bake time.
+        mtlx_member = next(
+            (n for n in members if n.rsplit("/", 1)[-1].lower().endswith(".mtlx")), None
+        )
+        mtlx_prefix = (
+            mtlx_member.rsplit("/", 1)[0] + "/" if mtlx_member and "/" in mtlx_member else ""
+        )
+
+        for name in members:
             basename = name.rsplit("/", 1)[-1].lower()
 
-            if basename.endswith(".mtlx"):
-                # Save to working dir for bake pipeline
+            if name == mtlx_member:
+                # Save to working dir for bake pipeline (flattened).
                 mtlx_path = mat_dir / "material.mtlx"
                 raw = zf.read(name)
                 mtlx_path.write_bytes(raw)
@@ -245,19 +282,19 @@ def _extract_from_zip(
                 continue
 
             if _IMG_RE.search(basename):
-                # Try to extract channel from filename
-                stem = basename.rsplit(".", 1)[0]
-                # Common patterns: basecolor.png, *_basecolor.png, *_normal.png
-                parts = re.split(r"[_\-]", stem)
+                # Preserve the mtlx-relative path so <image> refs resolve.
+                out_path = mat_dir / _rel_under_mtlx(name, mtlx_prefix)
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                out_path.write_bytes(zf.read(name))
+                # Map to a canonical channel when derivable — used by the
+                # neutral-multiplier convention and the no-mtlx flat path.
+                stem = out_path.stem.lower()
                 channel = None
-                for part in reversed(parts):
+                for part in reversed(re.split(r"[_\-]", stem)):
                     channel = normalize_channel("gpuopen", part)
                     if channel:
                         break
                 if channel and channel not in textures:
-                    ext = basename.rsplit(".", 1)[-1]
-                    out_path = mat_dir / f"{channel}.{ext}"
-                    out_path.write_bytes(zf.read(name))
                     textures[channel] = out_path
 
     return mtlx_path, textures

--- a/tests/test_gpuopen_extractor.py
+++ b/tests/test_gpuopen_extractor.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 from mat_vis_baker.sources.gpuopen import (
     UPSTREAM_ALLOWLIST,
     _authors,
+    _extract_from_zip,
     _fetch_one,
     _iso_date,
     _max_resolution_px,
@@ -281,3 +282,92 @@ def test_upstream_allowlist_includes_mtlx_anchor() -> None:
     assert "mtlx_material_name" in UPSTREAM_ALLOWLIST
     assert "packages" not in UPSTREAM_ALLOWLIST
     assert "renders" not in UPSTREAM_ALLOWLIST
+
+
+# ── #461: source images must land where the mtlx references them ──
+#
+# The bug: extraction renamed textures to channel names (color.png) but the
+# mtlx still referenced textures/<Original>.png, so TextureBaker resolved
+# nothing → no output PNGs → the whole gpuopen bake failed. No prior test
+# baked (or even extracted) a real image-referencing gpuopen material.
+
+
+def _zip_with(members: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+_PNG = b"\x89PNG\r\n\x1a\nfake"
+_MTLX_WITH_IMAGE = (
+    b'<?xml version="1.0"?><materialx version="1.38">'
+    b'<image name="base" type="color3"><input name="file" type="filename" '
+    b'value="textures/Foo_baseColor.png"/></image>'
+    b'<image name="msk" type="float"><input name="file" type="filename" '
+    b'value="textures/Foo_Mask.png"/></image></materialx>'
+)
+
+
+def test_extract_places_textures_at_mtlx_referenced_path(tmp_path: Path) -> None:
+    """#461: the file the mtlx references (``textures/Foo_baseColor.png``)
+    must exist relative to the extracted mtlx — NOT renamed to ``color.png``."""
+    zip_bytes = _zip_with(
+        {
+            "material.mtlx": _MTLX_WITH_IMAGE,
+            "textures/Foo_baseColor.png": _PNG,
+        }
+    )
+    mtlx_path, textures = _extract_from_zip(zip_bytes, "mat-1", tmp_path)
+    mat_dir = tmp_path / "mat-1"
+    # The mtlx's <image file="textures/Foo_baseColor.png"> resolves relative
+    # to the mtlx dir — so the file must be exactly there.
+    assert (mat_dir / "textures" / "Foo_baseColor.png").is_file()
+    assert mtlx_path == mat_dir / "material.mtlx"
+    # Channel map still derived, now pointing at the preserved path.
+    assert textures.get("color") == mat_dir / "textures" / "Foo_baseColor.png"
+    # Pre-#461 wrote color.png at the material root — must NOT be there.
+    assert not (mat_dir / "color.png").exists()
+
+
+def test_extract_strips_mtlx_subdir_prefix(tmp_path: Path) -> None:
+    """Zip laid out under a folder (``Foo/material.mtlx`` + ``Foo/textures/…``)
+    must still resolve: the mtlx flattens to mat_dir, so textures land at
+    ``mat_dir/textures/…`` (prefix stripped)."""
+    zip_bytes = _zip_with(
+        {
+            "Foo/material.mtlx": _MTLX_WITH_IMAGE,
+            "Foo/textures/Foo_baseColor.png": _PNG,
+        }
+    )
+    _extract_from_zip(zip_bytes, "mat-2", tmp_path)
+    assert (tmp_path / "mat-2" / "textures" / "Foo_baseColor.png").is_file()
+
+
+def test_extract_keeps_non_channel_textures(tmp_path: Path) -> None:
+    """A mask (no derivable channel) is referenced by the mtlx, so it must be
+    extracted too — pre-#461 gated extraction on a resolved channel and
+    dropped it, leaving a dangling <image> ref."""
+    zip_bytes = _zip_with(
+        {
+            "material.mtlx": _MTLX_WITH_IMAGE,
+            "textures/Foo_baseColor.png": _PNG,
+            "textures/Foo_Mask.png": _PNG,
+        }
+    )
+    _extract_from_zip(zip_bytes, "mat-3", tmp_path)
+    assert (tmp_path / "mat-3" / "textures" / "Foo_Mask.png").is_file()
+
+
+def test_extract_sanitizes_zip_slip(tmp_path: Path) -> None:
+    """A malicious ``../`` member must not escape the material dir."""
+    zip_bytes = _zip_with(
+        {
+            "material.mtlx": _MTLX_WITH_IMAGE,
+            "../evil_baseColor.png": _PNG,
+        }
+    )
+    _extract_from_zip(zip_bytes, "mat-4", tmp_path)
+    assert not (tmp_path / "evil_baseColor.png").exists()
+    assert (tmp_path / "mat-4" / "evil_baseColor.png").is_file()


### PR DESCRIPTION
## What

Fixes #461 — image-based gpuopen materials failed to bake (`TextureBaker produced no output PNGs`), which crashed the fresh -tst full bake's gpuopen 1k cell.

## Root cause

`_extract_from_zip` renamed each texture to a canonical channel name (`mat_dir/color.png`) and **dropped** images with no derivable channel (masks). But the mtlx — saved verbatim — still referenced the originals (`textures/Foo_baseColor.png`). `bakeAllMaterials` resolves `<image file=…>` relative to the mtlx's dir (`mat_dir`) → found nothing → no PNGs → `_bake_mtlx` raised. #441 (Xvfb) had been *masking* this by failing earlier at the display stage; fixing display exposed it.

## Fix (issue option 1)

Write each source image at the path the mtlx **references** it by: strip the mtlx's own zip sub-dir prefix, keep the remainder (`_rel_under_mtlx`) — so `Foo/material.mtlx` + `Foo/textures/bar.png` → `mat_dir/textures/bar.png`, which the baker resolves. **All** images are now extracted (masks included), and the `{channel: path}` map still builds (for the neutral-multiplier convention + the no-mtlx flat path), pointing at the preserved paths. Zip-slip stays covered (`..`/absolute parts dropped).

## Tests — closes the coverage gap

No prior test extracted a real image-referencing gpuopen material (the smoke test only *parses scalars* from the fixtures + bakes a hermetic synthetic mtlx). Added:
- texture lands at the exact `textures/<Original>.png` the mtlx references, **not** `color.png`;
- mtlx sub-dir prefix stripped so nested-layout zips resolve;
- non-channel **mask** kept, not dropped;
- `../` member sanitized inside the material dir.

**42 gpuopen tests green** (hermetic — zipfile + bytes, no MaterialX needed).

## Verification status

Verified hermetically at the extraction layer (the root cause). **End-to-end proof is the fresh -tst re-bake** — real gpuopen zips vary in layout, so the re-bake across the full catalog is the final confirmation. Recommend: merge → re-dispatch `bake.yml` (line=v2026.04, tag=v2026.04.99-tst-full-436) → the (now-unblocked) validate job exercises the #436 tier-completeness gate on real fresh data.

Refs #441, #285, #435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)