### PR TITLE
fix(ci): make #436 tier-completeness gate opt-in — bake.yml is bake-only

### DIFF
--- a/.dagger/src/mat_vis_ci/main.py
+++ b/.dagger/src/mat_vis_ci/main.py
@@ -983,6 +983,15 @@ class MatVisCi:
                 "comparison (clean by definition for first cuts)."
             ),
         ] = "",
+        check_completeness: Annotated[
+            bool,
+            Doc(
+                "#436: enable the matrix-vs-manifest tier-completeness gate. Only "
+                "for finished-release validation (release-validate) — NOT bake.yml's "
+                "per-phase post-bake validate, which sees only the native bake tier "
+                "and would false-fire on not-yet-derived tiers."
+            ),
+        ] = False,
     ) -> str:
         """Run scripts/validate_release.py --from-hf in the baker container.
 
@@ -1015,6 +1024,8 @@ class MatVisCi:
         ]
         if previous_tag:
             argv.extend(["--previous-tag", previous_tag])
+        if check_completeness:
+            argv.append("--check-completeness")
         return await ctr.with_exec(argv).stdout()
 
     # ── prod-cut pre-flight (mat-vis#345) ─────────────────────────

--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -123,6 +123,7 @@ jobs:
             --repo-id=${{ steps.tag.outputs.repo_id }}
             --hf-token=env:HF_TOKEN
             --previous-tag=${{ steps.prev.outputs.previous_tag }}
+            --check-completeness=true
 
       - name: Notify on failure
         if: failure()

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -20,15 +20,18 @@ Four gates (all hard-failing):
    (#290 pbr, #292 mtlx). Manifest-declared only → no false positives;
    only a definitive 404 fails (transient HF statuses are skipped).
 
-4. **Tier completeness** (#436, --from-hf only) — every ``(source, tier)``
-   cell the release **matrix** DECLARES (``release_matrix`` bake cells +
-   ``ktx2_matrix`` transcode cells) must be present and ``complete`` in the
-   manifest. Closes the "wanted (matrix) vs got (manifest)" gap the other
-   gates miss: gate 1 only fires on tiers that shrank vs the *previous*
-   release, gate 2 EXCLUDES ``ktx2-`` tiers, and gate 3 only checks
-   manifest-*declared* assets — so a matrix cell that silently never baked
-   (the ``ktx2-512`` never-derived #436 scenario) is invisible to all
-   three. This gate reconciles the two sides directly.
+4. **Tier completeness** (#436, --from-hf + ``--check-completeness``) — every
+   ``(source, tier)`` cell the release **matrix** DECLARES (``release_matrix``
+   bake + ``derive_matrix`` downscale + ``ktx2_matrix`` transcode cells) must
+   be present and ``complete`` in the manifest. Closes the "wanted (matrix) vs
+   got (manifest)" gap the other gates miss: gate 1 only fires on tiers that
+   shrank vs the *previous* release, gate 2 EXCLUDES ``ktx2-`` tiers, and gate
+   3 only checks manifest-*declared* assets — so a matrix cell that silently
+   never baked (the ``ktx2-512`` never-derived #436 scenario) is invisible to
+   all three. **Opt-in**: it's a whole-release invariant, valid only after
+   every phase (bake + derive + ktx2) has run — enabled in release-validate,
+   not in bake.yml's per-phase post-bake validate (which sees only the native
+   bake tier and would false-fire on the not-yet-derived tiers).
 
 Schema-autodetect: the underlying loader handles both the v0.5.x
 ``bake-metrics.parquet`` (one row per release-tag with an
@@ -724,6 +727,19 @@ def main(argv: list[str] | None = None) -> int:
         default=list(DEFAULT_EXCLUDE_TIER_PREFIXES),
         help="tier prefixes to skip in parity check (repeatable)",
     )
+    p.add_argument(
+        "--check-completeness",
+        action="store_true",
+        help=(
+            "#436: enable the matrix-vs-manifest tier-completeness gate. OFF by "
+            "default because it's a WHOLE-RELEASE invariant — it must only run "
+            "after every phase (bake + derive + ktx2) has produced its tiers. "
+            "Enable it in release-validate (the finished-release validator), NOT "
+            "in bake.yml's per-phase post-bake validate, which sees only the "
+            "freshly-baked native tier and would false-fire on the not-yet-"
+            "derived tiers."
+        ),
+    )
     args = p.parse_args(argv)
 
     if args.from_hf:
@@ -784,21 +800,25 @@ def _run_from_hf(args: argparse.Namespace) -> int:
     )
     # #436: matrix-vs-manifest tier completeness — every (source, tier) the
     # release matrix DECLARES must be present + complete in the manifest.
-    # Reconciles the "wanted" (matrix) side against "got" (manifest), which no
-    # other gate does (see module docstring, gate 4).
+    # Reconciles the "wanted" (matrix) side against "got" (manifest). OPT-IN
+    # (--check-completeness): a WHOLE-RELEASE invariant, valid only after every
+    # phase (bake + derive + ktx2) has produced its tiers — so it runs in
+    # release-validate, NOT bake.yml's per-phase post-bake validate (which sees
+    # only the native bake tier and would false-fire).
     completeness_violations: list[dict[str, Any]] = []
-    line = _line_for_tag(args.release_tag)
-    if line:
-        wanted = wanted_cells_for_line(line)
-        if wanted:
-            manifest = _fetch_release_manifest(api, args.repo_id, args.release_tag)
-            completeness_violations = find_tier_completeness_violations(manifest, wanted)
-        else:
-            print(
-                f"validate-release: no matrix cells for line {line!r} "
-                f"(tier-completeness gate skipped)",
-                file=sys.stderr,
-            )
+    if args.check_completeness:
+        line = _line_for_tag(args.release_tag)
+        if line:
+            wanted = wanted_cells_for_line(line)
+            if wanted:
+                manifest = _fetch_release_manifest(api, args.repo_id, args.release_tag)
+                completeness_violations = find_tier_completeness_violations(manifest, wanted)
+            else:
+                print(
+                    f"validate-release: no matrix cells for line {line!r} "
+                    f"(tier-completeness gate skipped)",
+                    file=sys.stderr,
+                )
     return _report(args, regressions, violations, asset_violations, completeness_violations)
 
 

--- a/tests/test_validate_release_per_file.py
+++ b/tests/test_validate_release_per_file.py
@@ -705,3 +705,31 @@ def test_wanted_cells_for_line_spans_all_three_phases():
 
 def test_wanted_cells_for_unknown_line_is_empty():
     assert wanted_cells_for_line("v1999.01") == set()
+
+
+def test_completeness_gate_is_opt_in(monkeypatch):
+    """#436 gate is a WHOLE-RELEASE invariant — it must stay OFF unless
+    --check-completeness is passed, so bake.yml's per-phase post-bake validate
+    (native tier only) doesn't false-fire on not-yet-derived tiers."""
+    import scripts.validate_release as vr
+
+    calls: list[int] = []
+    monkeypatch.setattr(vr, "find_regressions_from_hf", lambda *a, **k: [])
+    monkeypatch.setattr(vr, "find_tier_parity_violations_from_hf", lambda *a, **k: [])
+    monkeypatch.setattr(vr, "find_manifest_asset_violations", lambda *a, **k: [])
+    monkeypatch.setattr(vr, "wanted_cells_for_line", lambda line: {("gpuopen", "ktx2-512")})
+    monkeypatch.setattr(vr, "_fetch_release_manifest", lambda *a, **k: {"sources": {}})
+    monkeypatch.setattr(
+        vr, "find_tier_completeness_violations", lambda *a, **k: calls.append(1) or []
+    )
+    monkeypatch.setattr("huggingface_hub.HfApi", lambda *a, **k: object())
+
+    # Default (no flag) — completeness must NOT run.
+    rc = vr.main(["--from-hf", "--release-tag", "v2026.04.2", "--repo-id", "r"])
+    assert rc == 0
+    assert calls == []
+
+    # Opt-in — completeness runs.
+    rc = vr.main(["--from-hf", "--release-tag", "v2026.04.2", "--repo-id", "r", "--check-completeness"])
+    assert rc == 0
+    assert calls == [1]


