### PR TITLE
fix(baker): gpuopen bake — case-correct texture paths + handle procedural materials (#461)

### DIFF
--- a/src/mat_vis_baker/bake.py
+++ b/src/mat_vis_baker/bake.py
@@ -19,6 +19,19 @@ log = logging.getLogger("mat-vis-baker.bake")
 
 THUMB_SIZE = 128
 
+# #461 bug 2: distinguish a procedural/constant material (no <image> texture
+# refs → TextureBaker legitimately produces no PNGs → scalar-only) from an
+# image-based material whose textures failed to resolve (real error). Match
+# both quote styles — canonical MaterialX is double-quoted, but a single-quoted
+# image material must NOT be silently misclassified as scalar-only (that would
+# mask a real bake failure as an empty-but-ok record).
+_IMAGE_REF_RE = re.compile(r"""value=["'][^"']*\.(?:png|jpg|jpeg|exr|tif|tiff)["']""", re.IGNORECASE)
+
+
+def _mtlx_references_images(mtlx_text: str) -> bool:
+    """True if the mtlx has any ``<image file="...">`` texture reference."""
+    return bool(_IMAGE_REF_RE.search(mtlx_text))
+
 
 def _validate_and_resize_png(path: Path, target_px: int | None = None) -> bool:
     """Validate PNG. If target_px is smaller than source, resize in place."""
@@ -134,7 +147,7 @@ def _bake_mtlx(mtlx_path: Path, output_dir: Path, resolution_px: int) -> dict[st
         # the mtlx DID reference images but none baked — the real "textures
         # unresolved" error (the #461 bug-1 case-mismatch symptom).
         mtlx_text = mtlx_path.read_text(encoding="utf-8", errors="replace")
-        if re.search(r'value="[^"]*\.(?:png|jpg|jpeg|exr|tif|tiff)"', mtlx_text, re.IGNORECASE):
+        if _mtlx_references_images(mtlx_text):
             raise RuntimeError(
                 f"TextureBaker produced no output PNGs in {output_dir} "
                 f"(mtlx: {mtlx_path}): the material references image textures but "

--- a/src/mat_vis_baker/bake.py
+++ b/src/mat_vis_baker/bake.py
@@ -8,6 +8,7 @@ gpuopen layered graphs require MaterialX baking (optional dependency).
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
 
 from PIL import Image
@@ -127,10 +128,23 @@ def _bake_mtlx(mtlx_path: Path, output_dir: Path, resolution_px: int) -> dict[st
                 break
 
     if not baked:
-        raise RuntimeError(
-            f"TextureBaker produced no output PNGs in {output_dir} "
-            f"(mtlx: {mtlx_path})"
+        # #461 bug 2: a constant/procedural material (e.g. a glass BRDF) has no
+        # spatial <image> textures, so TextureBaker correctly produces nothing.
+        # That's a scalar-only material (#369), not a failure. Only raise when
+        # the mtlx DID reference images but none baked — the real "textures
+        # unresolved" error (the #461 bug-1 case-mismatch symptom).
+        mtlx_text = mtlx_path.read_text(encoding="utf-8", errors="replace")
+        if re.search(r'value="[^"]*\.(?:png|jpg|jpeg|exr|tif|tiff)"', mtlx_text, re.IGNORECASE):
+            raise RuntimeError(
+                f"TextureBaker produced no output PNGs in {output_dir} "
+                f"(mtlx: {mtlx_path}): the material references image textures but "
+                f"none resolved"
+            )
+        log.info(
+            "%s: procedural/constant mtlx (no image textures) — scalar-only, no maps",
+            mtlx_path.stem,
         )
+        return {}
 
     log.info(
         "%s: baked %d channels from mtlx (%s)",

--- a/src/mat_vis_baker/sources/gpuopen.py
+++ b/src/mat_vis_baker/sources/gpuopen.py
@@ -225,7 +225,11 @@ def _rel_under_mtlx(member: str, mtlx_prefix: str) -> str:
     return "/".join(parts) or "texture"
 
 
-_MTLX_IMG_REF_RE = re.compile(rb'value="([^"]*\.(?:png|jpg|jpeg|exr|tif|tiff))"', re.IGNORECASE)
+# Match both quote styles (canonical MaterialX is double-quoted; be robust so a
+# single-quoted image material still gets case-corrected — #461 review nit).
+_MTLX_IMG_REF_RE = re.compile(
+    rb"""value=["']([^"']*\.(?:png|jpg|jpeg|exr|tif|tiff))["']""", re.IGNORECASE
+)
 
 
 def _referenced_image_paths(mtlx_bytes: bytes) -> dict[str, str]:

--- a/src/mat_vis_baker/sources/gpuopen.py
+++ b/src/mat_vis_baker/sources/gpuopen.py
@@ -225,6 +225,30 @@ def _rel_under_mtlx(member: str, mtlx_prefix: str) -> str:
     return "/".join(parts) or "texture"
 
 
+_MTLX_IMG_REF_RE = re.compile(rb'value="([^"]*\.(?:png|jpg|jpeg|exr|tif|tiff))"', re.IGNORECASE)
+
+
+def _referenced_image_paths(mtlx_bytes: bytes) -> dict[str, str]:
+    """Map ``lower(relpath) -> exact relpath`` for every ``<image file="...">``
+    the mtlx references (#461 bug 1).
+
+    gpuopen mtlx files reference textures with different CASE than the zip
+    stores them under (``textures/Foo_baseColor.png`` in the mtlx vs
+    ``textures/Foo_basecolor.png`` on disk). MaterialX resolves via a
+    case-sensitive OS ``open()`` on Linux, so the extractor must write each
+    image at the case the mtlx names it. This returns the mtlx's exact-case
+    reference for each texture, keyed case-insensitively for matching.
+    """
+    refs: dict[str, str] = {}
+    for m in _MTLX_IMG_REF_RE.findall(mtlx_bytes):
+        ref = m.decode("utf-8", "replace").replace("\\", "/")
+        parts = [p for p in ref.split("/") if p not in ("", ".", "..")]
+        norm = "/".join(parts)
+        if norm:
+            refs.setdefault(norm.lower(), norm)
+    return refs
+
+
 def _extract_from_zip(
     zip_bytes: bytes,
     material_id: str,
@@ -258,13 +282,16 @@ def _extract_from_zip(
         members = [n for n in zf.namelist() if not n.endswith("/")]
 
         # Locate the mtlx first: texture members are placed relative to its
-        # dir so its <image file="..."> refs resolve at bake time.
+        # dir (and at the CASE it references, #461 bug 1) so its
+        # <image file="..."> refs resolve at bake time.
         mtlx_member = next(
             (n for n in members if n.rsplit("/", 1)[-1].lower().endswith(".mtlx")), None
         )
         mtlx_prefix = (
             mtlx_member.rsplit("/", 1)[0] + "/" if mtlx_member and "/" in mtlx_member else ""
         )
+        mtlx_bytes = zf.read(mtlx_member) if mtlx_member else b""
+        referenced = _referenced_image_paths(mtlx_bytes)
 
         for name in members:
             basename = name.rsplit("/", 1)[-1].lower()
@@ -272,18 +299,25 @@ def _extract_from_zip(
             if name == mtlx_member:
                 # Save to working dir for bake pipeline (flattened).
                 mtlx_path = mat_dir / "material.mtlx"
-                raw = zf.read(name)
-                mtlx_path.write_bytes(raw)
+                mtlx_path.write_bytes(mtlx_bytes)
                 # Also save attributed copy to mtlx_dir for git
                 if mtlx_dir:
                     git_mtlx = mtlx_dir / "gpuopen" / material_id / "material.mtlx"
                     git_mtlx.parent.mkdir(parents=True, exist_ok=True)
-                    git_mtlx.write_bytes(_inject_mtlx_comment(raw, material_id, source_url))
+                    git_mtlx.write_bytes(
+                        _inject_mtlx_comment(mtlx_bytes, material_id, source_url)
+                    )
                 continue
 
             if _IMG_RE.search(basename):
-                # Preserve the mtlx-relative path so <image> refs resolve.
-                out_path = mat_dir / _rel_under_mtlx(name, mtlx_prefix)
+                # Write at the CASE the mtlx references (bug 1): gpuopen mtlx
+                # names textures with different case than the zip stores them
+                # (baseColor vs basecolor), and MaterialX's open() is
+                # case-sensitive on Linux. Fall back to the preserved path when
+                # the mtlx doesn't reference this member.
+                rel = _rel_under_mtlx(name, mtlx_prefix)
+                rel = referenced.get(rel.lower(), rel)
+                out_path = mat_dir / rel
                 out_path.parent.mkdir(parents=True, exist_ok=True)
                 out_path.write_bytes(zf.read(name))
                 # Map to a canonical channel when derivable — used by the

--- a/tests/test_bake_mtlx_smoke.py
+++ b/tests/test_bake_mtlx_smoke.py
@@ -191,3 +191,46 @@ def test_bake_material_routes_mtlx_records(smoke_mtlx: Path, tmp_path: Path) -> 
 
     assert out.status != "failed", "mtlx bake failed through bake_material()"
     assert "color" in out.maps, f"expected color in maps, got {out.maps}"
+
+
+# -- #461 bug 2: procedural-vs-image decision (GL-free; the branch that
+# distinguishes "no textures = scalar-only" from "textures unresolved = error") --
+
+
+def test_mtlx_references_images_true_for_image_based() -> None:
+    from mat_vis_baker.bake import _mtlx_references_images
+
+    txt = (
+        '<materialx><image><input name="file" type="filename" '
+        'value="textures/Foo_baseColor.png"/></image></materialx>'
+    )
+    assert _mtlx_references_images(txt) is True
+
+
+def test_mtlx_references_images_false_for_procedural() -> None:
+    from mat_vis_baker.bake import _mtlx_references_images
+
+    # A constant/procedural material (e.g. glass BRDF) — no <image> file refs.
+    txt = (
+        '<materialx><standard_surface><input name="transmission" '
+        'type="float" value="1.0"/></standard_surface></materialx>'
+    )
+    assert _mtlx_references_images(txt) is False
+
+
+def test_mtlx_references_images_handles_single_quotes() -> None:
+    from mat_vis_baker.bake import _mtlx_references_images
+
+    # A single-quoted image material must NOT be misclassified as scalar-only
+    # (that would silently mask a real bake failure as an empty-ok record).
+    txt = "<image><input name='file' value='textures/Foo_normal.png'/></image>"
+    assert _mtlx_references_images(txt) is True
+
+
+def test_mtlx_references_images_ignores_non_image_values() -> None:
+    from mat_vis_baker.bake import _mtlx_references_images
+
+    # A value that merely contains a word ending in a mapish token but no image
+    # extension must not count.
+    txt = '<input name="base" type="color3" value="0.8, 0.8, 0.8"/>'
+    assert _mtlx_references_images(txt) is False

--- a/tests/test_gpuopen_extractor.py
+++ b/tests/test_gpuopen_extractor.py
@@ -371,3 +371,58 @@ def test_extract_sanitizes_zip_slip(tmp_path: Path) -> None:
     _extract_from_zip(zip_bytes, "mat-4", tmp_path)
     assert not (tmp_path / "evil_baseColor.png").exists()
     assert (tmp_path / "mat-4" / "evil_baseColor.png").is_file()
+
+
+# -- #461 bug 1: case-correction (mtlx ref case != zip filename case) --
+#
+# Real gpuopen zips store textures/Foo_basecolor.png but the mtlx references
+# textures/Foo_baseColor.png (capital C). MaterialX's open() is case-sensitive
+# on Linux, so the image must be written at the case the mtlx names it.
+
+_MTLX_MIXED_CASE = (
+    b'<?xml version="1.0"?><materialx version="1.38">'
+    b'<image name="c"><input name="file" type="filename" '
+    b'value="textures/Foo_baseColor.png"/></image>'
+    b'<image name="n"><input name="file" type="filename" '
+    b'value="textures/Foo_Normal.png"/></image></materialx>'
+)
+
+
+def test_extract_case_corrects_to_mtlx_reference(tmp_path: Path) -> None:
+    zip_bytes = _zip_with(
+        {
+            "material.mtlx": _MTLX_MIXED_CASE,
+            "textures/Foo_basecolor.png": _PNG,  # lowercase on disk
+            "textures/Foo_normal.png": _PNG,
+        }
+    )
+    _extract_from_zip(zip_bytes, "mat-5", tmp_path)
+    mat = tmp_path / "mat-5"
+    # Written at the mtlx-referenced CASE so the <image file> ref resolves.
+    assert (mat / "textures" / "Foo_baseColor.png").is_file()
+    assert (mat / "textures" / "Foo_Normal.png").is_file()
+    # The lowercase originals must NOT be what's on disk (case-corrected).
+    assert not (mat / "textures" / "Foo_basecolor.png").exists()
+    assert not (mat / "textures" / "Foo_normal.png").exists()
+
+
+def test_referenced_image_paths_keys_case_insensitively() -> None:
+    from mat_vis_baker.sources.gpuopen import _referenced_image_paths
+
+    refs = _referenced_image_paths(_MTLX_MIXED_CASE)
+    assert refs["textures/foo_basecolor.png"] == "textures/Foo_baseColor.png"
+    assert refs["textures/foo_normal.png"] == "textures/Foo_Normal.png"
+
+
+def test_extract_unreferenced_image_keeps_own_path(tmp_path: Path) -> None:
+    """An image the mtlx doesn't reference keeps its own preserved path."""
+    zip_bytes = _zip_with(
+        {
+            "material.mtlx": _MTLX_MIXED_CASE,
+            "textures/Foo_basecolor.png": _PNG,
+            "textures/Foo_normal.png": _PNG,
+            "textures/Extra_height.png": _PNG,  # not referenced by the mtlx
+        }
+    )
+    _extract_from_zip(zip_bytes, "mat-6", tmp_path)
+    assert (tmp_path / "mat-6" / "textures" / "Extra_height.png").is_file()


### PR DESCRIPTION
## Why

#462 (path preservation) got gpuopen bakes past the rename bug but **the re-bake still failed**. Downloading and inspecting the *real* failing zips revealed two distinct root causes #462 didn't address — both now verified against the actual packages.

### Bug 1 — case mismatch (image-based materials)
`Indigo Palm Wallpaper` zip stores `textures/Foo_basecolor.png` (lowercase) but its mtlx references `textures/Foo_baseColor.png` (capital C) / `_Normal.png`. MaterialX resolves `<image file>` via a **case-sensitive** OS `open()` on Linux → "Image file not found" → no PNGs.

**Proven GL-free against the real zip + real extractor code:**
```
current dev (#462):  2/3 refs unresolved  (_Normal, _baseColor MISS; _ORM OK)
with this fix:       0/3 unresolved
```
Fix: parse the mtlx's `<image file>` refs and write each image at the **exact case the mtlx names it** (`_referenced_image_paths` + case-insensitive match in `_extract_from_zip`). Unreferenced images keep their preserved path.

### Bug 2 — procedural materials crash
The material that actually raised (`0c94cea0` = "Frosted Glass": 835-byte zip, mtlx only, **zero `<image>` refs**) is a constant glass BRDF. TextureBaker correctly produces no PNGs, but `_bake_mtlx` treated that as fatal. These are the ~18 scalar-only gpuopen entries (#369).

Fix: on no-PNG output, raise **only** if the mtlx referenced images (real "textures unresolved"); if it has no image refs, it's scalar-only → `return {}` (no maps), which flows downstream as a valid no-texture record (verified: `bake_material` → `n_ok`, writes a catalog entry, no crash).

## Tests
- `test_extract_case_corrects_to_mtlx_reference`, `test_referenced_image_paths_keys_case_insensitively`, `test_extract_unreferenced_image_keeps_own_path` — extractor suite **26 green**; baker sweep **37 pass / 4 GL-skipped**.

## Verification honesty
Bug 1 is proven end-to-end **GL-free** (the mtlx-ref-resolves check against the real zip — MaterialX's failure is purely at `open()`, which needs no GL). The full **GLSL** bake segfaults under local `xvfb`+mesa (the #438/#441 env fragility), so the definitive end-to-end confirmation is the **Dagger re-bake** (its GL context works — the smoke test proves it). Recommend: merge → re-dispatch bake.

Refs #461, #462, #369, #435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)