### PR TITLE
fix(baker): scalar bake writes .tier_complete sentinel (#293-caught)

### DIFF
--- a/src/mat_vis_baker/hf_bake.py
+++ b/src/mat_vis_baker/hf_bake.py
@@ -107,11 +107,20 @@ def bake_scalar_source(
         )
         return {"dry_run": True, "materials": len(index)}
 
-    # 1) Catalog commit — single file, same wholesale-overwrite shape
-    # as before. push_to_hf takes care of branch creation if missing.
+    # 1) Catalog commit — catalog + the `.tier_complete` sentinel. #293: the
+    # scalar path declares `scalar: {complete: True}` in the manifest but
+    # (pre-fix) never wrote the `<source>/scalar/.tier_complete` marker the
+    # textured path writes, so the manifest-asset-reachability gate correctly
+    # 404'd on it. Emit the zero-byte sentinel so "declared" matches "shipped"
+    # and clients can probe scalar completeness in one HEAD like any tier.
+    sentinel_path = work_dir / ".tier_complete"
+    sentinel_path.write_bytes(b"")
     catalog_sha = push_to_hf(
         repo_id=repo_id,
-        files=[(catalog_path, f"{source}.json")],
+        files=[
+            (catalog_path, f"{source}.json"),
+            (sentinel_path, f"{source}/scalar/.tier_complete"),
+        ],
         revision=release_tag,
         commit_message=f"feat(data): {release_tag} — bake {source} (scalar)",
         token=hf_token,

--- a/src/mat_vis_baker/hf_bake.py
+++ b/src/mat_vis_baker/hf_bake.py
@@ -47,6 +47,11 @@ DEFAULT_REPO_ID = "gerchowl/mat-vis"
 DEFAULT_BATCH_SIZE = 300
 DEFAULT_BATCH_MAX_BYTES = 700 * 1024 * 1024  # 700 MiB
 
+# The single tier a scalar-only source ships. Shared so the manifest tier key
+# and the `.tier_complete` sentinel path can never drift apart (drift would
+# silently re-404 the #293 asset-reachability gate).
+SCALAR_TIER = "scalar"
+
 
 def _get_fetcher(source: str):
     if source == "ambientcg":
@@ -114,12 +119,14 @@ def bake_scalar_source(
     # 404'd on it. Emit the zero-byte sentinel so "declared" matches "shipped"
     # and clients can probe scalar completeness in one HEAD like any tier.
     sentinel_path = work_dir / ".tier_complete"
-    sentinel_path.write_bytes(b"")
+    # Carry the release tag (the convention the textured/thumb/derive paths
+    # use) — a "which tag completed this tier" breadcrumb, not just zero bytes.
+    sentinel_path.write_text(release_tag + "\n")
     catalog_sha = push_to_hf(
         repo_id=repo_id,
         files=[
             (catalog_path, f"{source}.json"),
-            (sentinel_path, f"{source}/scalar/.tier_complete"),
+            (sentinel_path, f"{source}/{SCALAR_TIER}/.tier_complete"),
         ],
         revision=release_tag,
         commit_message=f"feat(data): {release_tag} — bake {source} (scalar)",
@@ -139,7 +146,7 @@ def bake_scalar_source(
     manifest_sha = ""
     for attempt in range(max_retries):
         existing_manifest, parent_sha = _fetch_manifest_with_parent(api, repo_id, release_tag)
-        merged = _merge_manifest_for_source(existing_manifest, source, "scalar", release_tag)
+        merged = _merge_manifest_for_source(existing_manifest, source, SCALAR_TIER, release_tag)
         manifest_path.write_text(json.dumps(merged, indent=2, ensure_ascii=False) + "\n")
         try:
             manifest_commit = _create_commit_with_backoff(

--- a/tests/test_bake_scalar_source.py
+++ b/tests/test_bake_scalar_source.py
@@ -100,7 +100,14 @@ class TestBakeScalarSource:
         catalog_call = push_api.create_commit.call_args
         catalog_ops = catalog_call.kwargs["operations"]
         catalog_paths = {op.path_in_repo for op in catalog_ops}
-        assert catalog_paths == {"physicallybased.json"}, catalog_paths
+        # #293: the catalog commit now also carries the `.tier_complete`
+        # sentinel so the manifest's `scalar: complete` declaration is backed
+        # by a probeable marker (was missing → the asset-reachability gate
+        # 404'd on it).
+        assert catalog_paths == {
+            "physicallybased.json",
+            "physicallybased/scalar/.tier_complete",
+        }, catalog_paths
 
         # Manifest commit went via the bake-side HfApi → bake_api.create_commit.
         assert bake_api.create_commit.call_count == 1, (


### PR DESCRIPTION
## What the #293 gate caught

The **first successful full -tst bake** (all 4 sources baked clean — gpuopen finally works via #466) tripped the #293 manifest-asset-reachability gate:

```
=== manifest-declared assets missing (404) ===
  physicallybased/scalar/.tier_complete
```

## Root cause

`bake_scalar_source` (the scalar-only path for physicallybased) commits the catalog + a manifest declaring `scalar: {complete: True}`, but — unlike the textured path (`bake_one_per_file`, which writes `<source>/<tier>/.tier_complete`) — it **never wrote the sentinel**. So the scalar tier was *declared* complete but not *probeable*.

This was latent since the scalar path existed; the #293 gate (added in #455) is the **first thing to catch it** — the gate doing exactly its job (wanted-vs-is) on real fresh data.

## Fix

Include the zero-byte `<source>/scalar/.tier_complete` sentinel in the catalog commit, so "declared" matches "shipped" and clients can HEAD scalar completeness like any tier. Updated `test_bake_scalar_source` to assert the catalog commit carries both the catalog and the sentinel (3 green).

## Significance

**gpuopen baked clean for the first time** — the case-correction + procedural fixes (#462→#466) worked end-to-end on the real GLSL path. This sentinel fix is the last blocker to a green bake-phase validate; after it, the bake→(derive→ktx2)→release-validate chain can run to completion for the #436 proof + #293-P1 coverage.

Refs #293, #455, #466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)