### PR DESCRIPTION
## Bug (in already-merged #458)

The #436 tier-completeness gate wired **unconditionally** into `_run_from_hf`, which both `release-validate.yml` **and** `bake.yml`'s post-bake validate call. But `bake.yml` is **bake-only** (jobs: preflight/plan/bake/validate) — it produces only the native bake tier (`1k`/`scalar`); **derive** (512/256/128) and **ktx2** are separate downstream workflows.

Confirmed against the tst manifest — a bake declares only:
```
ambientcg: ['1k']   polyhaven: ['1k']   physicallybased: ['scalar']
```

So the completeness gate (which checks *all* matrix tiers) would flag 512/256/128/ktx2 as `tier_missing` on **every successful bake** → false red.

**Not yet triggered:** the one bake since #458 failed on gpuopen (#461), so its validate job was skipped. The next *successful* bake would have hit it — **caught while verifying before re-dispatching the fixed bake.**

## Fix

Completeness is a **whole-release invariant**, valid only after every phase (bake + derive + ktx2) has produced its tiers. Made it **opt-in** via `--check-completeness` (default off):
- `validate_release.py` — flag guards the gate-4 block (docstring updated).
- Dagger `validate_release` — `check_completeness: bool = False` → appends `--check-completeness`.
- `release-validate.yml` — passes `--check-completeness=true` (the finished-release validator; also manually dispatchable against a tst tag after a full bake+derive+ktx2).
- `bake.yml` — unchanged → gate stays **off** in per-phase validate.

The other three gates (regression / parity / asset-reachability) are phase-appropriate and remain on everywhere.

## Test

New `test_completeness_gate_is_opt_in`: gate does **not** run by default, **does** run with the flag. Full suite 37 green.

Refs #436, #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)