### PR TITLE
feat(ci): pbr coverage-regression gate (#293-P1)

### DIFF
--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -501,7 +501,15 @@ def _pbr_populated(pbr: Any) -> bool:
     """
     if not isinstance(pbr, dict):
         return False
-    return any(v is not None and v != [] and v != {} for v in pbr.values())
+    # Exclude ``*_source`` provenance strings (e.g. ``metalness_source =
+    # "graph_estimate"``, set WITH ``metalness=None``) — provenance is not a
+    # measured value, so a material with only provenance populated must read as
+    # uncovered, not mask an all-scalar-null gap (#293-P1 review).
+    return any(
+        v is not None and v != [] and v != {}
+        for k, v in pbr.items()
+        if not k.endswith("_source")
+    )
 
 
 def _fetch_source_catalog(api: Any, repo_id: str, release_tag: str, catalog: str) -> list[dict]:
@@ -529,6 +537,14 @@ def source_pbr_coverage(api: Any, repo_id: str, release_tag: str) -> dict[str, t
         if not catalog:
             continue
         entries = _fetch_source_catalog(api, repo_id, release_tag, str(catalog))
+        if not entries:
+            # Catalog missing / unfetchable (transient blip OR definitively
+            # absent) OR legitimately empty → coverage is unmeasurable. SKIP the
+            # source rather than record (0, 0). This mirrors the P0 asset gate's
+            # transient-safety: a network hiccup on one source's catalog must
+            # NOT read as 0% and spuriously red the daily cron (#293-P1 review).
+            # A genuinely-missing catalog is the asset gate's / count gate's job.
+            continue
         total = len(entries)
         populated = sum(
             1 for e in entries if _pbr_populated((e.get("mat_vis") or {}).get("pbr"))

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -1,7 +1,7 @@
 """Release validator — enforces coverage invariants against the
 per-file substrate metrics parquet (#263 phase C).
 
-Four gates (all hard-failing):
+Five gates (all hard-failing):
 
 1. **Regression gate** — current release's per-(source, tier) material
    total must be >= ``--min-ratio`` x previous release's total. Catches
@@ -32,6 +32,16 @@ Four gates (all hard-failing):
    every phase (bake + derive + ktx2) has run — enabled in release-validate,
    not in bake.yml's per-phase post-bake validate (which sees only the native
    bake tier and would false-fire on the not-yet-derived tiers).
+
+5. **PBR coverage regression** (#293-P1, --from-hf only) — each source's
+   populated-``pbr`` fraction (materials with ≥1 non-null scalar) must be >=
+   ``--pbr-coverage-min-ratio`` x the previous release's fraction. Catches the
+   #290 class the count/parity/asset gates are blind to: a material ships and
+   is counted "complete", but its scalar ``pbr`` block is silently all-null
+   (the gpuopen 454×``pbr=None`` that read as green). Regression-relative and
+   self-calibrating — a source with no prior coverage gets a free pass;
+   ``--pbr-waive-source`` exempts one. A catalog property (not tier-dependent),
+   so — unlike gate 4 — it's valid after the bake phase and stays always-on.
 
 Schema-autodetect: the underlying loader handles both the v0.5.x
 ``bake-metrics.parquet`` (one row per release-tag with an
@@ -73,6 +83,7 @@ import pyarrow.parquet as pq
 
 DEFAULT_MIN_RATIO = 0.95
 DEFAULT_PARITY_MIN_RATIO = 0.80
+DEFAULT_PBR_COVERAGE_MIN_RATIO = 0.95
 DEFAULT_EXCLUDE_TIER_PREFIXES = ("ktx2-",)
 
 
@@ -80,6 +91,7 @@ __all__ = [
     "baked_ids_from_release_manifest",
     "find_catalog_violations",
     "find_manifest_asset_violations",
+    "find_pbr_coverage_regressions",
     "find_regressions",
     "find_regressions_from_hf",
     "find_tier_completeness_violations",
@@ -475,6 +487,109 @@ def find_tier_completeness_violations(
     return violations
 
 
+# ── #293-P1: pbr scalar coverage regression (per source) ──
+
+
+def _pbr_populated(pbr: Any) -> bool:
+    """True if a material's ``mat_vis.pbr`` block carries at least one
+    non-null scalar value.
+
+    The block always serializes as a full dict (``asdict`` emits every key,
+    ``null`` where the extractor had nothing), so "has a pbr dict" is NOT
+    coverage — an all-null dict is the #290 gpuopen-omits-scalars bug. Coverage
+    means ≥1 field is actually populated.
+    """
+    if not isinstance(pbr, dict):
+        return False
+    return any(v is not None and v != [] and v != {} for v in pbr.values())
+
+
+def _fetch_source_catalog(api: Any, repo_id: str, release_tag: str, catalog: str) -> list[dict]:
+    """Fetch + parse a source catalog (``<source>.json``) from HF. ``[]`` if
+    missing/unparseable. Normalizes list vs ``{"materials": [...]}`` shapes."""
+    try:
+        p = api.hf_hub_download(
+            repo_id=repo_id, repo_type="dataset", revision=release_tag, filename=catalog
+        )
+        data = json.loads(Path(p).read_text())
+    except Exception:  # noqa: BLE001 — missing/unparseable catalog → empty
+        return []
+    if isinstance(data, list):
+        return data
+    return data.get("materials") or data.get("entries") or []
+
+
+def source_pbr_coverage(api: Any, repo_id: str, release_tag: str) -> dict[str, tuple[int, int]]:
+    """Return ``{source: (populated, total)}`` pbr coverage, reading each
+    source's catalog declared in the release manifest."""
+    manifest = _fetch_release_manifest(api, repo_id, release_tag)
+    out: dict[str, tuple[int, int]] = {}
+    for source, entry in (manifest.get("sources") or {}).items():
+        catalog = (entry or {}).get("catalog")
+        if not catalog:
+            continue
+        entries = _fetch_source_catalog(api, repo_id, release_tag, str(catalog))
+        total = len(entries)
+        populated = sum(
+            1 for e in entries if _pbr_populated((e.get("mat_vis") or {}).get("pbr"))
+        )
+        out[source] = (populated, total)
+    return out
+
+
+def find_pbr_coverage_regressions(
+    api: Any,
+    *,
+    repo_id: str,
+    current_tag: str,
+    previous_tag: str,
+    min_ratio: float = DEFAULT_PBR_COVERAGE_MIN_RATIO,
+    waivers: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    """#293-P1: flag a source whose populated-``pbr`` fraction dropped below
+    ``min_ratio`` × the previous release's fraction.
+
+    Regression-relative (mirrors the material-count :func:`find_regressions`):
+    self-calibrating, no per-source hardcoded floor, and it tolerates a
+    legitimate single-material gap (fresh data: all sources ~100%, ambientcg
+    99.9%). Catches the class the count/parity/asset gates are blind to — a
+    material ships but its scalar ``pbr`` block is silently all-null (#290: the
+    gpuopen 454×``pbr=None`` that read as "complete"). A source in ``waivers``
+    is skipped. Sources with no previous coverage (prev fraction 0 / absent)
+    get a free pass — nothing to regress against.
+    """
+    waivers = waivers or set()
+    prev = source_pbr_coverage(api, repo_id, previous_tag)
+    if not prev:
+        return []
+    cur = source_pbr_coverage(api, repo_id, current_tag)
+
+    violations: list[dict[str, Any]] = []
+    for source, (pop, total) in sorted(cur.items()):
+        if source in waivers or source not in prev:
+            continue
+        prev_pop, prev_total = prev[source]
+        prev_frac = prev_pop / prev_total if prev_total else 0.0
+        if prev_frac <= 0:
+            continue  # nothing to regress against (source had no pbr before)
+        cur_frac = pop / total if total else 0.0
+        ratio = cur_frac / prev_frac
+        if ratio < min_ratio:
+            violations.append(
+                {
+                    "source": source,
+                    "current_tag": current_tag,
+                    "previous_tag": previous_tag,
+                    "current_frac": cur_frac,
+                    "previous_frac": prev_frac,
+                    "ratio": ratio,
+                    "current_populated": pop,
+                    "current_total": total,
+                }
+            )
+    return violations
+
+
 # ── Live HF gate (no metrics parquet needed) ──────────────────
 
 
@@ -740,6 +855,22 @@ def main(argv: list[str] | None = None) -> int:
             "derived tiers."
         ),
     )
+    p.add_argument(
+        "--pbr-coverage-min-ratio",
+        type=float,
+        default=DEFAULT_PBR_COVERAGE_MIN_RATIO,
+        help=(
+            f"#293-P1 pbr-coverage regression threshold (default "
+            f"{DEFAULT_PBR_COVERAGE_MIN_RATIO}). A source's populated-pbr fraction "
+            f"must be >= this x the previous release's. --from-hf only."
+        ),
+    )
+    p.add_argument(
+        "--pbr-waive-source",
+        action="append",
+        default=[],
+        help="source to exempt from the pbr-coverage regression gate (repeatable)",
+    )
     args = p.parse_args(argv)
 
     if args.from_hf:
@@ -819,7 +950,31 @@ def _run_from_hf(args: argparse.Namespace) -> int:
                     f"(tier-completeness gate skipped)",
                     file=sys.stderr,
                 )
-    return _report(args, regressions, violations, asset_violations, completeness_violations)
+    # #293-P1: pbr scalar coverage regression — a source's populated-pbr
+    # fraction must not drop below min_ratio × the previous release's fraction.
+    # Catches the #290 class (material ships but its pbr block is silently
+    # all-null) that the count/parity/asset gates miss. Regression-relative and
+    # a catalog property (not tier-dependent), so it's safe after the bake phase
+    # too. Free pass when there's no previous tag / no prior coverage.
+    if args.previous_tag:
+        coverage_regressions = find_pbr_coverage_regressions(
+            api,
+            repo_id=args.repo_id,
+            current_tag=args.release_tag,
+            previous_tag=args.previous_tag,
+            min_ratio=args.pbr_coverage_min_ratio,
+            waivers=set(args.pbr_waive_source),
+        )
+    else:
+        coverage_regressions = []
+    return _report(
+        args,
+        regressions,
+        violations,
+        asset_violations,
+        completeness_violations,
+        coverage_regressions,
+    )
 
 
 def _report(
@@ -828,13 +983,17 @@ def _report(
     violations: list[dict[str, Any]],
     asset_violations: list[dict[str, Any]] | None = None,
     completeness_violations: list[dict[str, Any]] | None = None,
+    coverage_regressions: list[dict[str, Any]] | None = None,
 ) -> int:
     """Shared output writer + return-code computation. Centralised so
     both --metrics and --from-hf modes emit the same operator-facing
     text format."""
     asset_violations = asset_violations or []
     completeness_violations = completeness_violations or []
-    if not regressions and not violations and not asset_violations and not completeness_violations:
+    coverage_regressions = coverage_regressions or []
+    if not any(
+        (regressions, violations, asset_violations, completeness_violations, coverage_regressions)
+    ):
         mode = "from-hf" if args.from_hf else "parquet"
         print(f"validate-release {args.release_tag} ({mode}): clean")
         return 0
@@ -872,6 +1031,16 @@ def _report(
         )
         for c in completeness_violations:
             print(f"  {c['source']}/{c['tier']}: {c['kind']}")
+
+    if coverage_regressions:
+        print(f"\n=== pbr coverage regressions in {args.release_tag} (#293-P1) ===")
+        for c in coverage_regressions:
+            print(
+                f"  {c['source']}: {c['current_frac']:.1%} "
+                f"({c['current_populated']}/{c['current_total']}) "
+                f"vs {c['previous_frac']:.1%} in {c['previous_tag']} "
+                f"(ratio={c['ratio']:.3f}, min={args.pbr_coverage_min_ratio})"
+            )
 
     return 1
 

--- a/tests/test_validate_release_per_file.py
+++ b/tests/test_validate_release_per_file.py
@@ -733,3 +733,79 @@ def test_completeness_gate_is_opt_in(monkeypatch):
     rc = vr.main(["--from-hf", "--release-tag", "v2026.04.2", "--repo-id", "r", "--check-completeness"])
     assert rc == 0
     assert calls == [1]
+
+
+# -- #293-P1: pbr coverage regression gate --
+
+
+def test_pbr_populated_detects_real_vs_allnull():
+    from scripts.validate_release import _pbr_populated
+
+    assert _pbr_populated({"color_rgb": [0.5, 0.5, 0.5], "ior": None}) is True
+    assert _pbr_populated({"metalness": 0.0}) is True  # 0.0 is a real value
+    assert _pbr_populated({"is_conductor": False}) is True
+    assert _pbr_populated({"color_rgb": None, "ior": None}) is False  # #290 all-null
+    assert _pbr_populated({}) is False
+    assert _pbr_populated(None) is False
+
+
+def _stub_coverage(monkeypatch, mapping):
+    import scripts.validate_release as vr
+
+    monkeypatch.setattr(
+        vr, "source_pbr_coverage", lambda api, repo, tag: mapping.get(tag, {})
+    )
+
+
+def test_pbr_coverage_flags_collapse(monkeypatch):
+    from scripts.validate_release import find_pbr_coverage_regressions
+
+    _stub_coverage(monkeypatch, {"prev": {"gpuopen": (454, 454)}, "cur": {"gpuopen": (0, 454)}})
+    v = find_pbr_coverage_regressions(None, repo_id="r", current_tag="cur", previous_tag="prev")
+    assert len(v) == 1
+    assert v[0]["source"] == "gpuopen"
+    assert v[0]["ratio"] == 0.0
+    assert v[0]["current_frac"] == 0.0
+
+
+def test_pbr_coverage_stable_is_clean(monkeypatch):
+    from scripts.validate_release import find_pbr_coverage_regressions
+
+    _stub_coverage(monkeypatch, {"prev": {"gpuopen": (454, 454)}, "cur": {"gpuopen": (454, 454)}})
+    assert find_pbr_coverage_regressions(None, repo_id="r", current_tag="cur", previous_tag="prev") == []
+
+
+def test_pbr_coverage_tolerates_single_material_gap(monkeypatch):
+    from scripts.validate_release import find_pbr_coverage_regressions
+
+    # ambientcg 99.9% vs 100% → ratio 0.999 > 0.95 default → clean.
+    _stub_coverage(
+        monkeypatch,
+        {"prev": {"ambientcg": (1957, 1957)}, "cur": {"ambientcg": (1956, 1957)}},
+    )
+    assert find_pbr_coverage_regressions(None, repo_id="r", current_tag="cur", previous_tag="prev") == []
+
+
+def test_pbr_coverage_free_pass_when_prev_zero(monkeypatch):
+    from scripts.validate_release import find_pbr_coverage_regressions
+
+    # Previous release had 0% (e.g. pre-PBR stale) → nothing to regress against.
+    _stub_coverage(monkeypatch, {"prev": {"gpuopen": (0, 454)}, "cur": {"gpuopen": (0, 454)}})
+    assert find_pbr_coverage_regressions(None, repo_id="r", current_tag="cur", previous_tag="prev") == []
+
+
+def test_pbr_coverage_waiver_skips_source(monkeypatch):
+    from scripts.validate_release import find_pbr_coverage_regressions
+
+    _stub_coverage(monkeypatch, {"prev": {"gpuopen": (454, 454)}, "cur": {"gpuopen": (0, 454)}})
+    v = find_pbr_coverage_regressions(
+        None, repo_id="r", current_tag="cur", previous_tag="prev", waivers={"gpuopen"}
+    )
+    assert v == []
+
+
+def test_pbr_coverage_no_previous_is_empty(monkeypatch):
+    from scripts.validate_release import find_pbr_coverage_regressions
+
+    _stub_coverage(monkeypatch, {"cur": {"gpuopen": (0, 454)}})  # no "prev" entry
+    assert find_pbr_coverage_regressions(None, repo_id="r", current_tag="cur", previous_tag="prev") == []

--- a/tests/test_validate_release_per_file.py
+++ b/tests/test_validate_release_per_file.py
@@ -809,3 +809,53 @@ def test_pbr_coverage_no_previous_is_empty(monkeypatch):
 
     _stub_coverage(monkeypatch, {"cur": {"gpuopen": (0, 454)}})  # no "prev" entry
     assert find_pbr_coverage_regressions(None, repo_id="r", current_tag="cur", previous_tag="prev") == []
+
+
+# -- #293-P1 review nits: provenance exclusion + transient-safety --
+
+
+def test_pbr_populated_excludes_provenance():
+    from scripts.validate_release import _pbr_populated
+
+    # Only a *_source provenance string set, all measured scalars null → NOT
+    # covered (must not mask an all-scalar-null gap).
+    assert _pbr_populated(
+        {"metalness_source": "graph_estimate", "metalness": None, "color_rgb": None}
+    ) is False
+    # Provenance alongside a real measured value → covered.
+    assert _pbr_populated({"metalness_source": "graph_estimate", "metalness": 0.9}) is True
+
+
+def test_source_pbr_coverage_skips_unfetchable_catalog(monkeypatch):
+    import scripts.validate_release as vr
+
+    monkeypatch.setattr(
+        vr,
+        "_fetch_release_manifest",
+        lambda a, r, t: {
+            "sources": {
+                "gpuopen": {"catalog": "gpuopen.json"},
+                "polyhaven": {"catalog": "polyhaven.json"},
+            }
+        },
+    )
+
+    def fake_cat(api, repo, tag, catalog):
+        # gpuopen catalog blips (transient) → []; polyhaven fetches fine.
+        return [] if catalog == "gpuopen.json" else [{"mat_vis": {"pbr": {"metalness": 0.5}}}]
+
+    monkeypatch.setattr(vr, "_fetch_source_catalog", fake_cat)
+    cov = vr.source_pbr_coverage(None, "r", "t")
+    assert "gpuopen" not in cov  # unmeasurable → skipped, not (0, 0)
+    assert cov["polyhaven"] == (1, 1)
+
+
+def test_pbr_coverage_transient_current_no_false_regression(monkeypatch):
+    from scripts.validate_release import find_pbr_coverage_regressions
+
+    # Current catalog for gpuopen blipped → omitted from cur coverage; prev had
+    # 100%. Must NOT flag a regression (the network-blip-reds-the-cron bug).
+    _stub_coverage(monkeypatch, {"prev": {"gpuopen": (454, 454)}, "cur": {}})
+    assert find_pbr_coverage_regressions(
+        None, repo_id="r", current_tag="cur", previous_tag="prev"
+    ) == []


### PR DESCRIPTION
## What

Gate 5 of the release validator — closes the class the count/parity/asset gates are structurally blind to: **a material ships and is counted "complete", but its scalar `mat_vis.pbr` block is silently all-null** (#290 — the gpuopen 454×`pbr=None` that read as green, because the block serializes as a full dict of `null`s so *"has a pbr dict" ≠ coverage*).

## Design — data-backed by the fresh full bake

Fresh coverage (the bake we just landed): gpuopen **100%**, physicallybased 100%, polyhaven 100%, ambientcg **99.9%** (one legit gap). That settled the design you agreed to:

- **Regression-relative**, mirroring the material-count gate — each source's populated-pbr fraction must be ≥ `--pbr-coverage-min-ratio` (default **0.95**) × the previous release's fraction. Self-calibrating (no per-source hardcoded floor), tolerates the single-material ambientcg gap, and a source with **no prior coverage gets a free pass** — so the current stale-prod 0% gpuopen doesn't false-fire (it's an improvement, not a regression).
- `_pbr_populated`: ≥1 non-null scalar (`0.0` / `False` count as real values; all-null = the #290 bug).
- `--pbr-waive-source` exempts a source. **Always-on in `--from-hf`**: coverage is a *catalog* property (not tier-dependent), so — unlike the #436 tier gate — it's valid after the bake phase and **rides the existing `--from-hf --previous-tag` invocations** (bake.yml post-bake + release-validate cron) with **no workflow change**.

## Tests

7 unit tests (collapse flagged; stable / tiny-gap / prev-zero / waiver / no-prev all clean) + **verified live** against the fresh tst bake (`source_pbr_coverage` reads real HF coverage correctly: gpuopen 100%, ambientcg 99.9%, self-vs-self clean). Full validator suite **44 green**.

Refs #293, #290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)